### PR TITLE
fix: serialize datetime.date frontmatter fields as ISO 8601 strings

### DIFF
--- a/src/obsidian_vault_mcp/json_utils.py
+++ b/src/obsidian_vault_mcp/json_utils.py
@@ -1,0 +1,23 @@
+"""JSON serialization helpers for vault MCP tools.
+
+PyYAML / python-frontmatter auto-convert unquoted YAML dates
+(e.g. `created: 2026-05-18`) to datetime.date objects, which json.dumps
+cannot serialize by default. This helper converts date/datetime/time
+objects to ISO 8601 strings so vault_read and friends return proper JSON.
+"""
+import json
+from datetime import date, datetime, time
+
+
+def _default(obj):
+    """Convert non-JSON-serializable types to JSON-safe representations."""
+    if isinstance(obj, (date, datetime, time)):
+        return obj.isoformat()
+    raise TypeError(
+        f"Object of type {type(obj).__name__} is not JSON serializable"
+    )
+
+
+def dumps(data) -> str:
+    """json.dumps that handles datetime.date / datetime / time objects."""
+    return json.dumps(data, default=_default)

--- a/src/obsidian_vault_mcp/tools/manage.py
+++ b/src/obsidian_vault_mcp/tools/manage.py
@@ -1,6 +1,6 @@
 """Management tools for the Obsidian vault MCP server."""
 
-import json
+from ..json_utils import dumps as json_dumps
 import logging
 
 from ..vault import list_directory, move_path, delete_path, resolve_vault_path
@@ -24,41 +24,41 @@ def vault_list(
             include_dirs=include_dirs,
             pattern=pattern,
         )
-        return json.dumps({"items": items, "total": len(items)})
+        return json_dumps({"items": items, "total": len(items)})
     except ValueError as e:
-        return json.dumps({"error": str(e)})
+        return json_dumps({"error": str(e)})
     except FileNotFoundError:
-        return json.dumps({"error": f"Directory not found: {path}"})
+        return json_dumps({"error": f"Directory not found: {path}"})
     except Exception as e:
         logger.error(f"vault_list error: {e}")
-        return json.dumps({"error": str(e)})
+        return json_dumps({"error": str(e)})
 
 
 def vault_move(source: str, destination: str, create_dirs: bool = True) -> str:
     """Move a file or directory within the vault."""
     try:
         moved = move_path(source, destination, create_dirs=create_dirs)
-        return json.dumps({"source": source, "destination": destination, "moved": moved})
+        return json_dumps({"source": source, "destination": destination, "moved": moved})
     except ValueError as e:
-        return json.dumps({"error": str(e), "source": source, "destination": destination})
+        return json_dumps({"error": str(e), "source": source, "destination": destination})
     except Exception as e:
         logger.error(f"vault_move error: {e}")
-        return json.dumps({"error": str(e), "source": source, "destination": destination})
+        return json_dumps({"error": str(e), "source": source, "destination": destination})
 
 
 def vault_delete(path: str, confirm: bool = False) -> str:
     """Delete a file by moving it to .trash/ in the vault."""
     if not confirm:
