### PR TITLE
Fix date serialization (#5) and per-request index rebuild (#28)

### DIFF
--- a/src/obsidian_vault_mcp/frontmatter_index.py
+++ b/src/obsidian_vault_mcp/frontmatter_index.py
@@ -25,7 +25,13 @@ class FrontmatterIndex:
         self._pending_paths: set[str] = set()
 
     def start(self) -> None:
-        """Walk all .md files, parse frontmatter, and start watching for changes."""
+        """Walk all .md files, parse frontmatter, and start watching for changes.
+
+        Idempotent: a second call while already running is a no-op. The index is
+        built once at process start (server.main), never per request -- see #28.
+        """
+        if self._observer is not None:
+            return
         t0 = time.monotonic()
         count = 0
 

--- a/src/obsidian_vault_mcp/serialization.py
+++ b/src/obsidian_vault_mcp/serialization.py
@@ -1,0 +1,21 @@
+"""JSON serialization helpers for the Obsidian vault MCP server.
+
+python-frontmatter parses YAML date fields into Python date/datetime objects,
+which the stdlib json encoder can't handle. This module provides a drop-in
+replacement for json.dumps that serializes those types as ISO 8601 strings (#5).
+"""
+
+import json
+from datetime import date, datetime
+
+
+class _VaultEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, (datetime, date)):
+            return obj.isoformat()
+        return super().default(obj)
+
+
+def dumps(obj, **kwargs) -> str:
+    """json.dumps with automatic date/datetime serialization."""
+    return json.dumps(obj, cls=_VaultEncoder, **kwargs)

