### PR TITLE
oauth: extend access token lifetime from 24h to 1 year

### DIFF
--- a/src/obsidian_vault_mcp/oauth.py
+++ b/src/obsidian_vault_mcp/oauth.py
@@ -157,7 +157,7 @@ async def _handle_authorization_code(form, client_id: str, client_secret: str) -
     return JSONResponse({
         "access_token": config.VAULT_MCP_TOKEN,
         "token_type": "bearer",
-        "expires_in": 86400,
+        "expires_in": 31536000,
     })
 
 
@@ -177,7 +177,7 @@ async def _handle_client_credentials(client_id: str, client_secret: str) -> JSON
     return JSONResponse({
         "access_token": config.VAULT_MCP_TOKEN,
         "token_type": "bearer",
-        "expires_in": 86400,
+        "expires_in": 31536000,
     })
 
 


### PR DESCRIPTION
## Summary

- The server doesn't enforce token expiry: `auth.py` does a simple string compare against `VAULT_MCP_TOKEN` with no issuance timestamp or expiry check. `expires_in` is purely advisory to the client.
- The 24h value was forcing Claude clients to re-run the full OAuth flow daily with no security benefit — the bearer token + PKCE + client_secret are the actual security boundary, not token rotation.
- Bumps `expires_in` to 1 year (31536000s) in both the authorization_code and client_credentials grant paths to match the server's actual behavior and eliminate daily re-auth friction.

For multi-user or higher-threat deployments, proper refresh-token flow with token store + revocation would be the right answer — out of scope for this server's single-user threat model. This is a policy call; happy to close if the 24h advisory is intentional.

## Test plan

- [ ] Fresh OAuth authorization_code grant returns `expires_in: 31536000`
- [ ] Bearer token from that grant still validates on subsequent tool calls
- [ ] Client_credentials grant likewise returns 31536000
- [ ] No change to PKCE verification or client authentication

🤖 Generated with [Claude Code](https://claude.com/claude-code)