### PR TITLE
Add /authorize alias for OAuth connector compatibility

### DIFF
--- a/src/obsidian_vault_mcp/auth.py
+++ b/src/obsidian_vault_mcp/auth.py
@@ -10,6 +10,7 @@ from .config import VAULT_MCP_TOKEN
 _AUTH_EXEMPT_PATHS = {
     "/health",
     "/.well-known/oauth-authorization-server",
+    "/authorize",
     "/oauth/authorize",
     "/oauth/token",
     "/oauth/register",

--- a/src/obsidian_vault_mcp/oauth.py
+++ b/src/obsidian_vault_mcp/oauth.py
@@ -210,6 +210,7 @@ async def oauth_register(request: Request) -> JSONResponse:
 oauth_routes = [
     Route("/.well-known/oauth-authorization-server", oauth_metadata, methods=["GET"]),
     Route("/oauth/authorize", oauth_authorize, methods=["GET"]),
+    Route("/authorize", oauth_authorize, methods=["GET"]),
     Route("/oauth/token", oauth_token, methods=["POST"]),
     Route("/oauth/register", oauth_register, methods=["POST"]),
 ]


### PR DESCRIPTION
## Summary

Add `/authorize` as an alias for the existing OAuth authorize handler and exempt it from bearer auth.

Some MCP connectors call `/authorize` directly instead of `/oauth/authorize`. Without this alias, the connector receives a 401 during the browser authorization step even though the discovery document points at the same logical endpoint.

## Changes

- add `/authorize` route alias to the existing OAuth authorize handler
- add `/authorize` to the bearer-auth exemption list

## Why this is separate

This PR is intentionally limited to the alias/auth-exemption compatibility fix. It does not change session handling, transport path behavior, or OAuth persistence.

## Test plan

- verify `/oauth/authorize` still works as before
- verify `/authorize` reaches the same handler instead of returning `401`
