### PR TITLE
Add VAULT_MCP_ALLOWED_HOSTS + Start script

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,19 @@
+# Required: path to your Obsidian vault directory
+VAULT_PATH=/path/to/your/obsidian_vaults
+
+# Required: generate with: python3 -c "import secrets; print(secrets.token_hex(32))"
+VAULT_MCP_TOKEN=
+
+# Required: generate with: python3 -c "import secrets; print(secrets.token_hex(32))"
+VAULT_OAUTH_CLIENT_SECRET=
+
+# Optional: OAuth client ID (default: vault-mcp-client)
+VAULT_OAUTH_CLIENT_ID=vault-mcp-client
+
+# Optional: port to listen on (default: 8420)
+VAULT_MCP_PORT=3001
+
+# Optional: comma-separated extra allowed Host headers for DNS rebinding protection
+# Required if connecting from a remote MCP client (e.g. MCPJam, Claude web)
+# Example: VAULT_MCP_ALLOWED_HOSTS=vault-mcp.example.com,mcp2.dev
+VAULT_MCP_ALLOWED_HOSTS=

--- a/.env.template
+++ b/.env.template
@@ -11,7 +11,7 @@ VAULT_OAUTH_CLIENT_SECRET=
 VAULT_OAUTH_CLIENT_ID=vault-mcp-client
 
 # Optional: port to listen on (default: 8420)
-VAULT_MCP_PORT=3001
+VAULT_MCP_PORT=8420
 
 # Optional: comma-separated extra allowed Host headers for DNS rebinding protection
 # Required if connecting from a remote MCP client (e.g. MCPJam, Claude web)

--- a/README.md
+++ b/README.md
@@ -91,6 +91,41 @@ uv run vault-mcp
 
 The server starts on port 8420 by default. It serves MCP over Streamable HTTP at `/mcp/`.
 
+## Start Server Script (experimental)
+
+```bash
+# Install uv
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Install dependencies
+uv sync
+
+# Generate secrets (writes to .env, gitignored)
+./scripts/generate_secrets.sh
+
+# Start the server on port 3001
+./scripts/start-server.sh
+```
+
+### Manual Verify with Curl
+
+```bash
+source .env
+
+# Get a bearer token
+TOKEN=$(curl -s -X POST http://localhost:3001/oauth/token \
+  -d "grant_type=client_credentials" \
+  -d "client_id=$VAULT_OAUTH_CLIENT_ID" \
+  -d "client_secret=$VAULT_OAUTH_CLIENT_SECRET" | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])")
+
+# List available tools
+curl -s -X POST http://localhost:3001/mcp \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
+```
+
 ## Configuration
 
 All configuration is via environment variables:

--- a/README.md
+++ b/README.md
@@ -134,11 +134,14 @@ All configuration is via environment variables:
 |----------|----------|---------|-------------|
 | `VAULT_PATH` | Yes | `~/Obsidian/MyVault` | Absolute path to your Obsidian vault directory |
 | `VAULT_MCP_TOKEN` | Yes | (none) | 256-bit bearer token for authenticating MCP requests |
+| `VAULT_OAUTH_CLIENT_SECRET` | Yes | (none) | OAuth 2.0 client secret for Claude integration |
 | `VAULT_MCP_PORT` | No | `8420` | Port the HTTP server listens on |
 | `VAULT_OAUTH_CLIENT_ID` | No | `vault-mcp-client` | OAuth 2.0 client ID for Claude integration |
-| `VAULT_OAUTH_CLIENT_SECRET` | Yes | (none) | OAuth 2.0 client secret for Claude integration |
+| `VAULT_MCP_ALLOWED_HOSTS` | No | (none) | Comma-separated extra allowed `Host` headers for DNS rebinding protection. Required when connecting from remote clients (Claude web, MCPJam, etc). Example: `agentbrain.mcpnative.dev,vault-mcp.example.com` |
 
-Generate tokens with: `python -c "import secrets; print(secrets.token_hex(32))"`
+Generate tokens with: `python3 -c "import secrets; print(secrets.token_hex(32))"`
+
+See `.env.template` for a ready-to-copy configuration file.
 
 ## Connecting to Claude
 

--- a/scripts/generate_secrets.sh
+++ b/scripts/generate_secrets.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ENV_FILE="$REPO_ROOT/.env"
+
+if [ -f "$ENV_FILE" ]; then
+    echo ".env already exists at $ENV_FILE"
+    read -rp "Overwrite? [y/N] " answer
+    answer=${answer:-N}
+    if [[ ! "$answer" =~ ^[Yy] ]]; then
+        echo "Aborted."
+        exit 0
+    fi
+fi
+
+cat > "$ENV_FILE" <<EOF
+VAULT_MCP_TOKEN=$(python3 -c "import secrets; print(secrets.token_hex(32))")
+VAULT_OAUTH_CLIENT_ID=vault-mcp-client
+VAULT_OAUTH_CLIENT_SECRET=$(python3 -c "import secrets; print(secrets.token_hex(32))")
+VAULT_PATH=$HOME/obsidian_vaults
+VAULT_MCP_PORT=3001
+EOF
+
+chmod 600 "$ENV_FILE"
+echo "Secrets written to $ENV_FILE (mode 600)"

