### PR TITLE
fix: serialize datetime.date in frontmatter as ISO strings (#5)

### DIFF
--- a/src/obsidian_vault_mcp/frontmatter_index.py
+++ b/src/obsidian_vault_mcp/frontmatter_index.py
@@ -32,7 +32,7 @@ class FrontmatterIndex:
         for md_path in config.VAULT_PATH.rglob("*.md"):
             if self._is_excluded(md_path):
                 continue
-            rel = str(md_path.relative_to(config.VAULT_PATH))
+            rel = md_path.relative_to(config.VAULT_PATH).as_posix()
             fm = self._parse_frontmatter(md_path)
             if fm is not None:
                 self._index[rel] = fm
@@ -132,7 +132,7 @@ class FrontmatterIndex:
 
         for abs_path_str in paths:
             abs_path = Path(abs_path_str)
-            rel = str(abs_path.relative_to(config.VAULT_PATH))
+            rel = abs_path.relative_to(config.VAULT_PATH).as_posix()
             if abs_path.exists():
                 fm = self._parse_frontmatter(abs_path)
                 with self._lock:

--- a/src/obsidian_vault_mcp/tools/manage.py
+++ b/src/obsidian_vault_mcp/tools/manage.py
@@ -1,9 +1,8 @@
 """Management tools for the Obsidian vault MCP server."""
 
-import json
 import logging
 
-from ..vault import list_directory, move_path, delete_path, resolve_vault_path
+from ..vault import list_directory, move_path, delete_path, resolve_vault_path, vault_json_dumps
 
 logger = logging.getLogger(__name__)
 
@@ -24,41 +23,41 @@ def vault_list(
             include_dirs=include_dirs,
             pattern=pattern,
         )
-        return json.dumps({"items": items, "total": len(items)})
+        return vault_json_dumps({"items": items, "total": len(items)})
     except ValueError as e:
-        return json.dumps({"error": str(e)})
+        return vault_json_dumps({"error": str(e)})
     except FileNotFoundError:
-        return json.dumps({"error": f"Directory not found: {path}"})
+        return vault_json_dumps({"error": f"Directory not found: {path}"})
     except Exception as e:
         logger.error(f"vault_list error: {e}")
-        return json.dumps({"error": str(e)})
+        return vault_json_dumps({"error": str(e)})
 
 
 def vault_move(source: str, destination: str, create_dirs: bool = True) -> str:
     """Move a file or directory within the vault."""
     try:
         moved = move_path(source, destination, create_dirs=create_dirs)
-        return json.dumps({"source": source, "destination": destination, "moved": moved})
+        return vault_json_dumps({"source": source, "destination": destination, "moved": moved})
     except ValueError as e:
-        return json.dumps({"error": str(e), "source": source, "destination": destination})
+        return vault_json_dumps({"error": str(e), "source": source, "destination": destination})
     except Exception as e:
         logger.error(f"vault_move error: {e}")
-        return json.dumps({"error": str(e), "source": source, "destination": destination})
+        return vault_json_dumps({"error": str(e), "source": source, "destination": destination})
 
 
 def vault_delete(path: str, confirm: bool = False) -> str:
     """Delete a file by moving it to .trash/ in the vault."""
     if not confirm:
-        return json.dumps({
+        return vault_json_dumps({
             "error": "Set confirm=true to execute deletion. Files are moved to .trash/, not hard deleted.",
             "path": path,
         })
 
     try:
         deleted = delete_path(path)
-        return json.dumps({"path": path, "deleted": deleted})
+        return vault_json_dumps({"path": path, "deleted": deleted})
     except ValueError as e:
-        return json.dumps({"error": str(e), "path": path})
+        return vault_json_dumps({"error": str(e), "path": path})
     except Exception as e:
         logger.error(f"vault_delete error: {e}")
-        return json.dumps({"error": str(e), "path": path})
+        return vault_json_dumps({"error": str(e), "path": path})

--- a/src/obsidian_vault_mcp/tools/read.py
+++ b/src/obsidian_vault_mcp/tools/read.py
@@ -1,11 +1,10 @@
 """Read tools for the Obsidian vault MCP server."""
 
-import json
 import logging
 
 import frontmatter
 
-from ..vault import resolve_vault_path, read_file
+from ..vault import resolve_vault_path, read_file, vault_json_dumps as json_dumps
 
 logger = logging.getLogger(__name__)
 
@@ -24,19 +23,19 @@ def vault_read(path: str) -> str:
         except Exception:
             pass
 
-        return json.dumps({
+        return json_dumps({
             "path": path,
             "content": content,
             "metadata": metadata,
             "frontmatter": fm_data,
         })
     except ValueError as e:
-        return json.dumps({"error": str(e), "path": path})
+        return json_dumps({"error": str(e), "path": path})
     except FileNotFoundError:
-        return json.dumps({"error": f"File not found: {path}", "path": path})
+        return json_dumps({"error": f"File not found: {path}", "path": path})
     except Exception as e:
         logger.error(f"vault_read error for {path}: {e}")
-        return json.dumps({"error": str(e), "path": path})
+        return json_dumps({"error": str(e), "path": path})
 
 
 def vault_batch_read(paths: list[str], include_content: bool = True) -> str:
@@ -74,4 +73,4 @@ def vault_batch_read(paths: list[str], include_content: bool = True) -> str:
             results.append({"path": path, "error": str(e)})
             missing += 1
 
-    return json.dumps({"files": results, "found": found, "missing": missing})
+    return json_dumps({"files": results, "found": found, "missing": missing})

--- a/src/obsidian_vault_mcp/tools/search.py
+++ b/src/obsidian_vault_mcp/tools/search.py
@@ -20,7 +20,7 @@ def _search_ripgrep(
     file_pattern: str,
     max_results: int,
     context_lines: int,
-) -> list[dict]:
+) -> list[dict] | None:
     """Search using ripgrep for performance."""
     cmd = [
         "rg",
@@ -38,8 +38,11 @@ def _search_ripgrep(
 
     try:
         result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
-    except (subprocess.TimeoutExpired, FileNotFoundError):
-        return []
+    except (subprocess.TimeoutExpired, FileNotFoundError, PermissionError):
+        return None
+
+    if result.returncode not in (0, 1):
+        return None
 
     matches = []
     current_match = None
@@ -54,7 +57,7 @@ def _search_ripgrep(
             match_data = data["data"]
             file_path = match_data["path"]["text"]
             try:
-                rel_path = str(Path(file_path).relative_to(config.VAULT_PATH))
+                rel_path = Path(file_path).relative_to(config.VAULT_PATH).as_posix()
             except ValueError:
                 continue
 
@@ -109,7 +112,7 @@ def _search_python(
                 context = "\n".join(lines[start:end])
 
                 try:
-                    rel_path = str(file_path.relative_to(config.VAULT_PATH))
+                    rel_path = file_path.relative_to(config.VAULT_PATH).as_posix()
                 except ValueError:
                     continue
 
@@ -158,6 +161,9 @@ def vault_search(
         if shutil.which("rg"):
             matches = _search_ripgrep(query, search_path, file_pattern, max_results, context_lines)
         else:
+            matches = None
+
+        if matches is None:
             matches = _search_python(query, search_path, file_pattern, max_results, context_lines)
 
         for match in matches:

--- a/src/obsidian_vault_mcp/tools/search.py
+++ b/src/obsidian_vault_mcp/tools/search.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import frontmatter
 
 from .. import config
-from ..vault import resolve_vault_path
+from ..vault import resolve_vault_path, vault_json_dumps
 
 logger = logging.getLogger(__name__)
 
@@ -153,7 +153,7 @@ def vault_search(
             search_path = config.VAULT_PATH
 
         if not search_path.is_dir():
-            return json.dumps({"error": f"Search path is not a directory: {path_prefix}"})
+            return vault_json_dumps({"error": f"Search path is not a directory: {path_prefix}"})
 
         if shutil.which("rg"):
             matches = _search_ripgrep(query, search_path, file_pattern, max_results, context_lines)
@@ -166,16 +166,16 @@ def vault_search(
 
         truncated = len(matches) >= max_results
 
-        return json.dumps({
+        return vault_json_dumps({
             "results": matches,
             "total_matches": len(matches),
             "truncated": truncated,
         })
     except ValueError as e:
-        return json.dumps({"error": str(e)})
+        return vault_json_dumps({"error": str(e)})
     except Exception as e:
         logger.error(f"vault_search error: {e}")
-        return json.dumps({"error": str(e)})
+        return vault_json_dumps({"error": str(e)})
 
 
 def vault_search_frontmatter(
@@ -209,11 +209,11 @@ def vault_search_frontmatter(
 
         truncated = len(results) > max_results
 
-        return json.dumps({
+        return vault_json_dumps({
             "results": formatted,
             "total": len(formatted),
             "truncated": truncated,
         })
     except Exception as e:
         logger.error(f"vault_search_frontmatter error: {e}")
-        return json.dumps({"error": str(e)})
+        return vault_json_dumps({"error": str(e)})

--- a/src/obsidian_vault_mcp/tools/write.py
+++ b/src/obsidian_vault_mcp/tools/write.py
@@ -1,11 +1,10 @@
 """Write tools for the Obsidian vault MCP server."""
 
-import json
 import logging
 
 import frontmatter
 
-from ..vault import resolve_vault_path, read_file, write_file_atomic
+from ..vault import resolve_vault_path, read_file, write_file_atomic, vault_json_dumps
 
 logger = logging.getLogger(__name__)
 
@@ -33,12 +32,12 @@ def vault_write(path: str, content: str, create_dirs: bool = True, merge_frontma
 
         is_new, size = write_file_atomic(path, content, create_dirs=create_dirs)
 
-        return json.dumps({"path": path, "created": is_new, "size": size})
+        return vault_json_dumps({"path": path, "created": is_new, "size": size})
     except ValueError as e:
-        return json.dumps({"error": str(e), "path": path})
+        return vault_json_dumps({"error": str(e), "path": path})
     except Exception as e:
         logger.error(f"vault_write error for {path}: {e}")
-        return json.dumps({"error": str(e), "path": path})
+        return vault_json_dumps({"error": str(e), "path": path})
 
 
 def vault_batch_frontmatter_update(updates: list[dict]) -> str:
@@ -67,4 +66,4 @@ def vault_batch_frontmatter_update(updates: list[dict]) -> str:
         except Exception as e:
             results.append({"path": file_path, "updated": False, "error": str(e)})
 
-    return json.dumps({"results": results})
+    return vault_json_dumps({"results": results})

--- a/src/obsidian_vault_mcp/vault.py
+++ b/src/obsidian_vault_mcp/vault.py
@@ -1,13 +1,33 @@
 """Core filesystem operations for the Obsidian vault."""
 
 import fnmatch
+import json
 import os
 import shutil
 import tempfile
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from pathlib import Path
 
 from . import config
+
+
+class _DateAwareEncoder(json.JSONEncoder):
+    """JSON encoder that serialises date/datetime objects to ISO 8601 strings.
+
+    PyYAML's safe_load converts bare YAML dates (e.g. ``created: 2026-04-05``)
+    into ``datetime.date`` objects.  The stdlib ``json`` module cannot handle
+    these, so we provide a thin wrapper that converts them on the fly.
+    """
+
+    def default(self, obj: object) -> str:
+        if isinstance(obj, (date, datetime)):
+            return obj.isoformat()
+        return super().default(obj)
+
+
+def vault_json_dumps(obj: object, **kwargs) -> str:
+    """``json.dumps`` replacement that handles ``datetime.date`` values."""
+    return json.dumps(obj, cls=_DateAwareEncoder, **kwargs)
 
 
 def resolve_vault_path(relative_path: str) -> Path:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,8 +1,10 @@
 """Integration tests for tool functions."""
 
 import json
+from datetime import date, datetime
 
 import pytest
+import frontmatter
 
 from obsidian_vault_mcp.tools.read import vault_read, vault_batch_read
 from obsidian_vault_mcp.tools.write import vault_write, vault_batch_frontmatter_update
@@ -17,6 +19,33 @@ def test_vault_read_returns_frontmatter(vault_dir):
     assert result["frontmatter"]["status"] == "active"
     assert result["frontmatter"]["type"] == "note"
     assert "test note" in result["content"]
+
+
+def test_vault_read_serializes_yaml_date_frontmatter(vault_dir):
+    """vault_read returns YAML date frontmatter as ISO strings."""
+    (vault_dir / "dated-note.md").write_text(
+        "---\ncreated: 2026-04-05\n---\n\nDated content.\n",
+        encoding="utf-8",
+    )
+
+    result = json.loads(vault_read("dated-note.md"))
+    assert "error" not in result
+    assert result["frontmatter"]["created"] == "2026-04-05"
+
+
+def test_vault_search_frontmatter_excerpt_serializes_datetime(vault_dir):
+    """vault_search serializes datetime values found in frontmatter excerpts."""
+    post = frontmatter.Post("Searchable content.\n")
+    post.metadata["scheduled"] = datetime(2026, 4, 5, 13, 45, 0)
+    post.metadata["created"] = date(2026, 4, 5)
+    (vault_dir / "search-dated-note.md").write_text(frontmatter.dumps(post), encoding="utf-8")
+
+    result = json.loads(vault_search("Searchable"))
+    assert "error" not in result
+    matching = next(item for item in result["results"] if item["path"] == "search-dated-note.md")
+    excerpt = matching["frontmatter_excerpt"]
+    assert excerpt["created"] == "2026-04-05"
+    assert excerpt["scheduled"] == "2026-04-05T13:45:00"
 
 
 def test_vault_write_creates_file(vault_dir):


### PR DESCRIPTION
## Summary

Fixes #5 - `vault_read`, `vault_search`, `vault_batch_read`, and related JSON responses can crash with `Object of type date is not JSON serializable` when YAML frontmatter contains bare ISO dates like `created: 2026-04-05`.

## Root Cause

PyYAML converts bare ISO dates to `datetime.date`. Python `json.dumps()` cannot serialize these types by default.

## Fix

- Add `_DateAwareEncoder` and `vault_json_dumps` helper in `src/obsidian_vault_mcp/vault.py`.
- Replace direct `json.dumps(...)` usage in affected tool handlers with `vault_json_dumps(...)`.
- Add tests for date/datetime serialization in `tests/test_tools.py`.
- Include the Windows/ripgrep hardening and path normalization changes from the original second commit.

## Notes

This PR intentionally contains only the two original commits from the closed PR path, rebased onto upstream `main`.
