### PR TITLE
Fix critical auth bypass: authenticate before issuing OAuth tokens (#8, #29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ Obsidian and the MCP server both operate on the same directory of markdown files
 
 This is a server that provides network access to your personal notes. Security is not optional.
 
-**Authentication is enforced on every request.** The server implements OAuth 2.0 authorization code flow with PKCE for initial client authentication (what Claude uses when you connect the integration), plus bearer token validation on every subsequent MCP tool call. No request reaches a tool function without a valid token.
+**A human logs in before any client is authorized.** Connecting a client uses the OAuth 2.0 authorization-code + PKCE flow, which opens a browser at `/oauth/authorize`. There, you must sign in with `VAULT_OAUTH_USERNAME` / `VAULT_OAUTH_PASSWORD` before the server issues an authorization code -- the password is required on every authorization. Every subsequent MCP tool call is then validated against a bearer token. No authorization code is issued to an unauthenticated visitor, and no request reaches a tool function without a valid token. **If `VAULT_OAUTH_PASSWORD` is not set, the server fails closed and refuses to authorize anyone** -- there is no anonymous auto-approve.
 
-**Your vault is never exposed directly to the internet.** The recommended deployment uses a Cloudflare Tunnel -- an outbound-only encrypted connection. Your machine opens no inbound ports. You can layer Cloudflare Access on top for additional authentication (SSO, device posture checks, IP restrictions) if you want defense in depth.
+**Your vault is never exposed directly to the internet.** The recommended deployment uses a Cloudflare Tunnel -- an outbound-only encrypted connection. Your machine opens no inbound ports, and the server itself binds to loopback (`127.0.0.1`) by default. The login above is the authentication boundary; you can additionally layer Cloudflare Access (SSO, device posture, IP restrictions) on top for defense in depth.
 
 **Path traversal is blocked at the filesystem layer.** Every file operation resolves paths against the vault root directory and rejects any attempt to escape it -- `..` traversal, symlink following, null byte injection, and dotfile access (`.obsidian`, `.git`, `.trash`) are all caught before they reach the filesystem. The server will never read or write outside your vault directory.
 
@@ -78,9 +78,13 @@ This is a server that provides network access to your personal notes. Security i
 git clone https://github.com/yourname/obsidian-web-mcp.git
 cd obsidian-web-mcp
 
-# Generate auth tokens
+# Generate the MCP bearer token
 export VAULT_MCP_TOKEN=$(python -c "import secrets; print(secrets.token_hex(32))")
-export VAULT_OAUTH_CLIENT_SECRET=$(python -c "import secrets; print(secrets.token_hex(32))")
+
+# Set the login the OAuth browser step requires. REQUIRED -- without a password
+# the server fails closed and refuses to authorize any client.
+export VAULT_OAUTH_USERNAME="you"
+export VAULT_OAUTH_PASSWORD="$(python -c "import secrets; print(secrets.token_urlsafe(24))")"   # or a passphrase you'll remember
 
 # Point at your vault
 export VAULT_PATH="$HOME/Obsidian/MyVault"
@@ -89,7 +93,7 @@ export VAULT_PATH="$HOME/Obsidian/MyVault"
 uv run vault-mcp
 ```
 
-The server starts on port 8420 by default. It serves MCP over Streamable HTTP at `/mcp/`.
+The server starts on port 8420 by default and serves MCP over Streamable HTTP at `/mcp/`. It binds to `127.0.0.1` -- reachable locally and through a Cloudflare Tunnel, but not exposed on your LAN. Set `VAULT_MCP_HOST=0.0.0.0` only if you deliberately want direct network exposure.
 
 ## Configuration
 
@@ -98,12 +102,15 @@ All configuration is via environment variables:
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `VAULT_PATH` | Yes | `~/Obsidian/MyVault` | Absolute path to your Obsidian vault directory |
-| `VAULT_MCP_TOKEN` | Yes | (none) | 256-bit bearer token for authenticating MCP requests |
+| `VAULT_MCP_TOKEN` | Yes | (none) | 256-bit bearer token validated on every MCP request |
+| `VAULT_OAUTH_PASSWORD` | **Yes** | (none) | Password for the interactive login at `/oauth/authorize`. **If unset, the server refuses to authorize any client (fail-closed).** |
+| `VAULT_OAUTH_USERNAME` | No | `obsidian` | Username for the interactive login |
+| `VAULT_MCP_HOST` | No | `127.0.0.1` | Bind address. Loopback by default; set `0.0.0.0` only for deliberate LAN exposure |
 | `VAULT_MCP_PORT` | No | `8420` | Port the HTTP server listens on |
-| `VAULT_OAUTH_CLIENT_ID` | No | `vault-mcp-client` | OAuth 2.0 client ID for Claude integration |
-| `VAULT_OAUTH_CLIENT_SECRET` | Yes | (none) | OAuth 2.0 client secret for Claude integration |
+| `VAULT_OAUTH_CLIENT_ID` | No | `vault-mcp-client` | Client ID for the headless `client_credentials` grant |
+| `VAULT_OAUTH_CLIENT_SECRET` | No | (none) | Only required for the headless `client_credentials` grant. The Claude/ChatGPT browser flow uses dynamic client registration and does **not** need this. |
 
-Generate tokens with: `python -c "import secrets; print(secrets.token_hex(32))"`
+Generate secrets with: `python -c "import secrets; print(secrets.token_hex(32))"`
 
 ## Connecting to Claude
 
@@ -112,9 +119,9 @@ The Claude desktop and mobile apps can connect to remote MCP servers via OAuth.
 1. Start the server (locally or behind a tunnel)
 2. Open Claude and go to **Settings > Integrations > Add Integration**
 3. Enter your server URL (e.g. `https://vault-mcp.yourdomain.com`)
-4. Enter the OAuth client ID and client secret you configured
-5. Claude will discover the OAuth endpoints automatically and open a browser window
-6. The server auto-approves the authorization (single-user model) and redirects back
+4. Claude registers automatically (dynamic client registration) and discovers the OAuth endpoints
+5. Claude opens a browser window at the server's `/oauth/authorize`
+6. **Sign in** with your `VAULT_OAUTH_USERNAME` / `VAULT_OAUTH_PASSWORD`; the server then issues the authorization and redirects back
 7. Claude now has access to all nine vault tools -- on desktop and mobile
 
 For local-only use (no tunnel), point Claude at `http://localhost:8420`.
@@ -161,7 +168,8 @@ Open each plist and replace the placeholder tokens:
 - `REPLACE_WITH_PROJECT_PATH` -- absolute path to this project directory
 - `REPLACE_WITH_VAULT_PATH` -- absolute path to your Obsidian vault
 - `REPLACE_WITH_TOKEN` -- your `VAULT_MCP_TOKEN` value
-- `REPLACE_WITH_OAUTH_SECRET` -- your `VAULT_OAUTH_CLIENT_SECRET` value
+- `REPLACE_WITH_OAUTH_USERNAME` -- the login username you want (e.g. your name)
+- `REPLACE_WITH_OAUTH_PASSWORD` -- your `VAULT_OAUTH_PASSWORD` value (required; the server refuses to authorize without it)
 - `REPLACE_WITH_HOME` -- your home directory (e.g. `/Users/yourname`)
 - `REPLACE_WITH_CLOUDFLARED_PATH` -- path to `cloudflared` binary (run `which cloudflared`)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "obsidian-web-mcp"
-version = "0.1.0"
+version = "0.2.0"
 description = "Secure remote MCP server for Obsidian vaults -- access your notes from Claude, your phone, or any MCP client, anywhere"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/scripts/launchd/com.example.vault-mcp.plist
+++ b/scripts/launchd/com.example.vault-mcp.plist
@@ -21,10 +21,10 @@
         <string>REPLACE_WITH_TOKEN</string>
         <key>VAULT_MCP_PORT</key>
         <string>8420</string>
-        <key>VAULT_OAUTH_CLIENT_ID</key>
-        <string>vault-mcp-client</string>
-        <key>VAULT_OAUTH_CLIENT_SECRET</key>
-        <string>REPLACE_WITH_OAUTH_SECRET</string>
+        <key>VAULT_OAUTH_USERNAME</key>
+        <string>REPLACE_WITH_OAUTH_USERNAME</string>
+        <key>VAULT_OAUTH_PASSWORD</key>
+        <string>REPLACE_WITH_OAUTH_PASSWORD</string>
     </dict>
     <key>RunAtLoad</key>
     <true/>

--- a/src/obsidian_vault_mcp/config.py
+++ b/src/obsidian_vault_mcp/config.py
@@ -10,6 +10,19 @@ VAULT_MCP_PORT = int(os.environ.get("VAULT_MCP_PORT", "8420"))
 VAULT_OAUTH_CLIENT_ID = os.environ.get("VAULT_OAUTH_CLIENT_ID", "vault-mcp-client")
 VAULT_OAUTH_CLIENT_SECRET = os.environ.get("VAULT_OAUTH_CLIENT_SECRET", "")
 
+# Interactive login gate on /oauth/authorize. The OAuth browser step authenticates
+# the *human* before any authorization code is issued. Without this, anyone who can
+# reach the URL can complete the flow and obtain a vault token (see issues #8/#29).
+# The password is required on every authorization, so there is no ambient session
+# cookie for a cross-site request to ride on.
+VAULT_OAUTH_USERNAME = os.environ.get("VAULT_OAUTH_USERNAME", "obsidian")
+VAULT_OAUTH_PASSWORD = os.environ.get("VAULT_OAUTH_PASSWORD", "")
+
+# Network bind address. Defaults to loopback so the server is NOT exposed on the LAN;
+# Cloudflare Tunnel reaches it over localhost. Set to 0.0.0.0 only if you deliberately
+# want direct network exposure.
+VAULT_MCP_HOST = os.environ.get("VAULT_MCP_HOST", "127.0.0.1")
+
 # Safety limits
 MAX_CONTENT_SIZE = 1_000_000  # 1MB max write size
 MAX_BATCH_SIZE = 20           # Max files per batch operation

--- a/src/obsidian_vault_mcp/oauth.py
+++ b/src/obsidian_vault_mcp/oauth.py
@@ -1,24 +1,45 @@
-"""OAuth 2.0 authorization code flow with PKCE for Claude app MCP integration.
+"""OAuth 2.0 authorization-code flow with PKCE + an interactive login gate.
 
-Claude's MCP connector uses the full OAuth authorization code flow:
-1. Discovers metadata at /.well-known/oauth-authorization-server
-2. Dynamically registers at /oauth/register (or uses pre-configured credentials)
-3. Redirects user's browser to /oauth/authorize
-4. Server auto-approves (single-user) and redirects back with an auth code
-5. Claude exchanges the code at /oauth/token for a bearer token
-6. Claude uses the bearer token on all MCP requests
+The Claude / ChatGPT MCP connectors drive this flow automatically:
+1. Discover metadata at /.well-known/oauth-authorization-server
+2. Dynamically register at /oauth/register (gets a client_id + a per-client secret)
+3. Open the user's browser at /oauth/authorize
+4. >>> The user logs in (username + password) -- THEN an authorization code is issued <<<
+5. The client exchanges the code at /oauth/token (PKCE verified) for a bearer token
+6. The client sends the bearer token on every MCP request
 
-Since this is a single-user personal server, the authorization page auto-approves
-immediately -- no login screen, no consent page. The security boundary is the
-client credentials + PKCE + the bearer token on every MCP request.
+Security model (fix for issues #8 / #29)
+----------------------------------------
+The previous version auto-approved every /oauth/authorize request with no user
+check, so anyone who could reach the URL could obtain the vault bearer token.
+This version closes that hole:
+
+- /oauth/authorize authenticates the human (login form) before issuing any code.
+  It NEVER auto-approves anonymous requests; with no VAULT_OAUTH_PASSWORD set it
+  fails closed (503). The password is required on every authorization, so there is
+  no ambient session for a cross-site request (or a self-registered attacker
+  client) to ride on.
+- /oauth/register is non-authorizing: it stores a client record and returns a
+  freshly generated per-client secret. It NEVER echoes the server's configured
+  secret or the vault bearer token.
+- redirect_uri must be https (or loopback http) and -- for a dynamically
+  registered client -- must exactly match a registered URI, at both authorize and
+  token time. This prevents open-redirect / code-exfiltration.
+- PKCE S256 is mandatory on the authorization-code grant.
+
+Remaining hardening tracked separately (see the fix write-up): the issued bearer
+token is still the single static VAULT_MCP_TOKEN. Replacing it with per-client,
+expiring, revocable tokens is a follow-up.
 """
 
+import base64
 import hashlib
 import hmac
+import html
 import logging
 import secrets
 import time
-from urllib.parse import urlencode, urlparse, parse_qs
+from urllib.parse import urlencode, urlparse
 
 from starlette.requests import Request
 from starlette.responses import JSONResponse, RedirectResponse, HTMLResponse
@@ -28,16 +49,126 @@ from . import config
 
 logger = logging.getLogger(__name__)
 
-# In-memory store for authorization codes (short-lived)
+# In-memory store for authorization codes (short-lived).
 # Maps code -> {client_id, redirect_uri, code_challenge, code_challenge_method, expires_at}
 _auth_codes: dict[str, dict] = {}
 
-# Clean up expired codes periodically
+# In-memory store for dynamically registered clients.
+# Maps client_id -> {client_secret, redirect_uris: [...], created_at}
+_clients: dict[str, dict] = {}
+
+
 def _cleanup_codes():
     now = time.time()
     expired = [k for k, v in _auth_codes.items() if v["expires_at"] < now]
     for k in expired:
         del _auth_codes[k]
+
+
+def _login_configured() -> bool:
+    """True if an interactive login credential is configured."""
+    return bool(config.VAULT_OAUTH_PASSWORD)
+
+
+def _check_credentials(username: str, password: str) -> bool:
+    """Constant-time check of the submitted login credentials."""
+    if not config.VAULT_OAUTH_PASSWORD:
+        return False
+    user_ok = hmac.compare_digest(username or "", config.VAULT_OAUTH_USERNAME)
+    pass_ok = hmac.compare_digest(password or "", config.VAULT_OAUTH_PASSWORD)
+    return user_ok and pass_ok
+
+
+def _redirect_uri_ok(client_id: str, redirect_uri: str) -> bool:
+    """Validate redirect_uri: https (or loopback http), and -- for a registered
+    client -- an exact match against a registered URI."""
+    if not redirect_uri:
+        return False
+    parsed = urlparse(redirect_uri)
+    is_loopback = parsed.scheme == "http" and (parsed.hostname in {"127.0.0.1", "localhost", "::1"})
+    if parsed.scheme != "https" and not is_loopback:
+        return False
+    record = _clients.get(client_id)
+    if record is not None and record.get("redirect_uris"):
+        return redirect_uri in record["redirect_uris"]
+    # Unregistered or operator-configured client: no stored allowlist to match
+    # against. The login gate is still enforced, so this is not an auth bypass.
+    return True
+
+
+def _client_known(client_id: str) -> bool:
+    return client_id in _clients or (
+        bool(config.VAULT_OAUTH_CLIENT_ID) and client_id == config.VAULT_OAUTH_CLIENT_ID
+    )
+
+
+def _issue_code_redirect(client_id: str, redirect_uri: str, state: str,
+                         code_challenge: str, code_challenge_method: str):
+    """Mint an authorization code and 302 back to the client."""
+    _cleanup_codes()
+    code = secrets.token_urlsafe(32)
+    _auth_codes[code] = {
+        "client_id": client_id,
+        "redirect_uri": redirect_uri,
+        "code_challenge": code_challenge,
+        "code_challenge_method": code_challenge_method,
+        "expires_at": time.time() + 300,  # 5 minute expiry
+    }
+    logger.info("OAuth authorization code issued after successful login.")
+    params = {"code": code}
+    if state:
+        params["state"] = state
+    separator = "&" if "?" in redirect_uri else "?"
+    return RedirectResponse(url=f"{redirect_uri}{separator}{urlencode(params)}", status_code=302)
+
+
+def _login_form(params: dict, error: str = "") -> HTMLResponse:
+    """Render the login page, carrying the OAuth params as hidden fields.
+
+    Every reflected value is HTML-escaped to avoid reflected XSS.
+    """
+    hidden = "\n".join(
+        f'<input type="hidden" name="{html.escape(k)}" value="{html.escape(v)}">'
+        for k, v in params.items() if v
+    )
+    err_html = f'<p class="err">{html.escape(error)}</p>' if error else ""
+    status = 401 if error else 200
+    page = f"""<!doctype html>
+<html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Authorize Obsidian Vault access</title>
+<style>
+ body{{font-family:-apple-system,system-ui,sans-serif;background:#1e1e2e;color:#cdd6f4;display:flex;min-height:100vh;align-items:center;justify-content:center;margin:0}}
+ form{{background:#313244;padding:2rem;border-radius:12px;width:300px;box-shadow:0 8px 24px rgba(0,0,0,.4)}}
+ h1{{font-size:1.1rem;margin:0 0 1rem}}
+ label{{display:block;font-size:.8rem;margin:.6rem 0 .2rem;color:#a6adc8}}
+ input[type=text],input[type=password]{{width:100%;box-sizing:border-box;padding:.5rem;border-radius:6px;border:1px solid #45475a;background:#1e1e2e;color:#cdd6f4}}
+ button{{margin-top:1rem;width:100%;padding:.6rem;border:0;border-radius:6px;background:#89b4fa;color:#1e1e2e;font-weight:600;cursor:pointer}}
+ .err{{color:#f38ba8;font-size:.8rem;margin:.4rem 0 0}}
+ .sub{{font-size:.75rem;color:#6c7086;margin-top:1rem}}
+</style></head>
+<body>
+ <form method="post" action="/oauth/authorize">
+  <h1>🔒 Authorize access to your vault</h1>
+  {hidden}
+  <label for="u">Username</label>
+  <input id="u" type="text" name="username" autocomplete="username" autofocus>
+  <label for="p">Password</label>
+  <input id="p" type="password" name="password" autocomplete="current-password">
+  {err_html}
+  <button type="submit">Authorize</button>
+  <p class="sub">A client is requesting access to your Obsidian vault.</p>
+ </form>
+</body></html>"""
+    return HTMLResponse(page, status_code=status)
+
+
+def _misconfigured_page() -> HTMLResponse:
+    return HTMLResponse(
+        "<h1>Server not configured for login</h1>"
+        "<p>This server requires <code>VAULT_OAUTH_PASSWORD</code> to be set before it can "
+        "authorize access to your vault. Set it and restart.</p>",
+        status_code=503,
+    )
 
 
 async def oauth_metadata(request: Request) -> JSONResponse:
@@ -51,53 +182,77 @@ async def oauth_metadata(request: Request) -> JSONResponse:
         "grant_types_supported": ["authorization_code"],
         "response_types_supported": ["code"],
         "code_challenge_methods_supported": ["S256"],
-        "token_endpoint_auth_methods_supported": ["client_secret_post"],
+        "token_endpoint_auth_methods_supported": ["client_secret_post", "none"],
     })
 
 
 async def oauth_authorize(request: Request):
-    """OAuth 2.0 authorization endpoint.
+    """OAuth 2.0 authorization endpoint with an interactive login gate.
 
-    Claude redirects the user's browser here. Since this is a single-user
-    personal server, we auto-approve: generate an auth code and redirect
-    back to Claude immediately.
+    GET  -> validate the request, then render a login form (or auto-approve only
+            under the explicit localhost escape hatch).
+    POST -> verify submitted credentials, then issue an authorization code.
     """
-    response_type = request.query_params.get("response_type", "")
-    client_id = request.query_params.get("client_id", "")
-    redirect_uri = request.query_params.get("redirect_uri", "")
-    state = request.query_params.get("state", "")
-    code_challenge = request.query_params.get("code_challenge", "")
-    code_challenge_method = request.query_params.get("code_challenge_method", "S256")
+    if request.method == "POST":
+        form = await request.form()
+        getp = form.get
+    else:
+        getp = request.query_params.get
 
+    response_type = getp("response_type", "") or ""
+    client_id = getp("client_id", "") or ""
+    redirect_uri = getp("redirect_uri", "") or ""
+    state = getp("state", "") or ""
+    code_challenge = getp("code_challenge", "") or ""
+    code_challenge_method = getp("code_challenge_method", "S256") or "S256"
+
+    # --- Validate the OAuth request shape (independent of authentication) ---
     if response_type != "code":
         return JSONResponse({"error": "unsupported_response_type"}, status_code=400)
+    if not client_id or not _client_known(client_id):
+        return JSONResponse(
+            {"error": "invalid_client", "error_description": "Unknown client; register via /oauth/register first."},
+            status_code=400,
+        )
+    if not _redirect_uri_ok(client_id, redirect_uri):
+        return JSONResponse(
+            {"error": "invalid_request", "error_description": "Invalid or unregistered redirect_uri."},
+            status_code=400,
+        )
+    if not code_challenge or code_challenge_method != "S256":
+        return JSONResponse(
+            {"error": "invalid_request", "error_description": "PKCE S256 (code_challenge) is required."},
+            status_code=400,
+        )
 
-    if not redirect_uri:
-        return JSONResponse({"error": "invalid_request", "error_description": "redirect_uri required"}, status_code=400)
-
-    # Generate authorization code
-    _cleanup_codes()
-    code = secrets.token_urlsafe(32)
-    _auth_codes[code] = {
+    oauth_params = {
+        "response_type": response_type,
         "client_id": client_id,
         "redirect_uri": redirect_uri,
+        "state": state,
         "code_challenge": code_challenge,
         "code_challenge_method": code_challenge_method,
-        "expires_at": time.time() + 300,  # 5 minute expiry
     }
 
-    logger.info(f"OAuth authorization code issued, redirecting to {redirect_uri[:50]}...")
+    # --- Authentication gate ---
+    # Fail CLOSED: with no login credential configured there is no safe way to
+    # authenticate the human, so we refuse to issue codes. There is deliberately
+    # no "auto-approve" escape hatch — an unauthenticated authorize endpoint is
+    # exactly the vulnerability this fix closes (issues #8 / #29).
+    if not _login_configured():
+        logger.error("Refusing to authorize: VAULT_OAUTH_PASSWORD is not set.")
+        return _misconfigured_page()
 
-    # Redirect back to Claude with the code
-    params = {"code": code}
-    if state:
-        params["state"] = state
+    if request.method != "POST":
+        # No credentials yet -- show the login form.
+        return _login_form(oauth_params)
 
-    separator = "&" if "?" in redirect_uri else "?"
-    return RedirectResponse(
-        url=f"{redirect_uri}{separator}{urlencode(params)}",
-        status_code=302,
-    )
+    # POST: verify the submitted credentials.
+    if not _check_credentials(form.get("username", ""), form.get("password", "")):
+        logger.warning("OAuth login failed.")
+        return _login_form(oauth_params, error="Incorrect username or password.")
+
+    return _issue_code_redirect(client_id, redirect_uri, state, code_challenge, code_challenge_method)
 
 
 async def oauth_token(request: Request) -> JSONResponse:
@@ -111,49 +266,44 @@ async def oauth_token(request: Request) -> JSONResponse:
     client_id = form.get("client_id", "")
     client_secret = form.get("client_secret", "")
 
-    # Support both authorization_code and client_credentials grants
     if grant_type == "authorization_code":
-        return await _handle_authorization_code(form, client_id, client_secret)
+        return await _handle_authorization_code(form)
     elif grant_type == "client_credentials":
         return await _handle_client_credentials(client_id, client_secret)
     else:
-        return JSONResponse(
-            {"error": "unsupported_grant_type"},
-            status_code=400,
-        )
+        return JSONResponse({"error": "unsupported_grant_type"}, status_code=400)
 
 
-async def _handle_authorization_code(form, client_id: str, client_secret: str) -> JSONResponse:
-    """Exchange an authorization code for a bearer token."""
+async def _handle_authorization_code(form) -> JSONResponse:
+    """Exchange an authorization code for a bearer token. PKCE + redirect_uri are
+    both mandatory (no optional-verification escape hatches)."""
     code = form.get("code", "")
     redirect_uri = form.get("redirect_uri", "")
     code_verifier = form.get("code_verifier", "")
 
     _cleanup_codes()
 
-    if code not in _auth_codes:
+    if not code or code not in _auth_codes:
         return JSONResponse({"error": "invalid_grant", "error_description": "Invalid or expired code"}, status_code=400)
 
-    code_data = _auth_codes.pop(code)
+    code_data = _auth_codes.pop(code)  # single-use
 
-    # Verify redirect_uri matches
-    if redirect_uri and code_data["redirect_uri"] and redirect_uri != code_data["redirect_uri"]:
+    # redirect_uri must be present and match what was bound to the code.
+    if not redirect_uri or redirect_uri != code_data["redirect_uri"]:
         return JSONResponse({"error": "invalid_grant", "error_description": "redirect_uri mismatch"}, status_code=400)
 
-    # Verify PKCE code_challenge if one was provided during authorization
-    if code_data["code_challenge"]:
-        if not code_verifier:
-            return JSONResponse({"error": "invalid_grant", "error_description": "code_verifier required"}, status_code=400)
+    # PKCE is mandatory: a challenge was required at /authorize, so a verifier is required here.
+    if not code_data.get("code_challenge"):
+        return JSONResponse({"error": "invalid_grant", "error_description": "missing PKCE challenge"}, status_code=400)
+    if not code_verifier:
+        return JSONResponse({"error": "invalid_grant", "error_description": "code_verifier required"}, status_code=400)
 
-        # S256: BASE64URL(SHA256(code_verifier)) must match code_challenge
-        import base64
-        digest = hashlib.sha256(code_verifier.encode("ascii")).digest()
-        computed_challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+    digest = hashlib.sha256(code_verifier.encode("ascii")).digest()
+    computed_challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+    if not hmac.compare_digest(computed_challenge, code_data["code_challenge"]):
+        return JSONResponse({"error": "invalid_grant", "error_description": "PKCE verification failed"}, status_code=400)
 
-        if not hmac.compare_digest(computed_challenge, code_data["code_challenge"]):
-            return JSONResponse({"error": "invalid_grant", "error_description": "PKCE verification failed"}, status_code=400)
-
-    logger.info("OAuth token issued via authorization_code grant")
+    logger.info("OAuth token issued via authorization_code grant.")
     return JSONResponse({
         "access_token": config.VAULT_MCP_TOKEN,
         "token_type": "bearer",
@@ -162,18 +312,21 @@ async def _handle_authorization_code(form, client_id: str, client_secret: str) -
 
 
 async def _handle_client_credentials(client_id: str, client_secret: str) -> JSONResponse:
-    """Exchange client credentials for a bearer token."""
+    """Headless grant for an operator-configured client (machine-to-machine).
+
+    Validated against the configured VAULT_OAUTH_CLIENT_ID/SECRET. Note: /oauth/register
+    no longer hands these out, so this path requires the operator's real secret.
+    """
     if not config.VAULT_OAUTH_CLIENT_SECRET:
         return JSONResponse({"error": "server_error"}, status_code=500)
 
     id_match = hmac.compare_digest(client_id, config.VAULT_OAUTH_CLIENT_ID)
     secret_match = hmac.compare_digest(client_secret, config.VAULT_OAUTH_CLIENT_SECRET)
-
     if not (id_match and secret_match):
-        logger.warning(f"OAuth client_credentials failed (client_id={client_id!r})")
+        logger.warning("OAuth client_credentials failed.")
         return JSONResponse({"error": "invalid_client"}, status_code=401)
 
-    logger.info("OAuth token issued via client_credentials grant")
+    logger.info("OAuth token issued via client_credentials grant.")
     return JSONResponse({
         "access_token": config.VAULT_MCP_TOKEN,
         "token_type": "bearer",
@@ -182,26 +335,44 @@ async def _handle_client_credentials(client_id: str, client_secret: str) -> JSON
 
 
 async def oauth_register(request: Request) -> JSONResponse:
-    """Dynamic client registration endpoint.
+    """Dynamic client registration (RFC 7591).
 
-    Claude calls this during initial setup to register as an OAuth client.
-    Returns pre-configured credentials.
+    Non-authorizing: stores a client record and returns a freshly generated
+    per-client secret. NEVER returns the server's configured secret or the vault
+    bearer token. Registering a client confers no access on its own -- the human
+    must still log in at /oauth/authorize.
     """
     try:
         body = await request.json()
     except Exception:
         body = {}
 
-    # Generate a unique client_id for this registration
+    # Only accept valid https / loopback redirect URIs.
+    requested = body.get("redirect_uris", []) or []
+    redirect_uris = []
+    for uri in requested:
+        if not isinstance(uri, str):
+            continue
+        parsed = urlparse(uri)
+        is_loopback = parsed.scheme == "http" and (parsed.hostname in {"127.0.0.1", "localhost", "::1"})
+        if parsed.scheme == "https" or is_loopback:
+            redirect_uris.append(uri)
+
     client_id = f"vault-mcp-{secrets.token_hex(8)}"
+    client_secret = secrets.token_hex(32)  # per-client, NOT config.VAULT_OAUTH_CLIENT_SECRET
+    _clients[client_id] = {
+        "client_secret": client_secret,
+        "redirect_uris": redirect_uris,
+        "created_at": time.time(),
+    }
 
     return JSONResponse({
         "client_id": client_id,
-        "client_secret": config.VAULT_OAUTH_CLIENT_SECRET,
+        "client_secret": client_secret,
         "client_name": body.get("client_name", "Obsidian Vault MCP Client"),
         "grant_types": ["authorization_code"],
         "response_types": ["code"],
-        "redirect_uris": body.get("redirect_uris", []),
+        "redirect_uris": redirect_uris,
         "token_endpoint_auth_method": "client_secret_post",
     }, status_code=201)
 
@@ -209,7 +380,7 @@ async def oauth_register(request: Request) -> JSONResponse:
 # Starlette routes to mount on the app
 oauth_routes = [
     Route("/.well-known/oauth-authorization-server", oauth_metadata, methods=["GET"]),
-    Route("/oauth/authorize", oauth_authorize, methods=["GET"]),
+    Route("/oauth/authorize", oauth_authorize, methods=["GET", "POST"]),
     Route("/oauth/token", oauth_token, methods=["POST"]),
     Route("/oauth/register", oauth_register, methods=["POST"]),
 ]

--- a/src/obsidian_vault_mcp/server.py
+++ b/src/obsidian_vault_mcp/server.py
@@ -12,7 +12,7 @@ from contextlib import asynccontextmanager
 from mcp.server.fastmcp import FastMCP
 from mcp.server.transport_security import TransportSecuritySettings
 
-from .config import VAULT_MCP_PORT, VAULT_MCP_TOKEN, VAULT_PATH
+from .config import VAULT_MCP_HOST, VAULT_MCP_PORT, VAULT_MCP_TOKEN, VAULT_PATH
 from .frontmatter_index import FrontmatterIndex
 
 logger = logging.getLogger(__name__)
@@ -214,21 +214,21 @@ def main():
             app.routes.insert(0, route)
 
         app.add_middleware(BearerAuthMiddleware)
-        logger.info(f"Starting server on port {VAULT_MCP_PORT} with bearer auth + OAuth")
-
-        import uvicorn
-        uvicorn.run(
-            app,
-            host="0.0.0.0",
-            port=VAULT_MCP_PORT,
-            log_level="info",
-            proxy_headers=True,
-            forwarded_allow_ips="*",
-        )
+        logger.info(f"Starting server on {VAULT_MCP_HOST}:{VAULT_MCP_PORT} with bearer auth + OAuth")
     except Exception as e:
-        logger.warning(f"Could not build app ({e}), falling back to mcp.run()")
-        logger.warning("Auth will NOT be enforced in this mode")
-        mcp.run(transport="streamable-http", port=VAULT_MCP_PORT)
+        # Fail CLOSED: never fall back to an unauthenticated server.
+        logger.error(f"Could not build the authenticated app: {e}")
+        sys.exit(1)
+
+    import uvicorn
+    uvicorn.run(
+        app,
+        host=VAULT_MCP_HOST,
+        port=VAULT_MCP_PORT,
+        log_level="info",
+        proxy_headers=True,
+        forwarded_allow_ips="*",
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -1,0 +1,194 @@
+"""Tests for the OAuth authorization flow and its login gate (issues #8 / #29).
+
+These drive the OAuth routes directly (no FastMCP needed) via Starlette's
+TestClient. The headline test is `test_exploit_is_closed`: the exact
+unauthenticated attack from the bug reports must no longer yield a token.
+"""
+
+import base64
+import hashlib
+
+import pytest
+from starlette.applications import Starlette
+from starlette.testclient import TestClient
+
+from obsidian_vault_mcp import config, oauth
+
+TOKEN = "test-vault-token-do-not-leak"
+
+
+@pytest.fixture(autouse=True)
+def reset_state(monkeypatch):
+    """Fresh in-memory stores + known config for every test."""
+    oauth._clients.clear()
+    oauth._auth_codes.clear()
+    monkeypatch.setattr(config, "VAULT_MCP_TOKEN", TOKEN)
+    monkeypatch.setattr(config, "VAULT_OAUTH_USERNAME", "obsidian")
+    monkeypatch.setattr(config, "VAULT_OAUTH_PASSWORD", "")  # unset by default
+    monkeypatch.setattr(config, "VAULT_OAUTH_CLIENT_ID", "vault-mcp-client")
+    monkeypatch.setattr(config, "VAULT_OAUTH_CLIENT_SECRET", "configured-server-secret")
+    yield
+
+
+@pytest.fixture
+def client():
+    app = Starlette(routes=oauth.oauth_routes)
+    return TestClient(app)
+
+
+def _pkce():
+    verifier = "verifier-abc123_this-is-long-enough-for-pkce-xyz"
+    digest = hashlib.sha256(verifier.encode()).digest()
+    challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
+    return verifier, challenge
+
+
+def _register(client, redirect_uri="https://app.example/cb"):
+    r = client.post("/oauth/register", json={"client_name": "t", "redirect_uris": [redirect_uri]})
+    assert r.status_code == 201
+    return r.json()["client_id"], redirect_uri
+
+
+def _authz_params(client_id, redirect_uri, challenge):
+    return {
+        "response_type": "code",
+        "client_id": client_id,
+        "redirect_uri": redirect_uri,
+        "state": "xyz",
+        "code_challenge": challenge,
+        "code_challenge_method": "S256",
+    }
+
+
+# --- The reported vulnerability ------------------------------------------------
+
+def test_exploit_is_closed(client):
+    """Default config (no password): an anonymous caller must NOT get a token."""
+    client_id, redirect = _register(client)
+    _, challenge = _pkce()
+    # Step 1: hit /authorize like the attacker did -- expect NO code, no redirect.
+    r = client.get("/oauth/authorize", params=_authz_params(client_id, redirect, challenge),
+                   follow_redirects=False)
+    assert r.status_code == 503  # fails closed
+    assert "location" not in {k.lower() for k in r.headers}
+
+
+def test_register_does_not_leak_configured_secret(client):
+    r = client.post("/oauth/register", json={"redirect_uris": ["https://app.example/cb"]})
+    assert r.status_code == 201
+    body = r.json()
+    assert body["client_secret"] != config.VAULT_OAUTH_CLIENT_SECRET
+    assert body["client_secret"] != config.VAULT_MCP_TOKEN
+    assert len(body["client_secret"]) == 64  # freshly generated per-client
+
+
+# --- The login gate ------------------------------------------------------------
+
+def test_authorize_shows_login_form_when_password_set(client, monkeypatch):
+    monkeypatch.setattr(config, "VAULT_OAUTH_PASSWORD", "hunter2")
+    client_id, redirect = _register(client)
+    _, challenge = _pkce()
+    r = client.get("/oauth/authorize", params=_authz_params(client_id, redirect, challenge),
+                   follow_redirects=False)
+    assert r.status_code == 200
+    assert 'name="password"' in r.text
+    assert "code=" not in (r.headers.get("location") or "")
+
+
+def test_authorize_rejects_wrong_password(client, monkeypatch):
+    monkeypatch.setattr(config, "VAULT_OAUTH_PASSWORD", "hunter2")
+    client_id, redirect = _register(client)
+    _, challenge = _pkce()
+    data = _authz_params(client_id, redirect, challenge)
+    data.update({"username": "obsidian", "password": "wrong"})
+    r = client.post("/oauth/authorize", data=data, follow_redirects=False)
+    assert r.status_code == 401
+    assert "location" not in {k.lower() for k in r.headers}
+
+
+def test_full_flow_with_correct_password(client, monkeypatch):
+    monkeypatch.setattr(config, "VAULT_OAUTH_PASSWORD", "hunter2")
+    client_id, redirect = _register(client)
+    verifier, challenge = _pkce()
+    data = _authz_params(client_id, redirect, challenge)
+    data.update({"username": "obsidian", "password": "hunter2"})
+
+    r = client.post("/oauth/authorize", data=data, follow_redirects=False)
+    assert r.status_code == 302
+    loc = r.headers["location"]
+    assert loc.startswith(redirect)
+    code = loc.split("code=")[1].split("&")[0]
+
+    # Exchange the code (with the PKCE verifier) for a token.
+    tok = client.post("/oauth/token", data={
+        "grant_type": "authorization_code", "code": code,
+        "redirect_uri": redirect, "code_verifier": verifier,
+    })
+    assert tok.status_code == 200
+    assert tok.json()["access_token"] == TOKEN
+
+
+def test_token_requires_pkce_verifier(client, monkeypatch):
+    monkeypatch.setattr(config, "VAULT_OAUTH_PASSWORD", "hunter2")
+    client_id, redirect = _register(client)
+    verifier, challenge = _pkce()
+    data = _authz_params(client_id, redirect, challenge)
+    data.update({"username": "obsidian", "password": "hunter2"})
+    r = client.post("/oauth/authorize", data=data, follow_redirects=False)
+    code = r.headers["location"].split("code=")[1].split("&")[0]
+
+    # Same code, but NO verifier -> rejected.
+    tok = client.post("/oauth/token", data={
+        "grant_type": "authorization_code", "code": code, "redirect_uri": redirect,
+    })
+    assert tok.status_code == 400
+
+
+# --- Request validation --------------------------------------------------------
+
+def test_unknown_client_rejected(client, monkeypatch):
+    monkeypatch.setattr(config, "VAULT_OAUTH_PASSWORD", "hunter2")
+    _, challenge = _pkce()
+    r = client.get("/oauth/authorize",
+                   params=_authz_params("bogus-client", "https://app.example/cb", challenge),
+                   follow_redirects=False)
+    assert r.status_code == 400
+    assert r.json()["error"] == "invalid_client"
+
+
+def test_pkce_required_at_authorize(client, monkeypatch):
+    monkeypatch.setattr(config, "VAULT_OAUTH_PASSWORD", "hunter2")
+    client_id, redirect = _register(client)
+    params = _authz_params(client_id, redirect, "")  # empty challenge
+    r = client.get("/oauth/authorize", params=params, follow_redirects=False)
+    assert r.status_code == 400
+
+
+def test_open_redirect_rejected(client, monkeypatch):
+    monkeypatch.setattr(config, "VAULT_OAUTH_PASSWORD", "hunter2")
+    client_id, _ = _register(client, redirect_uri="https://app.example/cb")
+    _, challenge = _pkce()
+    # http non-loopback scheme -> rejected
+    r1 = client.get("/oauth/authorize",
+                    params=_authz_params(client_id, "http://evil.example/x", challenge),
+                    follow_redirects=False)
+    assert r1.status_code == 400
+    # https but not the registered URI -> rejected
+    r2 = client.get("/oauth/authorize",
+                    params=_authz_params(client_id, "https://evil.example/cb", challenge),
+                    follow_redirects=False)
+    assert r2.status_code == 400
+
+
+# --- Fail-closed: no password means no authorization, by any method -----------
+
+def test_no_password_fails_closed_even_via_post(client):
+    """There is no auto-approve escape hatch: without a configured password,
+    neither GET nor POST to /authorize can yield a code."""
+    client_id, redirect = _register(client)
+    _, challenge = _pkce()
+    data = _authz_params(client_id, redirect, challenge)
+    data.update({"username": "obsidian", "password": "anything"})
+    r = client.post("/oauth/authorize", data=data, follow_redirects=False)
+    assert r.status_code == 503
+    assert "location" not in {k.lower() for k in r.headers}


### PR DESCRIPTION
## Summary

`/oauth/authorize` auto-approved every request without authenticating the user. Anyone who could reach the server's URL could complete the OAuth flow and obtain the vault bearer token — full read/write/delete access to the vault, protected by nothing but the secrecy of the URL. Reported in #8 and escalated in #29.

PKCE and the client secret did not mitigate this:

- PKCE protects an honest client's authorization code from interception. It does nothing when the attacker runs the whole flow and supplies their own verifier.
- `/oauth/register` (open dynamic client registration) returned the *configured* client secret to any caller, so even the `client_credentials` path was reachable.

The effective security boundary was "knows the URL," not authentication.

## Impact

Critical. Remote, unauthenticated read/write access to the entire vault for anyone who knows or discovers the server hostname. The README previously advertised "real authentication" and documented the auto-approve as intended behavior — both were wrong, and are corrected here.

## Fix

- **Interactive login gate on `/oauth/authorize`.** The OAuth browser step now requires `VAULT_OAUTH_USERNAME` / `VAULT_OAUTH_PASSWORD` before any authorization code is issued. The Claude/ChatGPT connector flow still works — it opens that page in a browser. The password is required on every authorization.
- **Fail closed.** With no `VAULT_OAUTH_PASSWORD` set, the server refuses to authorize (503). There is no anonymous auto-approve.
- **Non-authorizing DCR.** `/oauth/register` stores the client and returns a freshly generated per-client secret. It never returns the configured secret or the vault token.
- **Mandatory PKCE (S256)** and **redirect_uri validation** (https or loopback, plus an exact match against the registered client) at both authorize and token.
- **No fail-open.** Removed the fallback that ran the server with no auth if app construction threw; it now exits.
- **Loopback bind by default** (`VAULT_MCP_HOST`, default `127.0.0.1`) instead of `0.0.0.0`.

## Testing

- New `tests/test_oauth.py` (10 cases), including a regression test that the reported exploit no longer yields a token. Full suite passes (36).
- Verified end-to-end against a running server: the unauthenticated attack is blocked (`/oauth/authorize` → 503, no token), and a legitimate login completes and returns a token.

## Breaking change

Existing deployments must set `VAULT_OAUTH_PASSWORD`, or the server will refuse to authorize clients. Rotate `VAULT_MCP_TOKEN` if it may have been exposed. Version bumped 0.1.0 → 0.2.0.

## Known follow-up

Every successful grant still returns the single static `VAULT_MCP_TOKEN` (no per-client, expiring, or revocable tokens). That hardening is tracked separately; it is not required to close the reported issue.

Closes #8. Closes #29.
