### PR TITLE
Connector interop: serve MCP at / (#19) + RFC 9728 metadata (#20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ export VAULT_PATH="$HOME/Obsidian/MyVault"
 uv run vault-mcp
 ```
 
-The server starts on port 8420 by default and serves MCP over Streamable HTTP at `/mcp/`. It binds to `127.0.0.1` -- reachable locally and through a Cloudflare Tunnel, but not exposed on your LAN. Set `VAULT_MCP_HOST=0.0.0.0` only if you deliberately want direct network exposure.
+The server starts on port 8420 by default and serves MCP over Streamable HTTP at `/` (the root path — MCP clients connect to the base URL directly). It binds to `127.0.0.1` -- reachable locally and through a Cloudflare Tunnel, but not exposed on your LAN. Set `VAULT_MCP_HOST=0.0.0.0` only if you deliberately want direct network exposure.
 
 ## Configuration
 

--- a/src/obsidian_vault_mcp/auth.py
+++ b/src/obsidian_vault_mcp/auth.py
@@ -10,6 +10,7 @@ from .config import VAULT_MCP_TOKEN
 _AUTH_EXEMPT_PATHS = {
     "/health",
     "/.well-known/oauth-authorization-server",
+    "/.well-known/oauth-protected-resource",
     "/oauth/authorize",
     "/oauth/token",
     "/oauth/register",

--- a/src/obsidian_vault_mcp/oauth.py
+++ b/src/obsidian_vault_mcp/oauth.py
@@ -186,6 +186,18 @@ async def oauth_metadata(request: Request) -> JSONResponse:
     })
 
 
+async def oauth_protected_resource(request: Request) -> JSONResponse:
+    """RFC 9728 OAuth protected-resource metadata. Claude/ChatGPT request this path
+    during discovery; it must be reachable without a bearer token (#20). With the MCP
+    endpoint served at "/" (#19), the protected resource is the base URL itself."""
+    base_url = str(request.base_url).rstrip("/")
+    return JSONResponse({
+        "resource": base_url,
+        "authorization_servers": [base_url],
+        "bearer_methods_supported": ["header"],
+    })
+
+
 async def oauth_authorize(request: Request):
     """OAuth 2.0 authorization endpoint with an interactive login gate.
 
@@ -380,6 +392,7 @@ async def oauth_register(request: Request) -> JSONResponse:
 # Starlette routes to mount on the app
 oauth_routes = [
     Route("/.well-known/oauth-authorization-server", oauth_metadata, methods=["GET"]),
+    Route("/.well-known/oauth-protected-resource", oauth_protected_resource, methods=["GET"]),
     Route("/oauth/authorize", oauth_authorize, methods=["GET", "POST"]),
     Route("/oauth/token", oauth_token, methods=["POST"]),
     Route("/oauth/register", oauth_register, methods=["POST"]),

--- a/src/obsidian_vault_mcp/server.py
+++ b/src/obsidian_vault_mcp/server.py
@@ -37,6 +37,9 @@ mcp = FastMCP(
     "obsidian_web_mcp",
     stateless_http=True,
     json_response=True,
+    # Serve MCP at "/" (not the /mcp default) so connectors that POST to the root
+    # complete the handshake instead of 404ing (#19).
+    streamable_http_path="/",
     lifespan=lifespan,
     transport_security=TransportSecuritySettings(
         enable_dns_rebinding_protection=True,

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -192,3 +192,19 @@ def test_no_password_fails_closed_even_via_post(client):
     r = client.post("/oauth/authorize", data=data, follow_redirects=False)
     assert r.status_code == 503
     assert "location" not in {k.lower() for k in r.headers}
+
+
+# --- #20: RFC 9728 protected-resource metadata --------------------------------
+
+def test_oauth_protected_resource_metadata(client):
+    r = client.get("/.well-known/oauth-protected-resource")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["resource"]
+    assert isinstance(body["authorization_servers"], list) and body["authorization_servers"]
+    assert body["bearer_methods_supported"] == ["header"]
+
+
+def test_protected_resource_path_is_auth_exempt():
+    from obsidian_vault_mcp.auth import _AUTH_EXEMPT_PATHS
+    assert "/.well-known/oauth-protected-resource" in _AUTH_EXEMPT_PATHS


### PR DESCRIPTION
## Summary
Two Claude.ai/ChatGPT connector-interop fixes (reported together).

- **#19 — MCP served at `/mcp` → connectors POST `/` and get 404.** Pass `streamable_http_path="/"` to `FastMCP` so MCP answers at the root.
- **#20 — `/.well-known/oauth-protected-resource` returned 401/404.** Adds the RFC 9728 handler (`{resource, authorization_servers, bearer_methods_supported}`) and the auth exemption. Claude requests this during discovery; without it, tools never load.

## Testing
New tests: the protected-resource endpoint returns metadata and is auth-exempt. Verified live: `POST /` serves MCP, old `/mcp` 404s, the metadata endpoint returns 200 unauthenticated, and explicit OAuth routes still match before the `/` MCP route (no shadowing).

**Please test end-to-end with a real Claude.ai/ChatGPT custom connector before merging** — this is the one change whose final gate is live connector behavior, not unit tests.

Closes #19. Closes #20.
