### PR TITLE
Configurable allowed_hosts via VAULT_MCP_ALLOWED_HOSTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,15 +142,10 @@ export VAULT_MCP_HOSTNAME="vault-mcp.yourdomain.com"
 
 The script authenticates with Cloudflare, creates a tunnel, writes the config, and sets up the DNS record. You will need a domain managed by Cloudflare.
 
-After setup, add your tunnel hostname to the `allowed_hosts` list in `server.py` so the MCP library's DNS rebinding protection accepts requests from your domain:
+After setup, allow your tunnel hostname through the MCP library's DNS rebinding protection by setting `VAULT_MCP_ALLOWED_HOSTS` (comma-separated; appended to the loopback defaults, so no source edit is needed):
 
-```python
-allowed_hosts=[
-    "127.0.0.1:*",
-    "localhost:*",
-    "[::1]:*",
-    "vault-mcp.yourdomain.com",  # add your hostname here
-],
+```bash
+export VAULT_MCP_ALLOWED_HOSTS="vault-mcp.yourdomain.com"
 ```
 
 ## Production Deployment (macOS)
@@ -313,15 +308,10 @@ journalctl -u caddy -f
 
 ### 5. Allow the public hostname in the server
 
-The MCP library enables DNS rebinding protection, so you must add your public hostname to `allowed_hosts` in `src/obsidian_vault_mcp/server.py`:
+The MCP library enables DNS rebinding protection, so set `VAULT_MCP_ALLOWED_HOSTS` to your public hostname (comma-separated; appended to the loopback defaults — no need to edit the source):
 
-```python
-allowed_hosts=[
-    "127.0.0.1:*",
-    "localhost:*",
-    "[::1]:*",
-    "your-mcp-server.dev",
-]
+```bash
+export VAULT_MCP_ALLOWED_HOSTS="your-mcp-server.dev"
 ```
 
 ### 6. Start obsidian-web-mcp on the VPS

--- a/src/obsidian_vault_mcp/config.py
+++ b/src/obsidian_vault_mcp/config.py
@@ -29,6 +29,12 @@ VAULT_OAUTH_REDIRECT_URIS = [u.strip() for u in os.environ.get("VAULT_OAUTH_REDI
 # want direct network exposure.
 VAULT_MCP_HOST = os.environ.get("VAULT_MCP_HOST", "127.0.0.1")
 
+# Extra hostnames allowed through the MCP library's DNS-rebinding protection,
+# comma-separated. Loopback (127.0.0.1, localhost, [::1]) is always allowed; set this
+# to your public tunnel/proxy hostname, e.g. "vault-mcp.example.com". Operator-supplied
+# hosts are APPENDED to the loopback defaults in server.py, never replace them.
+VAULT_MCP_ALLOWED_HOSTS = [h.strip() for h in os.environ.get("VAULT_MCP_ALLOWED_HOSTS", "").split(",") if h.strip()]
+
 # Safety limits
 MAX_CONTENT_SIZE = 1_000_000  # 1MB max write size
 MAX_BATCH_SIZE = 20           # Max files per batch operation

--- a/src/obsidian_vault_mcp/server.py
+++ b/src/obsidian_vault_mcp/server.py
@@ -13,7 +13,7 @@ from contextlib import asynccontextmanager
 from mcp.server.fastmcp import FastMCP
 from mcp.server.transport_security import TransportSecuritySettings
 
-from .config import VAULT_MCP_HOST, VAULT_MCP_PORT, VAULT_MCP_TOKEN, VAULT_PATH
+from .config import VAULT_MCP_ALLOWED_HOSTS, VAULT_MCP_HOST, VAULT_MCP_PORT, VAULT_MCP_TOKEN, VAULT_PATH
 from .frontmatter_index import FrontmatterIndex
 
 logger = logging.getLogger(__name__)
@@ -49,8 +49,9 @@ mcp = FastMCP(
             "127.0.0.1:*",
             "localhost:*",
             "[::1]:*",
-            # Add your tunnel hostname here, e.g.:
-            # "vault-mcp.example.com",
+            # Operator hostnames from VAULT_MCP_ALLOWED_HOSTS are appended to the
+            # loopback defaults above (set it to your tunnel/proxy hostname).
+            *VAULT_MCP_ALLOWED_HOSTS,
         ],
     ),
 )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,47 @@
+"""Tests for environment-driven configuration (VAULT_MCP_ALLOWED_HOSTS)."""
+
+import importlib
+
+import pytest
+
+import obsidian_vault_mcp.config as config_module
+
+
+@pytest.fixture(autouse=True)
+def _restore_config(monkeypatch):
+    """Reload config after each test so the module-level parse doesn't leak."""
+    yield
+    monkeypatch.delenv("VAULT_MCP_ALLOWED_HOSTS", raising=False)
+    importlib.reload(config_module)
+
+
+def test_allowed_hosts_defaults_empty(monkeypatch):
+    monkeypatch.delenv("VAULT_MCP_ALLOWED_HOSTS", raising=False)
+    cfg = importlib.reload(config_module)
+    assert cfg.VAULT_MCP_ALLOWED_HOSTS == []
+
+
+def test_allowed_hosts_parsed_stripped_and_compacted(monkeypatch):
+    monkeypatch.setenv("VAULT_MCP_ALLOWED_HOSTS", "vault-mcp.example.com, second.example.com ,")
+    cfg = importlib.reload(config_module)
+    # Whitespace trimmed; empty fragments (trailing comma) dropped.
+    assert cfg.VAULT_MCP_ALLOWED_HOSTS == ["vault-mcp.example.com", "second.example.com"]
+
+
+def test_server_appends_to_loopback_defaults(monkeypatch):
+    """server.py must APPEND operator hosts to loopback, never replace them."""
+    monkeypatch.setenv("VAULT_MCP_ALLOWED_HOSTS", "vault-mcp.example.com")
+    importlib.reload(config_module)
+    server_module = importlib.import_module("obsidian_vault_mcp.server")
+    importlib.reload(server_module)
+    try:
+        hosts = server_module.mcp.settings.transport_security.allowed_hosts
+        assert "127.0.0.1:*" in hosts
+        assert "localhost:*" in hosts
+        assert "[::1]:*" in hosts
+        assert "vault-mcp.example.com" in hosts
+    finally:
+        # Restore server module to ambient env so later test files are unaffected.
+        monkeypatch.delenv("VAULT_MCP_ALLOWED_HOSTS", raising=False)
+        importlib.reload(config_module)
+        importlib.reload(server_module)


### PR DESCRIPTION
Makes the DNS-rebinding `allowed_hosts` list configurable instead of requiring a `server.py` edit.

## What
- New `VAULT_MCP_ALLOWED_HOSTS` env var (comma-separated), **appended** to the loopback defaults (`127.0.0.1`, `localhost`, `[::1]`) rather than replacing them — local access is never accidentally dropped.
- Cloudflare Tunnel and VPS docs updated to use the env var (no more source edits).
- Tests for parsing + that the server appends operator hosts to the loopback defaults.

## Credit
Supersedes #10 (@mleitnercom) and #24 (@tleyden), which both asked for this. Took the append-to-defaults behavior to avoid the footgun of replacing the loopback entries.

`uv run --with pytest --with pytest-asyncio pytest` — 47 passed.