--- a/src/obsidian_vault_mcp/server.py
+++ b/src/obsidian_vault_mcp/server.py
@@ -4,6 +4,7 @@ Exposes read/write access to an Obsidian vault over Streamable HTTP.
 Designed to run behind Cloudflare Tunnel for secure remote access.
 """
 
+import atexit
 import json
 import logging
 import sys
@@ -23,13 +24,14 @@ frontmatter_index = FrontmatterIndex()
 
 @asynccontextmanager
 async def lifespan(server):
-    """Start frontmatter index on server startup, stop on shutdown."""
-    logger.info(f"Starting vault MCP server. Vault: {VAULT_PATH}")
-    frontmatter_index.start()
-    logger.info(f"Frontmatter index built: {frontmatter_index.file_count} files indexed")
+    """Per-request MCP lifespan.
+
+    With stateless_http=True this runs on EVERY HTTP request, so it must NOT build
+    or tear down the index -- doing so rebuilt the whole index per request and timed
+    out large vaults (#28). The index is built once in main() before serving; here we
+    only expose the already-built instance to tools.
+    """
     yield {"frontmatter_index": frontmatter_index}
-    frontmatter_index.stop()
-    logger.info("Vault MCP server shut down.")
 
 
 # Create the MCP server
@@ -201,6 +203,12 @@ def main():
 
     if not VAULT_MCP_TOKEN:
         logger.warning("VAULT_MCP_TOKEN is not set -- auth will reject all requests")
+
+    # Build the frontmatter index ONCE, before serving. With stateless_http the
+    # per-request MCP lifespan would otherwise rebuild it on every request (#28).
+    logger.info(f"Starting vault MCP server. Vault: {VAULT_PATH}")
+    frontmatter_index.start()
+    atexit.register(frontmatter_index.stop)
 
     # Build the Starlette app with auth middleware and OAuth endpoints
     try:

--- a/src/obsidian_vault_mcp/tools/read.py
+++ b/src/obsidian_vault_mcp/tools/read.py
@@ -1,10 +1,10 @@
 """Read tools for the Obsidian vault MCP server."""
 
-import json
 import logging
 
 import frontmatter
 
+from ..serialization import dumps
 from ..vault import resolve_vault_path, read_file
 
 logger = logging.getLogger(__name__)
@@ -24,19 +24,19 @@ def vault_read(path: str) -> str:
         except Exception:
             pass
 
-        return json.dumps({
+        return dumps({
             "path": path,
             "content": content,
             "metadata": metadata,
             "frontmatter": fm_data,
         })
     except ValueError as e:
-        return json.dumps({"error": str(e), "path": path})
+        return dumps({"error": str(e), "path": path})
     except FileNotFoundError:
-        return json.dumps({"error": f"File not found: {path}", "path": path})
+        return dumps({"error": f"File not found: {path}", "path": path})
     except Exception as e:
         logger.error(f"vault_read error for {path}: {e}")
-        return json.dumps({"error": str(e), "path": path})
+        return dumps({"error": str(e), "path": path})
 
 
 def vault_batch_read(paths: list[str], include_content: bool = True) -> str:
@@ -74,4 +74,4 @@ def vault_batch_read(paths: list[str], include_content: bool = True) -> str:
             results.append({"path": path, "error": str(e)})
             missing += 1
 
-    return json.dumps({"files": results, "found": found, "missing": missing})
+    return dumps({"files": results, "found": found, "missing": missing})

--- a/src/obsidian_vault_mcp/tools/search.py
+++ b/src/obsidian_vault_mcp/tools/search.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import frontmatter
 
 from .. import config
+from ..serialization import dumps
 from ..vault import resolve_vault_path
 
 logger = logging.getLogger(__name__)
@@ -153,7 +154,7 @@ def vault_search(
             search_path = config.VAULT_PATH
 
         if not search_path.is_dir():
-            return json.dumps({"error": f"Search path is not a directory: {path_prefix}"})
+            return dumps({"error": f"Search path is not a directory: {path_prefix}"})
 
         if shutil.which("rg"):
             matches = _search_ripgrep(query, search_path, file_pattern, max_results, context_lines)
@@ -166,16 +167,16 @@ def vault_search(
 
         truncated = len(matches) >= max_results
 
-        return json.dumps({
+        return dumps({
             "results": matches,
             "total_matches": len(matches),
             "truncated": truncated,
         })
     except ValueError as e:
-        return json.dumps({"error": str(e)})
+        return dumps({"error": str(e)})
     except Exception as e:
         logger.error(f"vault_search error: {e}")
-        return json.dumps({"error": str(e)})
+        return dumps({"error": str(e)})
 
 
 def vault_search_frontmatter(
@@ -209,11 +210,11 @@ def vault_search_frontmatter(
 
         truncated = len(results) > max_results
 
-        return json.dumps({
+        return dumps({
             "results": formatted,
             "total": len(formatted),
             "truncated": truncated,
         })
     except Exception as e:
         logger.error(f"vault_search_frontmatter error: {e}")
-        return json.dumps({"error": str(e)})
+        return dumps({"error": str(e)})

--- a/tests/test_issues_5_28.py
+++ b/tests/test_issues_5_28.py
@@ -1,0 +1,42 @@
+"""Tests for #5 (date JSON serialization) and #28 (index built once, not per request)."""
+
+import json
+from datetime import date, datetime
+
+from obsidian_vault_mcp.serialization import dumps
+from obsidian_vault_mcp.tools.read import vault_read
+
+
+# --- #5: bare YAML dates must serialize -----------------------------------------
+
+def test_dumps_serializes_date_and_datetime():
+    out = dumps({"created": date(2026, 4, 5), "ts": datetime(2026, 4, 5, 12, 30, 0)})
+    parsed = json.loads(out)
+    assert parsed["created"] == "2026-04-05"
+    assert parsed["ts"].startswith("2026-04-05T12:30")
+
+
+def test_vault_read_handles_bare_yaml_date(vault_dir):
+    """A file with an unquoted frontmatter date reads without error (#5)."""
+    (vault_dir / "dated.md").write_text(
+        "---\ncreated: 2026-04-05\ntags: [test]\n---\n\nBody.\n"
+    )
+    result = json.loads(vault_read("dated.md"))
+    assert "error" not in result, result
+    assert result["frontmatter"]["created"] == "2026-04-05"
+
+
+# --- #28: the index is built once and start() is idempotent ---------------------
+
+def test_frontmatter_index_start_is_idempotent(vault_dir):
+    """A second start() while already running is a no-op (index is process-scoped,
+    not rebuilt per request)."""
+    from obsidian_vault_mcp.frontmatter_index import FrontmatterIndex
+    idx = FrontmatterIndex()
+    try:
+        idx.start()
+        first_observer = idx._observer
+        idx.start()  # must NOT spawn a second observer or re-walk
+        assert idx._observer is first_observer
+    finally:
+        idx.stop()


### PR DESCRIPTION
## Summary
Two independent bugs that made the server unusable on real/large vaults.

- **#5 — "Object of type date is not JSON serializable".** Bare YAML frontmatter dates (`created: 2026-04-05`) parse to `datetime.date`, which stdlib `json.dumps` can't encode — breaking `vault_read`, `vault_batch_read`, `vault_search`, `vault_search_frontmatter`. Adds `serialization.py` (`dumps()` ISO-formats dates) and routes those tools through it. (write/manage need no change — no parsed-date responses.)
- **#28 — index rebuilt on every request → timeouts.** The frontmatter index was built inside the FastMCP `lifespan`, and with `stateless_http=True` that lifespan runs per HTTP request, so the whole index rebuilt every request (the reporter saw "index built: 2269 files in 32s" repeating). Now built **once** in `main()` before serving; the lifespan is a no-op yield; `start()` is idempotent; `atexit` stops the watcher.

## Testing
New `tests/test_issues_5_28.py`: date round-trip + `start()` idempotency. Verified live against a temp vault: the index builds exactly once across multiple requests, and a bare-date file reads cleanly. Codex-reviewed; no security regression.

Closes #5. Closes #28.
