### PR TITLE
Add edit tools and harden vault response serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Found a vulnerability? Please report it privately rather than opening a public i
 | `vault_read` | Read a file, returning content, metadata, and parsed YAML frontmatter |
 | `vault_batch_read` | Read multiple files in one call; handles missing files gracefully |
 | `vault_write` | Write a file with optional frontmatter merging; creates parent dirs |
+| `vault_edit` | Patch a file with ordered exact text replacements (token-efficient partial edits); supports dry-run diff previews |
+| `vault_append` | Append content to the end of a file without resending the existing body; creates the file when missing |
 | `vault_batch_frontmatter_update` | Update YAML frontmatter fields on multiple files without touching body content |
 | `vault_search` | Full-text search across vault files (uses ripgrep if available, falls back to Python) |
 | `vault_search_frontmatter` | Query the in-memory frontmatter index by field value, substring, or field existence |

--- a/src/obsidian_vault_mcp/models.py
+++ b/src/obsidian_vault_mcp/models.py
@@ -2,7 +2,7 @@
 
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from .config import (
     CONTEXT_LINES,
@@ -50,6 +50,89 @@ class VaultWriteInput(BaseModel):
     merge_frontmatter: bool = Field(
         default=False,
         description="If true, merge YAML frontmatter with existing file's frontmatter instead of replacing",
+    )
+
+
+class VaultEditOperationInput(BaseModel):
+    """Replace one exact text fragment inside a vault file."""
+
+    model_config = ConfigDict(str_strip_whitespace=False, extra="forbid")
+
+    @model_validator(mode="before")
+    @classmethod
+    def normalize_str_replace_aliases(cls, data):
+        if not isinstance(data, dict):
+            return data
+
+        normalized = dict(data)
+        for canonical, alias in (("old_text", "old_str"), ("new_text", "new_str")):
+            if canonical in normalized and alias in normalized:
+                raise ValueError(f"Use either '{canonical}' or '{alias}', not both")
+            if alias in normalized:
+                normalized[canonical] = normalized.pop(alias)
+
+        return normalized
+
+    old_text: str = Field(
+        ...,
+        description="Exact existing text fragment to replace; must appear exactly once",
+        min_length=1,
+        max_length=MAX_CONTENT_SIZE,
+    )
+    new_text: str = Field(
+        ...,
+        description="Replacement text for old_text",
+        max_length=MAX_CONTENT_SIZE,
+    )
+
+
+class VaultEditInput(BaseModel):
+    """Patch an existing file with exact text replacements."""
+
+    model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
+
+    path: str = Field(
+        ...,
+        description="Relative path from vault root",
+        min_length=1,
+        max_length=500,
+    )
+    edits: list[VaultEditOperationInput] = Field(
+        ...,
+        description="Ordered exact text replacements to apply without resending the full file",
+        min_length=1,
+        max_length=MAX_BATCH_SIZE,
+    )
+    dry_run: bool = Field(
+        default=False,
+        description="Preview the patch and diff without writing the file",
+    )
+
+
+class VaultAppendInput(BaseModel):
+    """Append content to a file without resending the existing body."""
+
+    model_config = ConfigDict(str_strip_whitespace=False, extra="forbid")
+
+    path: str = Field(
+        ...,
+        description="Relative path from vault root",
+        min_length=1,
+        max_length=500,
+    )
+    content: str = Field(
+        ...,
+        description="Content to append or write if the file does not exist",
+        max_length=MAX_CONTENT_SIZE,
+    )
+    separator: str = Field(
+        default="\n\n",
+        description="Text inserted between existing content and appended content",
+        max_length=100,
+    )
+    create_dirs: bool = Field(
+        default=True,
+        description="Create parent directories if they don't exist",
     )
 
 

--- a/src/obsidian_vault_mcp/server.py
+++ b/src/obsidian_vault_mcp/server.py
@@ -67,12 +67,19 @@ mcp = FastMCP(
 # --- Register all tools ---
 
 from .tools.read import vault_read as _vault_read, vault_batch_read as _vault_batch_read
-from .tools.write import vault_write as _vault_write, vault_batch_frontmatter_update as _vault_batch_frontmatter_update
+from .tools.write import (
+    vault_append as _vault_append,
+    vault_batch_frontmatter_update as _vault_batch_frontmatter_update,
+    vault_edit as _vault_edit,
+    vault_write as _vault_write,
+)
 from .tools.search import vault_search as _vault_search, vault_search_frontmatter as _vault_search_frontmatter
 from .tools.manage import vault_list as _vault_list, vault_move as _vault_move, vault_delete as _vault_delete
 from .models import (
     VaultReadInput,
     VaultWriteInput,
+    VaultEditInput,
+    VaultAppendInput,
     VaultBatchReadInput,
     VaultBatchFrontmatterUpdateInput,
     VaultSearchInput,
@@ -114,6 +121,38 @@ def vault_write(path: str, content: str, create_dirs: bool = True, merge_frontma
     """Write a file to the vault."""
     inp = VaultWriteInput(path=path, content=content, create_dirs=create_dirs, merge_frontmatter=merge_frontmatter)
     return _vault_write(inp.path, inp.content, inp.create_dirs, inp.merge_frontmatter)
+
+
+@mcp.tool(
+    name="vault_edit",
+    description=(
+        "Patch an existing vault file with exact text replacements. Use this for token-efficient partial edits "
+        "when only small fragments change; supports dry-run diff previews and avoids resending the full file."
+    ),
+    annotations={"readOnlyHint": False, "destructiveHint": True, "idempotentHint": False, "openWorldHint": False},
+)
+def vault_edit(path: str, edits: list[dict], dry_run: bool = False) -> str:
+    """Patch a file with exact text replacements."""
+    inp = VaultEditInput(path=path, edits=edits, dry_run=dry_run)
+    return _vault_edit(
+        inp.path,
+        [edit.model_dump() for edit in inp.edits],
+        inp.dry_run,
+    )
+
+
+@mcp.tool(
+    name="vault_append",
+    description=(
+        "Append content to a vault file without sending the existing file body. Use this for token-efficient "
+        "additions; creates the file when it does not exist."
+    ),
+    annotations={"readOnlyHint": False, "destructiveHint": True, "idempotentHint": False, "openWorldHint": False},
+)
+def vault_append(path: str, content: str, separator: str = "\n\n", create_dirs: bool = True) -> str:
+    """Append content to a file."""
+    inp = VaultAppendInput(path=path, content=content, separator=separator, create_dirs=create_dirs)
+    return _vault_append(inp.path, inp.content, inp.separator, inp.create_dirs)
 
 
 @mcp.tool(

--- a/src/obsidian_vault_mcp/tools/write.py
+++ b/src/obsidian_vault_mcp/tools/write.py
@@ -1,5 +1,6 @@
 """Write tools for the Obsidian vault MCP server."""
 
+import difflib
 import json
 import logging
 
@@ -39,6 +40,183 @@ def vault_write(path: str, content: str, create_dirs: bool = True, merge_frontma
     except Exception as e:
         logger.error(f"vault_write error for {path}: {e}")
         return json.dumps({"error": str(e), "path": path})
+
+
+def _unified_diff(path: str, before: str, after: str) -> str:
+    """Return a compact unified diff for an edit preview or result."""
+    return "".join(difflib.unified_diff(
+        before.splitlines(keepends=True),
+        after.splitlines(keepends=True),
+        fromfile=f"{path} before",
+        tofile=f"{path} after",
+        lineterm="",
+    ))
+
+
+def _normalize_edit_aliases(edit: dict) -> tuple[dict | None, str | None]:
+    normalized = dict(edit)
+    for canonical, alias in (("old_text", "old_str"), ("new_text", "new_str")):
+        if canonical in normalized and alias in normalized:
+            return None, f"Use either '{canonical}' or '{alias}', not both"
+        if alias in normalized:
+            normalized[canonical] = normalized.pop(alias)
+
+    return normalized, None
+
+
+def vault_edit(path: str, edits: list[dict], dry_run: bool = False) -> str:
+    """Apply exact text replacements to an existing file without resending the full body."""
+    try:
+        content, _ = read_file(path)
+        original_content = content
+
+        for index, edit in enumerate(edits):
+            normalized_edit, alias_error = _normalize_edit_aliases(edit)
+            if alias_error:
+                return json.dumps({
+                    "error": f"Edit {index}: {alias_error}",
+                    "path": path,
+                    "changed": False,
+                    "dry_run": dry_run,
+                    "diff": "",
+                    "edits_applied": 0,
+                    "size": len(original_content.encode("utf-8")),
+                })
+
+            old_text = normalized_edit.get("old_text", "")
+            new_text = normalized_edit.get("new_text", "")
+            count = content.count(old_text)
+
+            if count != 1:
+                return json.dumps({
+                    "error": (
+                        f"Edit {index} old_text must match exactly once; "
+                        f"found {count} matches"
+                    ),
+                    "path": path,
+                    "changed": False,
+                    "dry_run": dry_run,
+                    "diff": "",
+                    "edits_applied": 0,
+                    "size": len(original_content.encode("utf-8")),
+                })
+
+            content = content.replace(old_text, new_text, 1)
+
+        diff = _unified_diff(path, original_content, content)
+        size = len(content.encode("utf-8"))
+
+        if dry_run:
+            return json.dumps({
+                "path": path,
+                "changed": False,
+                "dry_run": True,
+                "diff": diff,
+                "edits_applied": len(edits),
+                "size": size,
+            })
+
+        changed = content != original_content
+        if changed:
+            write_file_atomic(path, content, create_dirs=False)
+
+        return json.dumps({
+            "path": path,
+            "changed": changed,
+            "dry_run": False,
+            "diff": diff,
+            "edits_applied": len(edits),
+            "size": size,
+        })
+    except ValueError as e:
+        return json.dumps({
+            "error": str(e),
+            "path": path,
+            "changed": False,
+            "dry_run": dry_run,
+            "diff": "",
+            "edits_applied": 0,
+            "size": 0,
+        })
+    except FileNotFoundError:
+        return json.dumps({
+            "error": f"File not found: {path}",
+            "path": path,
+            "changed": False,
+            "dry_run": dry_run,
+            "diff": "",
+            "edits_applied": 0,
+            "size": 0,
+        })
+    except Exception as e:
+        logger.error(f"vault_edit error for {path}: {e}")
+        return json.dumps({
+            "error": str(e),
+            "path": path,
+            "changed": False,
+            "dry_run": dry_run,
+            "diff": "",
+            "edits_applied": 0,
+            "size": 0,
+        })
+
+
+def vault_append(
+    path: str,
+    content: str,
+    separator: str = "\n\n",
+    create_dirs: bool = True,
+) -> str:
+    """Append content to a file without requiring the caller to send the full body."""
+    try:
+        resolve_vault_path(path)
+
+        created = False
+        try:
+            existing_content, _ = read_file(path)
+        except FileNotFoundError:
+            existing_content = ""
+            created = True
+
+        if created or not existing_content:
+            new_content = content
+        elif content:
+            new_content = f"{existing_content}{separator}{content}"
+        else:
+            new_content = existing_content
+
+        changed = new_content != existing_content
+        if changed:
+            _, size = write_file_atomic(path, new_content, create_dirs=create_dirs)
+        else:
+            size = len(existing_content.encode("utf-8"))
+
+        return json.dumps({
+            "path": path,
+            "changed": changed,
+            "created": created,
+            "appended": not created and changed,
+            "size": size,
+        })
+    except ValueError as e:
+        return json.dumps({
+            "error": str(e),
+            "path": path,
+            "changed": False,
+            "created": False,
+            "appended": False,
+            "size": 0,
+        })
+    except Exception as e:
+        logger.error(f"vault_append error for {path}: {e}")
+        return json.dumps({
+            "error": str(e),
+            "path": path,
+            "changed": False,
+            "created": False,
+            "appended": False,
+            "size": 0,
+        })
 
 
 def vault_batch_frontmatter_update(updates: list[dict]) -> str:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -5,7 +5,13 @@ import json
 import pytest
 
 from obsidian_vault_mcp.tools.read import vault_read, vault_batch_read
-from obsidian_vault_mcp.tools.write import vault_write, vault_batch_frontmatter_update
+from obsidian_vault_mcp.tools.write import (
+    vault_append,
+    vault_batch_frontmatter_update,
+    vault_edit,
+    vault_write,
+)
+from obsidian_vault_mcp.models import VaultAppendInput, VaultEditInput
 from obsidian_vault_mcp.tools.search import vault_search
 from obsidian_vault_mcp.tools.manage import vault_list, vault_delete
 
@@ -39,6 +45,185 @@ def test_vault_write_merge_frontmatter(vault_dir):
     read_result = json.loads(vault_read("test-note.md"))
     assert read_result["frontmatter"]["status"] == "active"  # preserved
     assert read_result["frontmatter"]["priority"] == "high"  # new
+
+
+def test_vault_edit_dry_run_returns_diff_without_writing(vault_dir):
+    """vault_edit dry run previews a partial edit without rewriting the file."""
+    before = (vault_dir / "test-note.md").read_text()
+
+    result = json.loads(vault_edit(
+        "test-note.md",
+        [{"old_text": "some content", "new_text": "more focused content"}],
+        dry_run=True,
+    ))
+
+    assert result["changed"] is False
+    assert result["dry_run"] is True
+    assert result["edits_applied"] == 1
+    assert "-This is a test note with some content." in result["diff"]
+    assert "+This is a test note with more focused content." in result["diff"]
+    assert (vault_dir / "test-note.md").read_text() == before
+
+
+def test_vault_edit_replaces_single_matching_fragment(vault_dir):
+    """vault_edit changes only the requested fragment."""
+    result = json.loads(vault_edit(
+        "test-note.md",
+        [{"old_text": "some content", "new_text": "more focused content"}],
+    ))
+
+    assert result["changed"] is True
+    assert result["dry_run"] is False
+    assert result["edits_applied"] == 1
+    content = (vault_dir / "test-note.md").read_text()
+    assert "This is a test note with more focused content." in content
+    assert "some content" not in content
+
+
+def test_vault_edit_accepts_str_replace_aliases(vault_dir):
+    """vault_edit accepts old_str/new_str aliases for compatibility."""
+    result = json.loads(vault_edit(
+        "test-note.md",
+        [{"old_str": "some content", "new_str": "more focused content"}],
+    ))
+
+    assert "error" not in result
+    assert result["changed"] is True
+    assert result["edits_applied"] == 1
+    assert "more focused content" in (vault_dir / "test-note.md").read_text()
+
+
+def test_vault_edit_rejects_mixed_canonical_and_alias_keys(vault_dir):
+    """vault_edit rejects ambiguous edits that mix canonical keys and aliases."""
+    before = (vault_dir / "test-note.md").read_text()
+
+    result = json.loads(vault_edit(
+        "test-note.md",
+        [{
+            "old_text": "some content",
+            "old_str": "some content",
+            "new_text": "more focused content",
+        }],
+    ))
+
+    assert "error" in result
+    assert "old_text" in result["error"]
+    assert "old_str" in result["error"]
+    assert result["changed"] is False
+    assert (vault_dir / "test-note.md").read_text() == before
+
+
+def test_vault_edit_missing_fragment_leaves_file_unchanged(vault_dir):
+    """vault_edit does not write when old_text is missing."""
+    before = (vault_dir / "test-note.md").read_text()
+
+    result = json.loads(vault_edit(
+        "test-note.md",
+        [{"old_text": "not in this file", "new_text": "replacement"}],
+    ))
+
+    assert "error" in result
+    assert result["changed"] is False
+    assert result["edits_applied"] == 0
+    assert (vault_dir / "test-note.md").read_text() == before
+
+
+def test_vault_edit_repeated_fragment_leaves_file_unchanged(vault_dir):
+    """vault_edit requires each old_text to appear exactly once."""
+    (vault_dir / "repeat.md").write_text("repeat\nrepeat\n")
+
+    result = json.loads(vault_edit(
+        "repeat.md",
+        [{"old_text": "repeat", "new_text": "once"}],
+    ))
+
+    assert "error" in result
+    assert result["changed"] is False
+    assert result["edits_applied"] == 0
+    assert (vault_dir / "repeat.md").read_text() == "repeat\nrepeat\n"
+
+
+def test_vault_edit_rolls_back_when_later_edit_fails(vault_dir):
+    """vault_edit applies all edits only if every edit can be matched."""
+    before = (vault_dir / "test-note.md").read_text()
+
+    result = json.loads(vault_edit(
+        "test-note.md",
+        [
+            {"old_text": "some content", "new_text": "more focused content"},
+            {"old_text": "missing later edit", "new_text": "replacement"},
+        ],
+    ))
+
+    assert "error" in result
+    assert result["changed"] is False
+    assert result["edits_applied"] == 0
+    assert (vault_dir / "test-note.md").read_text() == before
+
+
+def test_vault_append_adds_content_to_existing_file(vault_dir):
+    """vault_append adds new content without requiring the full existing body."""
+    result = json.loads(vault_append("no-frontmatter.md", "Appended note."))
+
+    assert result["changed"] is True
+    assert result["created"] is False
+    assert result["appended"] is True
+    assert (vault_dir / "no-frontmatter.md").read_text() == (
+        "Just plain text, no frontmatter here.\n\n\nAppended note."
+    )
+
+
+def test_vault_append_creates_new_file(vault_dir):
+    """vault_append creates a file when no target exists."""
+    result = json.loads(vault_append("new/append.md", "Brand new note."))
+
+    assert result["changed"] is True
+    assert result["created"] is True
+    assert result["appended"] is False
+    assert (vault_dir / "new" / "append.md").read_text() == "Brand new note."
+
+
+def test_vault_append_preserves_code_fences(vault_dir):
+    """vault_append preserves fenced markdown exactly."""
+    result = json.loads(vault_append(
+        "no-frontmatter.md",
+        "```python\nprint('hello')\n```",
+    ))
+
+    assert "error" not in result
+    assert "```python\nprint('hello')\n```" in (vault_dir / "no-frontmatter.md").read_text()
+
+
+def test_patch_style_inputs_preserve_edit_and_append_whitespace():
+    """Patch-style models preserve markdown whitespace in small payloads."""
+    edit_input = VaultEditInput(
+        path="note.md",
+        edits=[{"old_text": "  keep me\n", "new_text": "\n  keep replacement  "}],
+    )
+    append_input = VaultAppendInput(
+        path="note.md",
+        content="\n  appended block  \n",
+        separator="\n---\n",
+    )
+
+    assert edit_input.edits[0].old_text == "  keep me\n"
+    assert edit_input.edits[0].new_text == "\n  keep replacement  "
+    assert append_input.content == "\n  appended block  \n"
+    assert append_input.separator == "\n---\n"
+
+
+def test_patch_style_inputs_normalize_str_replace_aliases():
+    """Patch-style models normalize old_str/new_str to old_text/new_text."""
+    edit_input = VaultEditInput(
+        path="note.md",
+        edits=[{"old_str": "  keep me\n", "new_str": "\n  keep replacement  "}],
+    )
+
+    dumped = edit_input.edits[0].model_dump()
+    assert dumped == {
+        "old_text": "  keep me\n",
+        "new_text": "\n  keep replacement  ",
+    }
 
 
 def test_vault_search_finds_text(vault_dir):


### PR DESCRIPTION
## Summary

Adds two token-efficient write-side tools, rebased onto current `main`:

- `vault_edit`: patch an existing file with ordered exact text replacements, with optional dry-run unified diff previews.
- `vault_append`: append content to the end of a file, or create the file when it does not exist, without resending the existing body.

Per review feedback, this revision is narrowed to just these two tools and their tests. The earlier serialization changes are dropped, since v0.2.0 already routes responses through the shared `serialization.py` helper. The README auth section is left untouched; only the `## Tools` table gains the two new rows.

## Motivation

This targets the documented remote connector shape: the MCP server runs locally, a Cloudflare Tunnel forwards the HTTPS endpoint, and Claude.ai connects as a remote MCP connector. In that workflow, small note changes currently require sending the full Markdown file through `vault_write`, which spends far more context and tokens than the actual edit needs, especially for daily notes, instructions, and logs.

## Behavior

`vault_edit`:

- Requires every `old_text` fragment to appear exactly once in the current file content.
- Returns an error without writing when a fragment is missing or appears more than once.
- Applies multiple edits sequentially in memory, then writes once only if every edit matches (a later failing edit leaves the file untouched).
- Supports `dry_run=true`, returning a unified diff preview without changing the file.
- Accepts `old_text`/`new_text`, plus compatible `old_str`/`new_str` aliases for str_replace-style clients, and rejects mixing a canonical key with its alias in the same edit.

`vault_append`:

- Appends content to an existing file using a configurable separator.
- Creates a missing file when `create_dirs=true`, matching the default write behavior.
- Is intentionally simple and append-only; precise section insertion should use `vault_edit`.

Both tools register with write-side MCP annotations: `readOnlyHint=false`, `destructiveHint=true`, `idempotentHint=false`, `openWorldHint=false`.

## Tests

Adds regression tests for `vault_edit` (single match, dry-run diff, str_replace aliases, mixed-key rejection, missing/repeated fragment, atomic rollback) and `vault_append` (append, create, code-fence preservation), plus patch-style input model tests. Full suite green (69 passed).

## Safety and Compatibility

Existing `vault_write`, move, delete, search, and frontmatter update semantics are preserved.