### PR TITLE
Fix JSON serialization of YAML date objects in read/search tools

### DIFF
--- a/src/obsidian_vault_mcp/tools/__init__.py
+++ b/src/obsidian_vault_mcp/tools/__init__.py
@@ -1,1 +1,7 @@
+import datetime as _dt
 
+
+def json_default(obj):
+    if isinstance(obj, (_dt.datetime, _dt.date, _dt.time)):
+        return obj.isoformat()
+    raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")

--- a/src/obsidian_vault_mcp/tools/read.py
+++ b/src/obsidian_vault_mcp/tools/read.py
@@ -5,6 +5,7 @@ import logging
 
 import frontmatter
 
+from . import json_default
 from ..vault import resolve_vault_path, read_file
 
 logger = logging.getLogger(__name__)
@@ -29,7 +30,7 @@ def vault_read(path: str) -> str:
             "content": content,
             "metadata": metadata,
             "frontmatter": fm_data,
-        })
+        }, default=json_default)
     except ValueError as e:
         return json.dumps({"error": str(e), "path": path})
     except FileNotFoundError:
@@ -74,4 +75,4 @@ def vault_batch_read(paths: list[str], include_content: bool = True) -> str:
             results.append({"path": path, "error": str(e)})
             missing += 1
 
-    return json.dumps({"files": results, "found": found, "missing": missing})
+    return json.dumps({"files": results, "found": found, "missing": missing}, default=json_default)

--- a/src/obsidian_vault_mcp/tools/search.py
+++ b/src/obsidian_vault_mcp/tools/search.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import frontmatter
 
+from . import json_default
 from .. import config
 from ..vault import resolve_vault_path
 
@@ -170,7 +171,7 @@ def vault_search(
             "results": matches,
             "total_matches": len(matches),
             "truncated": truncated,
-        })
+        }, default=json_default)
     except ValueError as e:
         return json.dumps({"error": str(e)})
     except Exception as e:
@@ -213,7 +214,7 @@ def vault_search_frontmatter(
             "results": formatted,
             "total": len(formatted),
             "truncated": truncated,
-        })
+        }, default=json_default)
     except Exception as e:
         logger.error(f"vault_search_frontmatter error: {e}")
         return json.dumps({"error": str(e)})


### PR DESCRIPTION
## Summary

`vault_read`, `vault_batch_read`, `vault_search`, and `vault_search_frontmatter` all fail with `{"error": "Object of type date is not JSON serializable"}` on any vault file whose frontmatter contains an unquoted ISO date like `created: 2026-04-14`. PyYAML parses that as a Python `datetime.date`, and `json.dumps` can't serialize it.

This PR adds a shared `json_default` helper at `tools/__init__.py` that stringifies `datetime.date`, `datetime.datetime`, and `datetime.time` via `isoformat()`, and threads it into the four `json.dumps` calls that can surface frontmatter data. `tools/write.py` and `tools/manage.py` return only primitives and are unaffected.

## Repro

1. Create `note.md` in a vault with frontmatter `---\ncreated: 2026-04-14\n---\n`
2. Call `vault_read("note.md")`
3. Before: `{"error": "Object of type date is not JSON serializable", "path": "note.md"}`
4. After: `{"path": "note.md", "content": "...", "frontmatter": {"created": "2026-04-14"}, ...}`

Workaround for users on unpatched servers: quote date fields in frontmatter (`created: "2026-04-14"`).

## Test plan

- [x] `vault_read` on a file with unquoted YAML date — returns content + frontmatter with date as ISO string
- [x] `vault_write` + `vault_read` round-trip via remote MCP through Cloudflare Tunnel
- [ ] Unit tests — not added in this PR; happy to add under `tests/test_tools.py` if you'd prefer that before merging

## Notes

Found this while setting up a new deployment of this server as a personal-vault MCP. Thanks for publishing it — the OAuth + Cloudflare Tunnel path working end-to-end saved a ton of yak shaving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)