### PR TITLE
Advertise OAuth discovery metadata for MCP clients

### DIFF
--- a/src/obsidian_vault_mcp/auth.py
+++ b/src/obsidian_vault_mcp/auth.py
@@ -10,10 +10,21 @@ from .config import VAULT_MCP_TOKEN
 _AUTH_EXEMPT_PATHS = {
     "/health",
     "/.well-known/oauth-authorization-server",
+    "/.well-known/oauth-protected-resource",
     "/oauth/authorize",
     "/oauth/token",
     "/oauth/register",
 }
+
+
+def _challenge_header(request: Request, error: str) -> str:
+    base_url = str(request.base_url).rstrip("/")
+    resource_metadata = f"{base_url}/.well-known/oauth-protected-resource"
+    return (
+        f'Bearer realm="mcp", '
+        f'resource_metadata="{resource_metadata}", '
+        f'error="{error}"'
+    )
 
 
 class BearerAuthMiddleware(BaseHTTPMiddleware):
@@ -34,6 +45,7 @@ class BearerAuthMiddleware(BaseHTTPMiddleware):
             return JSONResponse(
                 {"error": "Missing or malformed Authorization header"},
                 status_code=401,
+                headers={"WWW-Authenticate": _challenge_header(request, "invalid_request")},
             )
 
         token = auth_header[7:]
@@ -41,6 +53,7 @@ class BearerAuthMiddleware(BaseHTTPMiddleware):
             return JSONResponse(
                 {"error": "Invalid token"},
                 status_code=401,
+                headers={"WWW-Authenticate": _challenge_header(request, "invalid_token")},
             )
 
         return await call_next(request)

--- a/src/obsidian_vault_mcp/oauth.py
+++ b/src/obsidian_vault_mcp/oauth.py
@@ -55,6 +55,22 @@ async def oauth_metadata(request: Request) -> JSONResponse:
     })
 
 
+async def protected_resource_metadata(request: Request) -> JSONResponse:
+    """RFC 9728 OAuth protected resource metadata.
+
+    MCP clients (including Claude Code) fetch this first to learn which
+    authorization server issues tokens for this resource. Without it, the
+    client can't start the OAuth flow and reports "Failed to connect"
+    instead of "Needs authentication".
+    """
+    base_url = str(request.base_url).rstrip("/")
+    return JSONResponse({
+        "resource": base_url,
+        "authorization_servers": [base_url],
+        "bearer_methods_supported": ["header"],
+    })
+
+
 async def oauth_authorize(request: Request):
     """OAuth 2.0 authorization endpoint.
 
@@ -209,6 +225,7 @@ async def oauth_register(request: Request) -> JSONResponse:
 # Starlette routes to mount on the app
 oauth_routes = [
     Route("/.well-known/oauth-authorization-server", oauth_metadata, methods=["GET"]),
+    Route("/.well-known/oauth-protected-resource", protected_resource_metadata, methods=["GET"]),
     Route("/oauth/authorize", oauth_authorize, methods=["GET"]),
     Route("/oauth/token", oauth_token, methods=["POST"]),
     Route("/oauth/register", oauth_register, methods=["POST"]),


### PR DESCRIPTION
## Summary
- Add the RFC 9728 `/.well-known/oauth-protected-resource` endpoint so MCP clients can discover which authorization server issues tokens for this resource.
- Include a `WWW-Authenticate: Bearer resource_metadata="…"` header on 401 responses from protected endpoints, giving clients an entry point to the OAuth flow.

## Motivation
Without these, spec-compliant MCP clients (including Claude Code) have no discovery path. Instead of walking the user through OAuth, they report "Failed to connect" and never surface the authentication prompt. The existing `/.well-known/oauth-authorization-server` endpoint is necessary but not sufficient — MCP's auth spec (aligning with RFC 9728) expects the protected-resource metadata document first.

Confirmed locally: before the patch, Claude Code showed "Failed to connect" for the deployed vault server; after the patch + service restart, it walks through the OAuth flow and connects cleanly.

## Test plan
- [ ] `curl https://<host>/.well-known/oauth-protected-resource` returns JSON with `resource`, `authorization_servers`, `bearer_methods_supported`.
- [ ] `curl -I -X POST https://<host>/mcp` returns 401 with a `WWW-Authenticate: Bearer ... resource_metadata=...` header.
- [ ] Existing auth flow (bearer token on `/mcp`) still works.
- [ ] Claude Code "Add MCP server" against the deployed host walks OAuth to completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)