### PR TITLE
fix(tools): normalize date/datetime in frontmatter for JSON serialization

### DIFF
--- a/src/obsidian_vault_mcp/tools/read.py
+++ b/src/obsidian_vault_mcp/tools/read.py
@@ -7,6 +7,17 @@ import frontmatter
 
 from ..vault import resolve_vault_path, read_file
 
+def _normalize_fm(value):
+    """Convert date/datetime objects to ISO strings for JSON serialization."""
+    import datetime
+    if isinstance(value, (datetime.date, datetime.datetime)):
+        return value.isoformat()
+    if isinstance(value, dict):
+        return {k: _normalize_fm(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_normalize_fm(v) for v in value]
+    return value
+
 logger = logging.getLogger(__name__)
 
 
@@ -20,7 +31,7 @@ def vault_read(path: str) -> str:
         try:
             post = frontmatter.loads(content)
             if post.metadata:
-                fm_data = post.metadata
+                fm_data = _normalize_fm(post.metadata)
         except Exception:
             pass
 
@@ -53,7 +64,7 @@ def vault_batch_read(paths: list[str], include_content: bool = True) -> str:
             try:
                 post = frontmatter.loads(content)
                 if post.metadata:
-                    fm_data = post.metadata
+                    fm_data = _normalize_fm(post.metadata)
             except Exception:
                 pass
 

--- a/src/obsidian_vault_mcp/tools/search.py
+++ b/src/obsidian_vault_mcp/tools/search.py
@@ -124,6 +124,16 @@ def _search_python(
 
     return matches
 
+def _normalize_fm(value):
+    """Convert date/datetime objects to ISO strings for JSON serialization."""
+    import datetime
+    if isinstance(value, (datetime.date, datetime.datetime)):
+        return value.isoformat()
+    if isinstance(value, dict):
+        return {k: _normalize_fm(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_normalize_fm(v) for v in value]
+    return value
 
 def _get_frontmatter_excerpt(file_path: Path, max_keys: int = 3) -> dict | None:
     """Read frontmatter from a file, returning first N key-value pairs."""
@@ -133,7 +143,7 @@ def _get_frontmatter_excerpt(file_path: Path, max_keys: int = 3) -> dict | None:
         if not post.metadata:
             return None
         keys = list(post.metadata.keys())[:max_keys]
-        return {k: post.metadata[k] for k in keys}
+        return _normalize_fm({k: post.metadata[k] for k in keys})
     except Exception:
         return None
 


### PR DESCRIPTION
## Summary

`vault_read`, `vault_batch_read`, and `vault_search` fail with `Object of type date is not JSON serializable` when a vault file's YAML frontmatter contains an unquoted date value (e.g. `created: 2026-05-24`). This affects any vault that uses Obsidian's built-in **Properties** feature with the `Date` type, which writes bare YAML dates by default.

## Reproduction

Create a file in the vault with this frontmatter:

```markdown
---
title: Test note
created: 2026-05-24
updated: 2026-05-24
---

Body text.
```

Then call any of the affected tools:

```
vault_read(path="test.md")
→ {"error": "Object of type date is not JSON serializable", "path": "test.md"}

vault_batch_read(paths=["test.md"])
→ Error: Object of type date is not JSON serializable

vault_search(query=".", path_prefix="00-Inbox", file_pattern="test.md")
→ {"error": "Object of type date is not JSON serializable"}
```

## Root cause

PyYAML (used internally by `python-frontmatter`) parses unquoted ISO-8601 date strings as `datetime.date` objects per the YAML 1.1 spec. Python's default `json` encoder does not know how to serialize `datetime.date` / `datetime.datetime`, so the call raises `TypeError` at the JSON-RPC response boundary — even though the in-memory metadata dict is otherwise valid and the frontmatter index works correctly for queries.

This is not visible in local Python REPL tests against the tool functions because the failure only manifests during JSON serialization of the MCP response.

## Fix

Add a small recursive helper `_normalize_fm()` that converts `date` / `datetime` objects to ISO-8601 strings, walking through nested dicts and lists in the metadata. Applied to `post.metadata` in `tools/read.py` (covers `vault_read` and `vault_batch_read`) and `tools/search.py` (covers frontmatter excerpts in search results).

The helper is intentionally local to each file rather than centralized, matching the existing project structure. Happy to refactor into a shared util module if preferred.

## What this PR does *not* change

- No behavior change for frontmatter that doesn't contain date values
- Tools still return the same shape; date values just appear as ISO strings instead of crashing
- The in-memory frontmatter index is unaffected (it operates on the parsed dict directly, where `datetime.date` objects work fine for comparisons)

## Suggested follow-up (not in this PR)

A regression test fixture with bare YAML dates would catch this. I can submit a separate PR adding one to `tests/conftest.py` if useful — just let me know.

## Testing

Verified locally against a vault containing several files with `created:` / `updated:` bare-date frontmatter. All three tools now return correctly, with the date fields appearing as ISO strings in the response metadata.