### PR TITLE
Fix JSON serialization of YAML date objects in read/search tools

### DIFF
--- a/src/obsidian_vault_mcp/tools/__init__.py
+++ b/src/obsidian_vault_mcp/tools/__init__.py
@@ -1,1 +1,7 @@
+import datetime as _dt
 
+
+def json_default(obj):
+    if isinstance(obj, (_dt.datetime, _dt.date, _dt.time)):
+        return obj.isoformat()
+    raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")

--- a/src/obsidian_vault_mcp/tools/read.py
+++ b/src/obsidian_vault_mcp/tools/read.py
@@ -5,6 +5,7 @@ import logging
 
 import frontmatter
 
+from . import json_default
 from ..vault import resolve_vault_path, read_file
 
 logger = logging.getLogger(__name__)
@@ -29,7 +30,7 @@ def vault_read(path: str) -> str:
             "content": content,
             "metadata": metadata,
             "frontmatter": fm_data,
-        })
+        }, default=json_default)
     except ValueError as e:
         return json.dumps({"error": str(e), "path": path})
     except FileNotFoundError:
@@ -74,4 +75,4 @@ def vault_batch_read(paths: list[str], include_content: bool = True) -> str:
             results.append({"path": path, "error": str(e)})
             missing += 1
 
-    return json.dumps({"files": results, "found": found, "missing": missing})
+    return json.dumps({"files": results, "found": found, "missing": missing}, default=json_default)

--- a/src/obsidian_vault_mcp/tools/search.py
+++ b/src/obsidian_vault_mcp/tools/search.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import frontmatter
 
+from . import json_default
 from .. import config
 from ..vault import resolve_vault_path
 
@@ -170,7 +171,7 @@ def vault_search(
             "results": matches,
             "total_matches": len(matches),
             "truncated": truncated,
-        })
+        }, default=json_default)
     except ValueError as e:
         return json.dumps({"error": str(e)})
     except Exception as e:
@@ -213,7 +214,7 @@ def vault_search_frontmatter(
             "results": formatted,
             "total": len(formatted),
             "truncated": truncated,
-        })
+        }, default=json_default)
     except Exception as e:
         logger.error(f"vault_search_frontmatter error: {e}")
         return json.dumps({"error": str(e)})


### PR DESCRIPTION
## Summary

- YAML frontmatter `date` / `datetime` values parse into Python `date`/`datetime` objects, which `json.dumps` can't serialize by default. Any vault file with a date-typed frontmatter field causes `vault_read` / `vault_search` responses to 500.
- Fix converts date/datetime to ISO strings during response serialization so the tools don't blow up on date-typed frontmatter.

## Test plan

- [ ] Read a file with `created: 2026-04-19` (unquoted date) via `vault_read` — no 500
- [ ] Search across vault that returns a file with date-typed frontmatter — no 500
- [ ] String-typed dates (quoted) still round-trip unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)