--- a/scripts/start-server.sh
+++ b/scripts/start-server.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+if [ -f ".env" ]; then
+    set -o allexport
+    # shellcheck source=../.env
+    source .env
+    set +o allexport
+fi
+
+missing=()
+[ -z "${VAULT_MCP_TOKEN:-}" ] && missing+=("VAULT_MCP_TOKEN")
+[ -z "${VAULT_OAUTH_CLIENT_SECRET:-}" ] && missing+=("VAULT_OAUTH_CLIENT_SECRET")
+
+if [ ${#missing[@]} -gt 0 ]; then
+    echo "ERROR: missing required secrets: ${missing[*]}"
+    echo "Run ./scripts/generate_secrets.sh to create them."
+    exit 1
+fi
+
+if [ ! -d ".venv" ]; then
+    echo "Virtual environment not found."
+    read -rp "Run 'uv sync' now? [Y/n] " answer
+    answer=${answer:-Y}
+    if [[ "$answer" =~ ^[Yy] ]]; then
+        uv sync
+    fi
+fi
+
+VAULT_MCP_PORT=${VAULT_MCP_PORT:-3001} VAULT_PATH=${VAULT_PATH:-"$HOME/obsidian_vaults"} uv run vault-mcp

--- a/scripts/start-server.sh
+++ b/scripts/start-server.sh
@@ -21,6 +21,10 @@ if [ ${#missing[@]} -gt 0 ]; then
     exit 1
 fi
 
+if [ -z "${VAULT_MCP_ALLOWED_HOSTS:-}" ]; then
+    echo "INFO: VAULT_MCP_ALLOWED_HOSTS not set -- server only reachable via localhost"
+fi
+
 if [ ! -d ".venv" ]; then
     echo "Virtual environment not found."
     read -rp "Run 'uv sync' now? [Y/n] " answer

--- a/scripts/start-server.sh
+++ b/scripts/start-server.sh
@@ -34,4 +34,4 @@ if [ ! -d ".venv" ]; then
     fi
 fi
 
-VAULT_MCP_PORT=${VAULT_MCP_PORT:-3001} VAULT_PATH=${VAULT_PATH:-"$HOME/obsidian_vaults"} uv run vault-mcp
+VAULT_PATH=${VAULT_PATH:-"$HOME/obsidian_vaults"} uv run vault-mcp

--- a/src/obsidian_vault_mcp/config.py
+++ b/src/obsidian_vault_mcp/config.py
@@ -10,6 +10,11 @@ VAULT_MCP_PORT = int(os.environ.get("VAULT_MCP_PORT", "8420"))
 VAULT_OAUTH_CLIENT_ID = os.environ.get("VAULT_OAUTH_CLIENT_ID", "vault-mcp-client")
 VAULT_OAUTH_CLIENT_SECRET = os.environ.get("VAULT_OAUTH_CLIENT_SECRET", "")
 
+# Additional allowed hosts for DNS rebinding protection (comma-separated)
+# e.g. "agentbrain.mcpnative.dev,vault-mcp.example.com"
+_extra = os.environ.get("VAULT_MCP_ALLOWED_HOSTS", "")
+VAULT_MCP_EXTRA_ALLOWED_HOSTS: list[str] = [h.strip() for h in _extra.split(",") if h.strip()]
+
 # Safety limits
 MAX_CONTENT_SIZE = 1_000_000  # 1MB max write size
 MAX_BATCH_SIZE = 20           # Max files per batch operation

--- a/src/obsidian_vault_mcp/server.py
+++ b/src/obsidian_vault_mcp/server.py
@@ -12,7 +12,7 @@ from contextlib import asynccontextmanager
 from mcp.server.fastmcp import FastMCP
 from mcp.server.transport_security import TransportSecuritySettings
 
-from .config import VAULT_MCP_PORT, VAULT_MCP_TOKEN, VAULT_PATH
+from .config import VAULT_MCP_EXTRA_ALLOWED_HOSTS, VAULT_MCP_PORT, VAULT_MCP_TOKEN, VAULT_PATH
 from .frontmatter_index import FrontmatterIndex
 
 logger = logging.getLogger(__name__)
@@ -44,9 +44,7 @@ mcp = FastMCP(
             "127.0.0.1:*",
             "localhost:*",
             "[::1]:*",
-            # Add your tunnel hostname here, e.g.:
-            # "vault-mcp.example.com",
-        ],
+        ] + VAULT_MCP_EXTRA_ALLOWED_HOSTS,
     ),
 )
 


### PR DESCRIPTION
I got it running on my VPS and connected to Claude Desktop + Mobile (yay!) and made a few tweaks along the way:

- Added `VAULT_MCP_ALLOWED_HOSTS` to make it easier to extend allowed hosts without having to hardcode them.  This seems pretty useful, and if needed I can extract this change into a separate PR
- Start script that does some validation
- Add `.env.template` to make it easier to copy and edit
- Update `README` with instructions on running `server-start`, as well as manually verifying the OAuth2 via `curl`.  Not sure how useful this is though, something like [MCPJam Inspector](https://github.com/MCPJam/inspector) is probably a better approach.

Let me know if you want any of these cleaned up and split out into separate PRs!

# AI Generated Summary

  - Start script (scripts/start-server.sh) — single command to launch the server; auto-sources .env; validates required secrets are set; prompts to run uv sync if virtualenv is missing; warns when
  VAULT_MCP_ALLOWED_HOSTS is unset so it's clear the server is localhost-only
  - Secret generation (scripts/generate_secrets.sh) — generates cryptographically secure tokens for VAULT_MCP_TOKEN and VAULT_OAUTH_CLIENT_SECRET, writes them to .env (mode 600, gitignored), guards against
  accidental overwrite
  - Remote client support — new VAULT_MCP_ALLOWED_HOSTS env var (comma-separated) extends the DNS rebinding protection allowlist, fixing 421 errors when connecting from remote MCP clients like Claude web or MCPJam
  - Config template (.env.template) — documents all env vars with inline comments and example values; secrets blanked out for safe copying
  - README — adds setup and server-start instructions; adds curl-based smoke test for verifying auth and tool listing; updates Configuration table with all vars including VAULT_MCP_ALLOWED_HOSTS
