### PR TITLE
Make allowed hosts configurable via environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,15 +134,10 @@ export VAULT_MCP_HOSTNAME="vault-mcp.yourdomain.com"
 
 The script authenticates with Cloudflare, creates a tunnel, writes the config, and sets up the DNS record. You will need a domain managed by Cloudflare.
 
-After setup, add your tunnel hostname to the `allowed_hosts` list in `server.py` so the MCP library's DNS rebinding protection accepts requests from your domain:
+After setup, set `VAULT_ALLOWED_HOSTS` to include your tunnel hostname so DNS rebinding protection accepts requests from your domain, for example:
 
-```python
-allowed_hosts=[
-    "127.0.0.1:*",
-    "localhost:*",
-    "[::1]:*",
-    "vault-mcp.yourdomain.com",  # add your hostname here
-],
+```bash
+export VAULT_ALLOWED_HOSTS="127.0.0.1:*,localhost:*,[::1]:*,vault-mcp.yourdomain.com"
 ```
 
 ## Production Deployment (macOS)

--- a/src/obsidian_vault_mcp/config.py
+++ b/src/obsidian_vault_mcp/config.py
@@ -1,10 +1,23 @@
 import os
 from pathlib import Path
 
+
+def _env_csv(name: str, default: list[str]) -> list[str]:
+    """Parse a comma-separated env var into a list of trimmed values."""
+    raw = os.environ.get(name, "")
+    if not raw.strip():
+        return default
+    return [item.strip() for item in raw.split(",") if item.strip()]
+
+
 # Vault configuration
 VAULT_PATH = Path(os.environ.get("VAULT_PATH", os.path.expanduser("~/Obsidian/MyVault")))
 VAULT_MCP_TOKEN = os.environ.get("VAULT_MCP_TOKEN", "")
 VAULT_MCP_PORT = int(os.environ.get("VAULT_MCP_PORT", "8420"))
+ALLOWED_HOSTS = _env_csv(
+    "VAULT_ALLOWED_HOSTS",
+    ["127.0.0.1:*", "localhost:*", "[::1]:*"],
+)
 
 # OAuth 2.0 client credentials (for Claude app integration)
 VAULT_OAUTH_CLIENT_ID = os.environ.get("VAULT_OAUTH_CLIENT_ID", "vault-mcp-client")

--- a/src/obsidian_vault_mcp/server.py
+++ b/src/obsidian_vault_mcp/server.py
@@ -12,6 +12,7 @@ from contextlib import asynccontextmanager
 from mcp.server.fastmcp import FastMCP
 from mcp.server.transport_security import TransportSecuritySettings
 
+from . import config
 from .config import VAULT_MCP_PORT, VAULT_MCP_TOKEN, VAULT_PATH
 from .frontmatter_index import FrontmatterIndex
 
@@ -40,13 +41,7 @@ mcp = FastMCP(
     lifespan=lifespan,
     transport_security=TransportSecuritySettings(
         enable_dns_rebinding_protection=True,
-        allowed_hosts=[
-            "127.0.0.1:*",
-            "localhost:*",
-            "[::1]:*",
-            # Add your tunnel hostname here, e.g.:
-            # "vault-mcp.example.com",
-        ],
+        allowed_hosts=config.ALLOWED_HOSTS,
     ),
 )
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,29 @@
+"""Configuration parsing tests."""
+
+import obsidian_vault_mcp.config as config
+
+
+def test_allowed_hosts_defaults(monkeypatch):
+    """Default allowed hosts remain loopback-only when env is unset."""
+    monkeypatch.delenv("VAULT_ALLOWED_HOSTS", raising=False)
+
+    result = config._env_csv("VAULT_ALLOWED_HOSTS", ["127.0.0.1:*", "localhost:*", "[::1]:*"])
+
+    assert result == ["127.0.0.1:*", "localhost:*", "[::1]:*"]
+
+
+def test_allowed_hosts_parses_csv(monkeypatch):
+    """Comma-separated allowed hosts are split into trimmed entries."""
+    monkeypatch.setenv(
+        "VAULT_ALLOWED_HOSTS",
+        "127.0.0.1:*, localhost:*, [::1]:*, vault-mcp.example.com",
+    )
+
+    result = config._env_csv("VAULT_ALLOWED_HOSTS", ["127.0.0.1:*"])
+
+    assert result == [
+        "127.0.0.1:*",
+        "localhost:*",
+        "[::1]:*",
+        "vault-mcp.example.com",
+    ]


### PR DESCRIPTION
## Summary

Make the DNS rebinding protection host list configurable through `VAULT_ALLOWED_HOSTS` instead of requiring source edits in `server.py`.

Today, anyone deploying behind a tunnel or reverse proxy has to patch the hard-coded `allowed_hosts` list in source and reinstall the package whenever the hostname changes. Moving this to configuration makes deployments easier to maintain without changing the default behavior.

## Changes

- add `VAULT_ALLOWED_HOSTS` parsing in `config.py`
- use `config.ALLOWED_HOSTS` in the FastMCP transport security settings
- update README examples to use the environment variable instead of editing source
- add a small config parsing test

## Default behavior

If `VAULT_ALLOWED_HOSTS` is unset, the default remains:

- `127.0.0.1:*`
- `localhost:*`
- `[::1]:*`

## Test plan

- `python -m pytest tests/test_config.py -q`
- manual smoke check with and without `VAULT_ALLOWED_HOSTS` set