-        return json.dumps({
+        return json_dumps({
             "error": "Set confirm=true to execute deletion. Files are moved to .trash/, not hard deleted.",
             "path": path,
         })
 
     try:
         deleted = delete_path(path)
-        return json.dumps({"path": path, "deleted": deleted})
+        return json_dumps({"path": path, "deleted": deleted})
     except ValueError as e:
-        return json.dumps({"error": str(e), "path": path})
+        return json_dumps({"error": str(e), "path": path})
     except Exception as e:
         logger.error(f"vault_delete error: {e}")
-        return json.dumps({"error": str(e), "path": path})
+        return json_dumps({"error": str(e), "path": path})

--- a/src/obsidian_vault_mcp/tools/read.py
+++ b/src/obsidian_vault_mcp/tools/read.py
@@ -1,6 +1,6 @@
 """Read tools for the Obsidian vault MCP server."""
 
-import json
+from ..json_utils import dumps as json_dumps
 import logging
 
 import frontmatter
@@ -24,19 +24,19 @@ def vault_read(path: str) -> str:
         except Exception:
             pass
 
-        return json.dumps({
+        return json_dumps({
             "path": path,
             "content": content,
             "metadata": metadata,
             "frontmatter": fm_data,
         })
     except ValueError as e:
-        return json.dumps({"error": str(e), "path": path})
+        return json_dumps({"error": str(e), "path": path})
     except FileNotFoundError:
-        return json.dumps({"error": f"File not found: {path}", "path": path})
+        return json_dumps({"error": f"File not found: {path}", "path": path})
     except Exception as e:
         logger.error(f"vault_read error for {path}: {e}")
-        return json.dumps({"error": str(e), "path": path})
+        return json_dumps({"error": str(e), "path": path})
 
 
 def vault_batch_read(paths: list[str], include_content: bool = True) -> str:
@@ -74,4 +74,4 @@ def vault_batch_read(paths: list[str], include_content: bool = True) -> str:
             results.append({"path": path, "error": str(e)})
             missing += 1
 
-    return json.dumps({"files": results, "found": found, "missing": missing})
+    return json_dumps({"files": results, "found": found, "missing": missing})

--- a/src/obsidian_vault_mcp/tools/search.py
+++ b/src/obsidian_vault_mcp/tools/search.py
@@ -1,6 +1,6 @@
 """Search tools for the Obsidian vault MCP server."""
 
-import json
+from ..json_utils import dumps as json_dumps
 import logging
 import shutil
 import subprocess
@@ -153,7 +153,7 @@ def vault_search(
             search_path = config.VAULT_PATH
 
         if not search_path.is_dir():
-            return json.dumps({"error": f"Search path is not a directory: {path_prefix}"})
+            return json_dumps({"error": f"Search path is not a directory: {path_prefix}"})
 
         if shutil.which("rg"):
             matches = _search_ripgrep(query, search_path, file_pattern, max_results, context_lines)
@@ -166,16 +166,16 @@ def vault_search(
 
         truncated = len(matches) >= max_results
 
-        return json.dumps({
+        return json_dumps({
             "results": matches,
             "total_matches": len(matches),
             "truncated": truncated,
         })
     except ValueError as e:
-        return json.dumps({"error": str(e)})
+        return json_dumps({"error": str(e)})
     except Exception as e:
         logger.error(f"vault_search error: {e}")
-        return json.dumps({"error": str(e)})
+        return json_dumps({"error": str(e)})
 
 
 def vault_search_frontmatter(
@@ -209,11 +209,11 @@ def vault_search_frontmatter(
 
         truncated = len(results) > max_results
 
-        return json.dumps({
+        return json_dumps({
             "results": formatted,
             "total": len(formatted),
             "truncated": truncated,
         })
     except Exception as e:
         logger.error(f"vault_search_frontmatter error: {e}")
-        return json.dumps({"error": str(e)})
+        return json_dumps({"error": str(e)})

--- a/src/obsidian_vault_mcp/tools/write.py
+++ b/src/obsidian_vault_mcp/tools/write.py
@@ -1,6 +1,6 @@
 """Write tools for the Obsidian vault MCP server."""
 
-import json
+from ..json_utils import dumps as json_dumps
 import logging
 
 import frontmatter
@@ -33,12 +33,12 @@ def vault_write(path: str, content: str, create_dirs: bool = True, merge_frontma
 
         is_new, size = write_file_atomic(path, content, create_dirs=create_dirs)
 
-        return json.dumps({"path": path, "created": is_new, "size": size})
+        return json_dumps({"path": path, "created": is_new, "size": size})
     except ValueError as e:
-        return json.dumps({"error": str(e), "path": path})
+        return json_dumps({"error": str(e), "path": path})
     except Exception as e:
         logger.error(f"vault_write error for {path}: {e}")
-        return json.dumps({"error": str(e), "path": path})
+        return json_dumps({"error": str(e), "path": path})
 
 
 def vault_batch_frontmatter_update(updates: list[dict]) -> str:
@@ -67,4 +67,4 @@ def vault_batch_frontmatter_update(updates: list[dict]) -> str:
         except Exception as e:
             results.append({"path": file_path, "updated": False, "error": str(e)})
 
-    return json.dumps({"results": results})
+    return json_dumps({"results": results})

--- a/tests/test_json_utils.py
+++ b/tests/test_json_utils.py
@@ -1,0 +1,83 @@
+"""Tests for the json_utils serialization helper."""
+import json
+from datetime import date, datetime, time
+
+import pytest
+
+from obsidian_vault_mcp.json_utils import _default, dumps
+
+
+def test_dumps_handles_plain_strings():
+    """Pure strings should serialize like normal json.dumps."""
+    result = dumps({"name": "Hello", "count": 42})
+    assert json.loads(result) == {"name": "Hello", "count": 42}
+
+
+def test_dumps_handles_date_objects():
+    """datetime.date should serialize as ISO 8601 string."""
+    payload = {"created": date(2026, 5, 18)}
+    result = dumps(payload)
+    assert json.loads(result) == {"created": "2026-05-18"}
+
+
+def test_dumps_handles_datetime_objects():
+    """datetime.datetime should serialize with full ISO 8601 timestamp."""
+    payload = {"timestamp": datetime(2026, 5, 18, 14, 30, 0)}
+    result = dumps(payload)
+    assert json.loads(result) == {"timestamp": "2026-05-18T14:30:00"}
+
+
+def test_dumps_handles_time_objects():
+    """datetime.time should serialize as ISO 8601 time string."""
+    payload = {"clock": time(9, 15, 30)}
+    result = dumps(payload)
+    assert json.loads(result) == {"clock": "09:15:30"}
+
+
+def test_dumps_handles_nested_dates():
+    """Dates nested in dicts and lists should all convert."""
+    payload = {
+        "created": date(2026, 1, 1),
+        "tags": ["a", "b"],
+        "history": [
+            {"day": date(2026, 5, 17), "note": "first"},
+            {"day": date(2026, 5, 18), "note": "second"},
+        ],
+    }
+    result = dumps(payload)
+    parsed = json.loads(result)
+    assert parsed["created"] == "2026-01-01"
+    assert parsed["history"][0]["day"] == "2026-05-17"
+    assert parsed["history"][1]["day"] == "2026-05-18"
+
+
+def test_dumps_simulates_frontmatter_payload():
+    """Realistic frontmatter dict from python-frontmatter library."""
+    fm = {
+        "title": "Project Note",
+        "created": date(2026, 5, 4),
+        "updated": date(2026, 5, 18),
+        "tags": ["map", "roadmap"],
+        "status": "in-progress",
+    }
+    payload = {"path": "notes/project.md", "frontmatter": fm}
+    result = dumps(payload)
+    parsed = json.loads(result)
+    assert parsed["frontmatter"]["created"] == "2026-05-04"
+    assert parsed["frontmatter"]["updated"] == "2026-05-18"
+    assert parsed["frontmatter"]["tags"] == ["map", "roadmap"]
+
+
+def test_default_raises_for_unsupported_types():
+    """Unsupported types should still raise TypeError."""
+    class CustomObject:
+        pass
+
+    with pytest.raises(TypeError, match="not JSON serializable"):
+        _default(CustomObject())
+
+
+def test_dumps_passes_through_none_and_booleans():
+    """None and booleans should pass through unchanged."""
+    result = dumps({"key": None, "active": True, "draft": False})
+    assert json.loads(result) == {"key": None, "active": True, "draft": False}


### PR DESCRIPTION
## Problem

When a vault note has an unquoted YAML date field in its frontmatter — e.g.

```yaml
---
created: 2026-05-18
updated: 2026-05-18
---
```

— PyYAML (via `python-frontmatter`) automatically parses these as `datetime.date` objects. `json.dumps()` then fails with:

```
TypeError: Object of type date is not JSON serializable
```

This breaks every tool that returns frontmatter to the client: `vault_read`, `vault_batch_read`, `vault_search`, `vault_search_frontmatter` — effectively making the server unusable for any vault containing notes with unquoted date frontmatter.

This is a fairly common pattern in Obsidian vaults since the popular [Templater](https://github.com/SilentVoid13/Templater) and Daily Notes plugins both emit unquoted dates by default.

## Solution

New module `src/obsidian_vault_mcp/json_utils.py` exposes a `dumps()` helper that wraps `json.dumps` with a `default=` handler converting `date` / `datetime` / `time` to ISO 8601 strings:

```python
def _default(obj):
    if isinstance(obj, (date, datetime, time)):
        return obj.isoformat()
    raise TypeError(
        f"Object of type {type(obj).__name__} is not JSON serializable"
    )

def dumps(data) -> str:
    return json.dumps(data, default=_default)
```

All four tool modules (`read.py`, `write.py`, `search.py`, `manage.py`) now import this helper instead of calling `json.dumps` directly.

## Why this approach

- **No content-side workaround required** — users can keep writing unquoted dates in their frontmatter
- **Minimal blast radius** — only the serialization boundary changes, YAML parsing logic is untouched
- **Same Python stdlib pattern** as `json.JSONEncoder` subclassing, just simpler with `default=`
- **Forward-compatible** — easy to extend for other non-serializable types if needed

## Tests

New test file `tests/test_json_utils.py` with 8 unit tests covering:

- Plain string serialization (regression)
- `datetime.date` → ISO string
- `datetime.datetime` → ISO timestamp
- `datetime.time` → ISO time
- Nested dates in lists/dicts
- Realistic frontmatter payload (mimics `python-frontmatter` output)
- `TypeError` still raised for unsupported types
- `None` / `True` / `False` passthrough

All existing tests (26) continue to pass. Full suite is **34/34 green**.

## Verification

Tested live against a vault with 158+ notes, several with unquoted `created:` / `updated:` / `start:` / `ende:` date fields. Before the fix: `vault_read` returned `{"error": "Object of type date is not JSON serializable"}`. After: returns proper JSON with date fields as `"2026-05-18"` ISO strings.

## Commits

1. `9bac2f0` — `fix(serialization): handle datetime.date in JSON responses`
2. `5c7684f` — `test(json_utils): add unit tests for date/datetime/time serialization`