### PR TITLE
Harden OAuth: constant-time compare + client_id binding + redirect allowlist (#2, #4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ All configuration is via environment variables:
 | `VAULT_MCP_PORT` | No | `8420` | Port the HTTP server listens on |
 | `VAULT_OAUTH_CLIENT_ID` | No | `vault-mcp-client` | Client ID for the headless `client_credentials` grant |
 | `VAULT_OAUTH_CLIENT_SECRET` | No | (none) | Only required for the headless `client_credentials` grant. The Claude/ChatGPT browser flow uses dynamic client registration and does **not** need this. |
+| `VAULT_OAUTH_REDIRECT_URIS` | No | (none) | Comma-separated allowlist of redirect URIs for the static `VAULT_OAUTH_CLIENT_ID` when using the browser flow. Dynamically-registered clients (Claude/ChatGPT) carry their own; leave unset unless you connect a static client through `/oauth/authorize`. |
 
 Generate secrets with: `python -c "import secrets; print(secrets.token_hex(32))"`
 

--- a/src/obsidian_vault_mcp/auth.py
+++ b/src/obsidian_vault_mcp/auth.py
@@ -1,5 +1,7 @@
 """Bearer token authentication middleware for the vault MCP server."""
 
+import hmac
+
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import JSONResponse
@@ -37,7 +39,8 @@ class BearerAuthMiddleware(BaseHTTPMiddleware):
             )
 
         token = auth_header[7:]
