### PR TITLE
Add /.well-known/oauth-protected-resource (RFC 9728)

### DIFF
--- a/src/obsidian_vault_mcp/auth.py
+++ b/src/obsidian_vault_mcp/auth.py
@@ -10,6 +10,7 @@ from .config import VAULT_MCP_TOKEN
 _AUTH_EXEMPT_PATHS = {
     "/health",
     "/.well-known/oauth-authorization-server",
+    "/.well-known/oauth-protected-resource",
     "/oauth/authorize",
     "/oauth/token",
     "/oauth/register",

--- a/src/obsidian_vault_mcp/oauth.py
+++ b/src/obsidian_vault_mcp/oauth.py
@@ -55,6 +55,20 @@ async def oauth_metadata(request: Request) -> JSONResponse:
     })
 
 
+async def oauth_protected_resource(request: Request) -> JSONResponse:
+    """RFC 9728 OAuth 2.0 Protected Resource Metadata.
+
+    Lets clients (e.g. claude.ai) discover which authorization server protects
+    this MCP resource without first authenticating to the resource itself.
+    """
+    base_url = str(request.base_url).rstrip("/")
+    return JSONResponse({
+        "resource": f"{base_url}/mcp",
+        "authorization_servers": [base_url],
+        "bearer_methods_supported": ["header"],
+    })
+
+
 async def oauth_authorize(request: Request):
     """OAuth 2.0 authorization endpoint.
 
@@ -209,6 +223,7 @@ async def oauth_register(request: Request) -> JSONResponse:
 # Starlette routes to mount on the app
 oauth_routes = [
     Route("/.well-known/oauth-authorization-server", oauth_metadata, methods=["GET"]),
+    Route("/.well-known/oauth-protected-resource", oauth_protected_resource, methods=["GET"]),
     Route("/oauth/authorize", oauth_authorize, methods=["GET"]),
     Route("/oauth/token", oauth_token, methods=["POST"]),
     Route("/oauth/register", oauth_register, methods=["POST"]),


### PR DESCRIPTION
## Summary

Adds the OAuth 2.0 Protected Resource Metadata endpoint (RFC 9728) at `/.well-known/oauth-protected-resource`, which is required by recent MCP clients — notably claude.ai — to validate the relationship between the resource server and its authorization server before using an issued access token.

## Problem

When connecting `obsidian-web-mcp` as a custom MCP connector in claude.ai (via Cloudflare Tunnel + dynamic client registration), the OAuth flow appears to complete successfully on the server side: `POST /oauth/register` returns 201, `GET /oauth/authorize` returns 302 with an auth code, and `POST /oauth/token` returns 200 with an access token.

But immediately after the token is issued, claude.ai displays "Authorization with the MCP server failed" and never sends a single `POST /mcp` request with the bearer token. The server logs show the entire flow completing cleanly, then silence.

## Root cause

While probing the server, claude.ai requests `/.well-known/oauth-protected-resource` (RFC 9728) to discover which authorization server protects the MCP resource. This endpoint does not exist in `obsidian-web-mcp`, so the request would normally fall through to the route resolver — but the `BearerAuthMiddleware` intercepts it first and returns 401 (because the path is not in `_AUTH_EXEMPT_PATHS`).

A 401 here is misleading: a missing endpoint should return 404, which clients treat as "this server does not implement RFC 9728, fall back to legacy discovery". A 401 instead is interpreted as "the protected resource metadata is reachable but requires authentication" — which is a contradiction, since the whole point of the endpoint is to be public. claude.ai concludes the OAuth setup is inconsistent and aborts without ever using the token it just received.

## Fix

Two minimal changes:

1. **`oauth.py`** — new handler `oauth_protected_resource` returning RFC 9728 metadata with `resource`, `authorization_servers`, and `bearer_methods_supported`. The base URL is derived from the request the same way `oauth_metadata` does, so it works correctly behind reverse proxies via `X-Forwarded-Proto` / `X-Forwarded-Host`. Route added to `oauth_routes`.

2. **`auth.py`** — `/.well-known/oauth-protected-resource` added to `_AUTH_EXEMPT_PATHS` so the middleware lets it pass through to the route handler.

Total diff: +16 lines, 0 deletions, 2 files.

## Testing

Verified end-to-end with a claude.ai custom MCP connector reaching the server through a Cloudflare Tunnel:

- `curl https://my-tunnel.example.com/.well-known/oauth-protected-resource` returns 200 with the JSON body (URLs correctly derived from forwarded headers).
- claude.ai connector authorization now completes without error.
- All 9 tools (`vault_read`, `vault_list`, `vault_write`, etc.) are usable from claude.ai.
- Round-trip read and atomic write tested against a real iCloud-synced vault.

## References

- [RFC 9728: OAuth 2.0 Protected Resource Metadata](https://datatracker.ietf.org/doc/html/rfc9728)
- [MCP authorization spec](https://spec.modelcontextprotocol.io/specification/server/authorization/) — references RFC 9728 as the discovery mechanism for MCP resource servers.