### PR TITLE
fix: handle YAML date objects in vault_search and vault_read

### DIFF
--- a/src/obsidian_vault_mcp/tools/read.py
+++ b/src/obsidian_vault_mcp/tools/read.py
@@ -1,5 +1,6 @@
 """Read tools for the Obsidian vault MCP server."""
 
+import datetime
 import json
 import logging
 
@@ -8,6 +9,12 @@ import frontmatter
 from ..vault import resolve_vault_path, read_file
 
 logger = logging.getLogger(__name__)
+
+
+def _json_default(obj):
+    if isinstance(obj, (datetime.date, datetime.datetime, datetime.time)):
+        return obj.isoformat()
+    raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
 
 
 def vault_read(path: str) -> str:
@@ -29,7 +36,7 @@ def vault_read(path: str) -> str:
             "content": content,
             "metadata": metadata,
             "frontmatter": fm_data,
-        })
+        }, default=_json_default)
     except ValueError as e:
         return json.dumps({"error": str(e), "path": path})
     except FileNotFoundError:
@@ -74,4 +81,4 @@ def vault_batch_read(paths: list[str], include_content: bool = True) -> str:
             results.append({"path": path, "error": str(e)})
             missing += 1
 
-    return json.dumps({"files": results, "found": found, "missing": missing})
+    return json.dumps({"files": results, "found": found, "missing": missing}, default=_json_default)

--- a/src/obsidian_vault_mcp/tools/search.py
+++ b/src/obsidian_vault_mcp/tools/search.py
@@ -1,5 +1,6 @@
 """Search tools for the Obsidian vault MCP server."""
 
+import datetime
 import json
 import logging
 import shutil
@@ -12,6 +13,12 @@ from .. import config
 from ..vault import resolve_vault_path
 
 logger = logging.getLogger(__name__)
+
+
+def _json_default(obj):
+    if isinstance(obj, (datetime.date, datetime.datetime, datetime.time)):
+        return obj.isoformat()
+    raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
 
 
 def _search_ripgrep(
@@ -170,7 +177,7 @@ def vault_search(
             "results": matches,
             "total_matches": len(matches),
             "truncated": truncated,
-        })
+        }, default=_json_default)
     except ValueError as e:
         return json.dumps({"error": str(e)})
     except Exception as e:
@@ -213,7 +220,7 @@ def vault_search_frontmatter(
             "results": formatted,
             "total": len(formatted),
             "truncated": truncated,
-        })
+        }, default=_json_default)
     except Exception as e:
         logger.error(f"vault_search_frontmatter error: {e}")
         return json.dumps({"error": str(e)})


### PR DESCRIPTION
## Summary

`vault_search`, `vault_search_frontmatter`, `vault_read`, and `vault_batch_read` raise `TypeError: Object of type date is not JSON serializable` (surfaced to MCP clients as an `isError` tool result) when frontmatter contains unquoted ISO 8601 dates such as `created: 2026-05-25`.

PyYAML — used under the hood by `python-frontmatter` — parses unquoted ISO dates as `datetime.date` objects. These objects flow into the `json.dumps()` response builders in `tools/search.py` and `tools/read.py`, which have no `default=` fallback, so the date object bubbles up as a `TypeError`.

## Fix

Add a small `_json_default` helper to `tools/search.py` and `tools/read.py` that converts `datetime.date`, `datetime.datetime`, and `datetime.time` to ISO 8601 strings at serialization time. Anything else still raises, so other type bugs are not silently swallowed.

## Reproduction (before patch)

1. Create a note with unquoted ISO date frontmatter:

   ```markdown
   ---
   created: 2026-05-25
   tags: [test]
   ---
   body
   ```

2. Call `vault_search` for any term matching the body, or `vault_read` on that file.
3. The tool returns an error containing `Object of type date is not JSON serializable`.

## Test plan

- [x] Created vault file with unquoted `created: 2026-05-25` in frontmatter
- [x] Confirmed `vault_search` returns clean JSON with `frontmatter_excerpt: {"created": "2026-05-25", ...}`
- [x] Confirmed `vault_read` returns the file with frontmatter serialized as ISO string
- [x] Confirmed `vault_search_frontmatter` returns clean JSON (also affected)
- [x] `python -m py_compile` clean on both modified modules
- [ ] Existing pytest suite not run on this branch — `pytest` is in optional `[dev]` extras and was not installed in the deployment venv used to verify this patch. Patch surface is small (adds `default=` callable only, no logic changes), so regression risk is low. Happy to run the suite if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
