### PR TITLE
Fix: frontmatter index misses atomic-rename writes (add on_moved handler)

### DIFF
--- a/src/obsidian_vault_mcp/frontmatter_index.py
+++ b/src/obsidian_vault_mcp/frontmatter_index.py
@@ -170,3 +170,22 @@ class _VaultEventHandler(FileSystemEventHandler):
 
     def on_deleted(self, event: FileSystemEvent) -> None:
         self._handle(event)
+
+    def on_moved(self, event: FileSystemEvent) -> None:
+        # Atomic writes (write_file_atomic: tempfile.mkstemp + os.replace) and
+        # vault_move/vault_delete (shutil.move) surface as MOVED events, not
+        # created/modified -- without this the index never sees vault_write output.
+        # Schedule BOTH endpoints: src (now gone -> popped on flush) and dest
+        # (now present -> re-parsed + added). .tmp/.trash paths are filtered out
+        # by the .md-suffix and _is_excluded checks inside the loop.
+        if event.is_directory:
+            return
+        for raw_path in (event.src_path, getattr(event, "dest_path", None)):
+            if not raw_path:
+                continue
+            path = Path(raw_path)
+            if path.suffix != ".md":
+                continue
+            if self._index._is_excluded(path):
+                continue
+            self._index._schedule_debounce(raw_path)


### PR DESCRIPTION
## Problem

`_VaultEventHandler` implements `on_created`, `on_modified`, and `on_deleted`, but not `on_moved`.

Most tools — and this server itself — write files atomically: write to a temp file, then `rename()` / `os.replace()` into place. The kernel reports that as a *moved* event, not create/modify. Concretely:

- `vault_write` → `write_file_atomic` (`tempfile.mkstemp` + `os.replace`)
- `vault_move` / `vault_delete` → `shutil.move`

Because `on_moved` isn't handled, the watchdog `FileMovedEvent` is silently dropped and the in-memory frontmatter index never updates. The index only reflects the initial `rglob` walk at process start, so a file created via `vault_write` is **invisible to `vault_search_frontmatter` until the server is restarted**. On a long-running server the index can lag the live vault by days.

## Fix

Add `on_moved`. A `FileMovedEvent` carries both `src_path` (old, now gone) and `dest_path` (new, now present); schedule the existing debounce for both. On flush, the source is removed (no longer exists) and the destination is parsed and added. Non-`.md` paths (e.g. the temp file) and excluded dirs are filtered exactly as in `_handle`, reusing `_schedule_debounce` / `_flush_pending` with no other changes.

## Verification

On a live deployment (vault ~7.9k indexed files): before, `vault_write` of a new note → `vault_search_frontmatter` returned 0 hits until a restart; after, the note is discoverable within the debounce window (~5s), and a subsequent `vault_delete` removes it from the index.

~12 added lines in one file; no new dependencies.