### PR TITLE
Emit RFC 9728 WWW-Authenticate challenge on 401s

### DIFF
--- a/src/obsidian_vault_mcp/auth.py
+++ b/src/obsidian_vault_mcp/auth.py
@@ -19,6 +19,21 @@ _AUTH_EXEMPT_PATHS = {
 }
 
 
+def _www_authenticate(request: Request, error: str) -> str:
+    """RFC 9728 challenge header pointing clients at the protected-resource metadata.
+
+    Without it a 401 just looks like a failed request; with it, a spec-compliant MCP
+    client (e.g. Claude Code, ChatGPT) knows to fetch the metadata and start the OAuth
+    flow -- "Needs authentication" instead of "Failed to connect". The resource URL is
+    derived from request.base_url, matching the oauth_metadata / oauth_protected_resource
+    endpoints, so it is only as trustworthy as the Host/forwarded-header validation in
+    front of the app.
+    """
+    base_url = str(request.base_url).rstrip("/")
+    resource_metadata = f"{base_url}/.well-known/oauth-protected-resource"
+    return f'Bearer realm="mcp", resource_metadata="{resource_metadata}", error="{error}"'
+
+
 class BearerAuthMiddleware(BaseHTTPMiddleware):
     """Validates Bearer tokens on all requests except OAuth and health endpoints."""
 
@@ -37,6 +52,7 @@ class BearerAuthMiddleware(BaseHTTPMiddleware):
             return JSONResponse(
                 {"error": "Missing or malformed Authorization header"},
                 status_code=401,
+                headers={"WWW-Authenticate": _www_authenticate(request, "invalid_request")},
             )
 
         token = auth_header[7:]
@@ -45,6 +61,7 @@ class BearerAuthMiddleware(BaseHTTPMiddleware):
             return JSONResponse(
                 {"error": "Invalid token"},
                 status_code=401,
+                headers={"WWW-Authenticate": _www_authenticate(request, "invalid_token")},
             )
 
         return await call_next(request)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,47 @@
+"""Tests for the bearer-auth middleware's RFC 9728 WWW-Authenticate challenge."""
+
+import pytest
+from starlette.applications import Starlette
+from starlette.responses import PlainTextResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from obsidian_vault_mcp import auth as auth_module
+
+
+@pytest.fixture
+def client(monkeypatch):
+    # Bind a known token into the middleware's module namespace.
+    monkeypatch.setattr(auth_module, "VAULT_MCP_TOKEN", "secret-token")
+
+    async def ok(request):
+        return PlainTextResponse("ok")
+
+    app = Starlette(routes=[Route("/", ok)])
+    app.add_middleware(auth_module.BearerAuthMiddleware)
+    return TestClient(app)
+
+
+def test_missing_auth_returns_401_with_challenge(client):
+    r = client.get("/")
+    assert r.status_code == 401
+    wa = r.headers.get("WWW-Authenticate", "")
+    assert wa.startswith("Bearer ")
+    assert "/.well-known/oauth-protected-resource" in wa
+    assert 'resource_metadata="' in wa
+    assert 'error="invalid_request"' in wa
+
+
+def test_bad_token_returns_401_with_invalid_token_challenge(client):
+    r = client.get("/", headers={"Authorization": "Bearer wrong"})
+    assert r.status_code == 401
+    wa = r.headers.get("WWW-Authenticate", "")
+    assert 'error="invalid_token"' in wa
+    assert "/.well-known/oauth-protected-resource" in wa
+
+
+def test_valid_token_passes_through(client):
+    r = client.get("/", headers={"Authorization": "Bearer secret-token"})
+    assert r.status_code == 200
+    assert r.text == "ok"
+    assert "WWW-Authenticate" not in r.headers


### PR DESCRIPTION
401 responses carried no `WWW-Authenticate` header, so a spec-compliant MCP client (Claude Code, ChatGPT) couldn't discover where to authenticate — it reported "Failed to connect" instead of starting the OAuth flow.

## What
- 401s now return `WWW-Authenticate: Bearer realm="mcp", resource_metadata="…/.well-known/oauth-protected-resource", error="…"` (RFC 9728 §5.1).
- `error=invalid_request` for a missing/malformed header, `error=invalid_token` for a bad token.
- Tests cover both challenge paths + that a valid token passes through with no challenge header.

## Credit
Cherry-picked from #13 (@casmokey). That PR also re-added the `/.well-known/oauth-protected-resource` route, which main already serves (#20) — dropped here to avoid the duplicate. The `resource_metadata` URL is derived from `request.base_url` to match the existing metadata endpoints; tightening that against forwarded-header spoofing is tracked separately.

`pytest` — 50 passed.