-        if token != VAULT_MCP_TOKEN:
+        # Constant-time compare: avoid leaking the token via response timing (#2).
+        if not hmac.compare_digest(token, VAULT_MCP_TOKEN):
             return JSONResponse(
                 {"error": "Invalid token"},
                 status_code=401,

--- a/src/obsidian_vault_mcp/config.py
+++ b/src/obsidian_vault_mcp/config.py
@@ -18,6 +18,12 @@ VAULT_OAUTH_CLIENT_SECRET = os.environ.get("VAULT_OAUTH_CLIENT_SECRET", "")
 VAULT_OAUTH_USERNAME = os.environ.get("VAULT_OAUTH_USERNAME", "obsidian")
 VAULT_OAUTH_PASSWORD = os.environ.get("VAULT_OAUTH_PASSWORD", "")
 
+# Allowed redirect URIs for the operator-configured client (VAULT_OAUTH_CLIENT_ID),
+# comma-separated. Dynamically-registered clients carry their own redirect_uris; this
+# governs only the static operator client. If empty, the operator client cannot use the
+# browser authorization-code flow (it can still use the client_credentials grant).
+VAULT_OAUTH_REDIRECT_URIS = [u.strip() for u in os.environ.get("VAULT_OAUTH_REDIRECT_URIS", "").split(",") if u.strip()]
+
 # Network bind address. Defaults to loopback so the server is NOT exposed on the LAN;
 # Cloudflare Tunnel reaches it over localhost. Set to 0.0.0.0 only if you deliberately
 # want direct network exposure.

--- a/src/obsidian_vault_mcp/oauth.py
+++ b/src/obsidian_vault_mcp/oauth.py
@@ -80,8 +80,12 @@ def _check_credentials(username: str, password: str) -> bool:
 
 
 def _redirect_uri_ok(client_id: str, redirect_uri: str) -> bool:
-    """Validate redirect_uri: https (or loopback http), and -- for a registered
-    client -- an exact match against a registered URI."""
+    """Validate redirect_uri: must be https (or loopback http) AND exact-match an
+    allowlist for the client -- no open fallthrough (#4):
+      - DCR-registered client  -> must match one of its registered redirect_uris.
+      - operator-configured client -> must match VAULT_OAUTH_REDIRECT_URIS.
+    A client with no allowlisted URIs cannot use the browser authorization-code flow.
+    """
     if not redirect_uri:
         return False
     parsed = urlparse(redirect_uri)
@@ -89,11 +93,13 @@ def _redirect_uri_ok(client_id: str, redirect_uri: str) -> bool:
     if parsed.scheme != "https" and not is_loopback:
         return False
     record = _clients.get(client_id)
-    if record is not None and record.get("redirect_uris"):
-        return redirect_uri in record["redirect_uris"]
-    # Unregistered or operator-configured client: no stored allowlist to match
-    # against. The login gate is still enforced, so this is not an auth bypass.
-    return True
+    if record is not None:
+        # DCR-registered client: exact-match its registered URIs (empty list -> deny).
+        return redirect_uri in (record.get("redirect_uris") or [])
+    if client_id == config.VAULT_OAUTH_CLIENT_ID:
+        # Operator-configured client: only the explicit allowlist is accepted.
+        return redirect_uri in config.VAULT_OAUTH_REDIRECT_URIS
+    return False
 
 
 def _client_known(client_id: str) -> bool:
@@ -287,6 +293,11 @@ async def _handle_authorization_code(form) -> JSONResponse:
         return JSONResponse({"error": "invalid_grant", "error_description": "Invalid or expired code"}, status_code=400)
 
     code_data = _auth_codes.pop(code)  # single-use
+
+    # RFC 6749 4.1.3: the code must be redeemed by the client it was issued to (#4).
+    request_client_id = form.get("client_id", "")
+    if not hmac.compare_digest(request_client_id or "", code_data.get("client_id") or ""):
+        return JSONResponse({"error": "invalid_grant", "error_description": "client_id mismatch"}, status_code=400)
 
     # redirect_uri must be present and match what was bound to the code.
     if not redirect_uri or redirect_uri != code_data["redirect_uri"]:

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -27,6 +27,7 @@ def reset_state(monkeypatch):
     monkeypatch.setattr(config, "VAULT_OAUTH_PASSWORD", "")  # unset by default
     monkeypatch.setattr(config, "VAULT_OAUTH_CLIENT_ID", "vault-mcp-client")
     monkeypatch.setattr(config, "VAULT_OAUTH_CLIENT_SECRET", "configured-server-secret")
+    monkeypatch.setattr(config, "VAULT_OAUTH_REDIRECT_URIS", [])
     yield
 
 
@@ -121,7 +122,7 @@ def test_full_flow_with_correct_password(client, monkeypatch):
 
     # Exchange the code (with the PKCE verifier) for a token.
     tok = client.post("/oauth/token", data={
-        "grant_type": "authorization_code", "code": code,
+        "grant_type": "authorization_code", "code": code, "client_id": client_id,
         "redirect_uri": redirect, "code_verifier": verifier,
     })
     assert tok.status_code == 200
@@ -139,7 +140,8 @@ def test_token_requires_pkce_verifier(client, monkeypatch):
 
     # Same code, but NO verifier -> rejected.
     tok = client.post("/oauth/token", data={
-        "grant_type": "authorization_code", "code": code, "redirect_uri": redirect,
+        "grant_type": "authorization_code", "code": code, "client_id": client_id,
+        "redirect_uri": redirect,
     })
     assert tok.status_code == 400
 
@@ -192,3 +194,67 @@ def test_no_password_fails_closed_even_via_post(client):
     r = client.post("/oauth/authorize", data=data, follow_redirects=False)
     assert r.status_code == 503
     assert "location" not in {k.lower() for k in r.headers}
+
+
+# --- #4: client identity at token exchange + redirect allowlist ---------------
+
+def _login_and_get_code(client, client_id, redirect, challenge):
+    data = _authz_params(client_id, redirect, challenge)
+    data.update({"username": "obsidian", "password": "hunter2"})
+    r = client.post("/oauth/authorize", data=data, follow_redirects=False)
+    assert r.status_code == 302
+    return r.headers["location"].split("code=")[1].split("&")[0]
+
+
+def test_token_rejects_client_id_mismatch(client, monkeypatch):
+    """A code issued to client A cannot be redeemed by client B (RFC 6749 4.1.3)."""
+    monkeypatch.setattr(config, "VAULT_OAUTH_PASSWORD", "hunter2")
+    client_id, redirect = _register(client)
+    other_id, _ = _register(client, redirect_uri="https://other.example/cb")
+    verifier, challenge = _pkce()
+    code = _login_and_get_code(client, client_id, redirect, challenge)
+    tok = client.post("/oauth/token", data={
+        "grant_type": "authorization_code", "code": code, "client_id": other_id,
+        "redirect_uri": redirect, "code_verifier": verifier,
+    })
+    assert tok.status_code == 400
+    assert tok.json()["error"] == "invalid_grant"
+
+
+def test_operator_client_redirect_requires_allowlist(client, monkeypatch):
+    """The operator-configured client_id no longer accepts an arbitrary redirect_uri;
+    it must match VAULT_OAUTH_REDIRECT_URIS (#4a fallthrough closed)."""
+    monkeypatch.setattr(config, "VAULT_OAUTH_PASSWORD", "hunter2")
+    _, challenge = _pkce()
+    op = config.VAULT_OAUTH_CLIENT_ID  # not DCR-registered
+
+    # No allowlist -> any redirect rejected.
+    r = client.get("/oauth/authorize",
+                   params=_authz_params(op, "https://anywhere.example/cb", challenge),
+                   follow_redirects=False)
+    assert r.status_code == 400
+
+    # Allowlist set -> only the listed URI is accepted.
+    monkeypatch.setattr(config, "VAULT_OAUTH_REDIRECT_URIS", ["https://allowed.example/cb"])
+    r_bad = client.get("/oauth/authorize",
+                       params=_authz_params(op, "https://anywhere.example/cb", challenge),
+                       follow_redirects=False)
+    assert r_bad.status_code == 400
+    r_ok = client.get("/oauth/authorize",
+                      params=_authz_params(op, "https://allowed.example/cb", challenge),
+                      follow_redirects=False)
+    assert r_ok.status_code == 200  # login form for an allowed redirect
+
+
+def test_registered_client_empty_redirects_denied(client, monkeypatch):
+    """A DCR client that registered no usable (https/loopback) redirect_uris
+    cannot use the authorization-code flow (no fallthrough)."""
+    monkeypatch.setattr(config, "VAULT_OAUTH_PASSWORD", "hunter2")
+    r = client.post("/oauth/register", json={"redirect_uris": ["http://evil.example/cb"]})
+    cid = r.json()["client_id"]
+    assert r.json()["redirect_uris"] == []  # http non-loopback filtered out
+    _, challenge = _pkce()
+    r2 = client.get("/oauth/authorize",
+                    params=_authz_params(cid, "https://evil.example/cb", challenge),
+                    follow_redirects=False)
+    assert r2.status_code == 400


### PR DESCRIPTION
## Summary
Finishes the OAuth hardening on top of v0.2.0, closing the two remaining security issues. (#3 was already fixed in v0.2.0 — see note below.)

- **#2 — constant-time token compare.** `auth.py` compared the bearer token with `!=`, which short-circuits on the first differing byte (timing side channel). Now uses `hmac.compare_digest`.
- **#4b — client identity at token exchange.** The `authorization_code` grant never verified that the redeeming `client_id` matched the one the code was issued to (RFC 6749 §4.1.3). It does now.
- **#4a — strict redirect_uri allowlist.** `_redirect_uri_ok` previously fell through to "any https/loopback" for the operator-configured client or a DCR client that registered no `redirect_uris`. Now: DCR clients must exact-match a registered URI; the static operator client must match the new `VAULT_OAUTH_REDIRECT_URIS` allowlist (empty → denied). No open fallthrough.

## Testing
New tests in `tests/test_oauth.py`: client_id mismatch rejected, operator-client allowlist enforced, empty-registration client denied. Full suite green. Codex-reviewed: no v0.2.0 posture regression; the Claude/ChatGPT DCR flow (registers its redirect, sends client_id at the token step) is unaffected.

Closes #2. Closes #4.
