### PR TITLE
fix: stop trusting X-Forwarded-* from arbitrary clients (advertised-origin spoofing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ All configuration is via environment variables:
 | `VAULT_OAUTH_USERNAME` | No | `obsidian` | Username for the interactive login |
 | `VAULT_MCP_HOST` | No | `127.0.0.1` | Bind address. Loopback by default; set `0.0.0.0` only for deliberate LAN exposure |
 | `VAULT_MCP_PORT` | No | `8420` | Port the HTTP server listens on |
+| `VAULT_MCP_FORWARDED_ALLOW_IPS` | No | `127.0.0.1` | Client IPs uvicorn trusts to set `X-Forwarded-*` headers. Loopback-only by default, because a trusted Cloudflare Tunnel / Caddy proxy connects over localhost. **Never set this to `*`** -- that lets any caller spoof the advertised OAuth origin via `X-Forwarded-Host`. Set to `::1` if your proxy connects over IPv6 loopback. |
+| `VAULT_MCP_PUBLIC_URL` | No | (none) | Canonical public origin (e.g. `https://vault-mcp.yourdomain.com`) for every URL the server advertises -- the OAuth discovery metadata and the `WWW-Authenticate` challenge. When set it **pins** those URLs so a spoofed `Host` / `X-Forwarded-Host` header cannot redirect OAuth discovery to an attacker. When unset, the per-request base URL is used. Recommended for any reverse-proxy deployment. |
 | `VAULT_OAUTH_CLIENT_ID` | No | `vault-mcp-client` | Client ID for the headless `client_credentials` grant |
 | `VAULT_OAUTH_CLIENT_SECRET` | No | (none) | Only required for the headless `client_credentials` grant. The Claude/ChatGPT browser flow uses dynamic client registration and does **not** need this. |
 | `VAULT_OAUTH_REDIRECT_URIS` | No | (none) | Comma-separated allowlist of redirect URIs for the static `VAULT_OAUTH_CLIENT_ID` when using the browser flow. Dynamically-registered clients (Claude/ChatGPT) carry their own; leave unset unless you connect a static client through `/oauth/authorize`. |
@@ -312,6 +314,12 @@ The MCP library enables DNS rebinding protection, so set `VAULT_MCP_ALLOWED_HOST
 
 ```bash
 export VAULT_MCP_ALLOWED_HOSTS="your-mcp-server.dev"
+```
+
+Caddy reverse-proxies from `localhost`, so the loopback-only `VAULT_MCP_FORWARDED_ALLOW_IPS` default already trusts its `X-Forwarded-*` headers — no change needed. As defense in depth, pin the origin the server advertises in OAuth discovery so a spoofed `X-Forwarded-Host` can never redirect it:
+
+```bash
+export VAULT_MCP_PUBLIC_URL="https://your-mcp-server.dev"
 ```
 
 ### 6. Start obsidian-web-mcp on the VPS

--- a/src/obsidian_vault_mcp/auth.py
+++ b/src/obsidian_vault_mcp/auth.py
@@ -6,6 +6,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 
+from . import config
 from .config import VAULT_MCP_TOKEN
 
 # Paths that don't require bearer auth (OAuth flow + health)
@@ -25,11 +26,11 @@ def _www_authenticate(request: Request, error: str) -> str:
     Without it a 401 just looks like a failed request; with it, a spec-compliant MCP
     client (e.g. Claude Code, ChatGPT) knows to fetch the metadata and start the OAuth
     flow -- "Needs authentication" instead of "Failed to connect". The resource URL is
-    derived from request.base_url, matching the oauth_metadata / oauth_protected_resource
-    endpoints, so it is only as trustworthy as the Host/forwarded-header validation in
-    front of the app.
+    derived from VAULT_MCP_PUBLIC_URL when set (otherwise request.base_url), matching the
+    oauth_metadata / oauth_protected_resource endpoints. Pinning the public URL keeps a
+    spoofed Host/X-Forwarded-Host header from pointing clients at an attacker's server.
     """
-    base_url = str(request.base_url).rstrip("/")
+    base_url = config.advertised_base_url(str(request.base_url))
     resource_metadata = f"{base_url}/.well-known/oauth-protected-resource"
     return f'Bearer realm="mcp", resource_metadata="{resource_metadata}", error="{error}"'
 

--- a/src/obsidian_vault_mcp/config.py
+++ b/src/obsidian_vault_mcp/config.py
@@ -35,6 +35,35 @@ VAULT_MCP_HOST = os.environ.get("VAULT_MCP_HOST", "127.0.0.1")
 # hosts are APPENDED to the loopback defaults in server.py, never replace them.
 VAULT_MCP_ALLOWED_HOSTS = [h.strip() for h in os.environ.get("VAULT_MCP_ALLOWED_HOSTS", "").split(",") if h.strip()]
 
+# Which client IPs uvicorn trusts to set X-Forwarded-* headers. Because the server
+# derives request.base_url from those headers and advertises it in OAuth discovery
+# metadata + the RFC 9728 WWW-Authenticate challenge, trusting them from arbitrary
+# sources lets an attacker spoof the advertised authorization-server / resource URL
+# (X-Forwarded-Host: evil.example) -- a token-redirection vector. The server binds
+# loopback and is reached by Cloudflare Tunnel / Caddy over localhost, so the only
+# trustworthy forwarder is loopback. Defaults to uvicorn's own default, "127.0.0.1";
+# override only if your reverse proxy connects from a different address (e.g. "::1").
+# Never set this to "*".
+VAULT_MCP_FORWARDED_ALLOW_IPS = os.environ.get("VAULT_MCP_FORWARDED_ALLOW_IPS", "127.0.0.1")
+
+# Canonical public origin for every URL the server advertises -- the OAuth metadata
+# endpoints (issuer / authorization_endpoint / token_endpoint / registration_endpoint /
+# resource) and the WWW-Authenticate resource_metadata pointer. When set (e.g.
+# "https://vault-mcp.example.com") it PINS those URLs so a spoofed Host / X-Forwarded-Host
+# header cannot redirect OAuth discovery to an attacker-controlled server. When empty,
+# the server falls back to the per-request base_url. A trailing slash is ignored.
+VAULT_MCP_PUBLIC_URL = os.environ.get("VAULT_MCP_PUBLIC_URL", "").strip()
+
+
+def advertised_base_url(request_base_url: str) -> str:
+    """Return the canonical origin to advertise, with no trailing slash.
+
+    Prefers the operator-pinned VAULT_MCP_PUBLIC_URL; falls back to the request's
+    own base_url. Centralizing this keeps the OAuth metadata endpoints and the
+    WWW-Authenticate challenge consistent and spoof-resistant.
+    """
+    return (VAULT_MCP_PUBLIC_URL or request_base_url).rstrip("/")
+
 # Safety limits
 MAX_CONTENT_SIZE = 1_000_000  # 1MB max write size
 MAX_BATCH_SIZE = 20           # Max files per batch operation

--- a/src/obsidian_vault_mcp/oauth.py
+++ b/src/obsidian_vault_mcp/oauth.py
@@ -179,7 +179,7 @@ def _misconfigured_page() -> HTMLResponse:
 
 async def oauth_metadata(request: Request) -> JSONResponse:
     """RFC 8414 OAuth authorization server metadata."""
-    base_url = str(request.base_url).rstrip("/")
+    base_url = config.advertised_base_url(str(request.base_url))
     return JSONResponse({
         "issuer": base_url,
         "authorization_endpoint": f"{base_url}/oauth/authorize",
@@ -196,7 +196,7 @@ async def oauth_protected_resource(request: Request) -> JSONResponse:
     """RFC 9728 OAuth protected-resource metadata. Claude/ChatGPT request this path
     during discovery; it must be reachable without a bearer token (#20). With the MCP
     endpoint served at "/" (#19), the protected resource is the base URL itself."""
-    base_url = str(request.base_url).rstrip("/")
+    base_url = config.advertised_base_url(str(request.base_url))
     return JSONResponse({
         "resource": base_url,
         "authorization_servers": [base_url],

--- a/src/obsidian_vault_mcp/server.py
+++ b/src/obsidian_vault_mcp/server.py
@@ -13,7 +13,14 @@ from contextlib import asynccontextmanager
 from mcp.server.fastmcp import FastMCP
 from mcp.server.transport_security import TransportSecuritySettings
 
-from .config import VAULT_MCP_ALLOWED_HOSTS, VAULT_MCP_HOST, VAULT_MCP_PORT, VAULT_MCP_TOKEN, VAULT_PATH
+from .config import (
+    VAULT_MCP_ALLOWED_HOSTS,
+    VAULT_MCP_FORWARDED_ALLOW_IPS,
+    VAULT_MCP_HOST,
+    VAULT_MCP_PORT,
+    VAULT_MCP_TOKEN,
+    VAULT_PATH,
+)
 from .frontmatter_index import FrontmatterIndex
 
 logger = logging.getLogger(__name__)
@@ -238,8 +245,11 @@ def main():
         host=VAULT_MCP_HOST,
         port=VAULT_MCP_PORT,
         log_level="info",
+        # Honor X-Forwarded-* ONLY from the trusted loopback proxy (Cloudflare
+        # Tunnel / Caddy), never from arbitrary clients. Trusting "*" let any
+        # caller spoof the advertised OAuth origin via X-Forwarded-Host.
         proxy_headers=True,
-        forwarded_allow_ips="*",
+        forwarded_allow_ips=VAULT_MCP_FORWARDED_ALLOW_IPS,
     )
 
 

--- a/tests/test_forwarded_host.py
+++ b/tests/test_forwarded_host.py
@@ -1,0 +1,111 @@
+"""Regression tests: a spoofed Host / X-Forwarded-Host header must not let an
+attacker control the URLs the server advertises during OAuth discovery.
+
+Two layers of defense are exercised:
+  1. VAULT_MCP_PUBLIC_URL pins the advertised origin (app layer -- the OAuth
+     metadata endpoints and the RFC 9728 WWW-Authenticate challenge).
+  2. uvicorn forwarded_allow_ips="127.0.0.1" stops the proxy layer from honoring
+     X-Forwarded-* from non-loopback clients (config default, asserted below).
+
+Note on the test client: Starlette's TestClient speaks ASGI directly and does NOT
+run uvicorn's ProxyHeadersMiddleware, so X-Forwarded-Host alone never reaches
+request.base_url here. We therefore also spoof via the Host header -- that is the
+scope value a *trusting* proxy would synthesize from X-Forwarded-Host, so it is
+the faithful app-layer stand-in for the attack. The forwarded_allow_ips default
+test covers the proxy layer that would otherwise turn X-Forwarded-Host into Host.
+"""
+
+import pytest
+from starlette.applications import Starlette
+from starlette.responses import PlainTextResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from obsidian_vault_mcp import auth as auth_module
+from obsidian_vault_mcp import config, oauth
+
+SPOOFED = "evil.example"
+PUBLIC = "https://vault-mcp.example.com"
+SPOOF_HEADERS = {"Host": SPOOFED, "X-Forwarded-Host": SPOOFED, "X-Forwarded-Proto": "https"}
+
+
+@pytest.fixture(autouse=True)
+def reset_state(monkeypatch):
+    # Isolate from any real env: no pinned public URL unless a test sets one.
+    monkeypatch.setattr(config, "VAULT_MCP_PUBLIC_URL", "")
+    monkeypatch.setattr(auth_module, "VAULT_MCP_TOKEN", "secret-token")
+    yield
+
+
+@pytest.fixture
+def client():
+    async def protected(request):
+        return PlainTextResponse("ok")
+
+    app = Starlette(routes=[*oauth.oauth_routes, Route("/protected", protected)])
+    app.add_middleware(auth_module.BearerAuthMiddleware)
+    return TestClient(app)
+
+
+# --- The spoofable surface (documents the mechanism the fix neutralizes) -------
+
+def test_advertised_origin_follows_host_when_unpinned(client):
+    """Without VAULT_MCP_PUBLIC_URL, the advertised origin follows the (proxied)
+    Host header. This is exactly the surface an over-trusting proxy turns into an
+    X-Forwarded-Host spoofing vector -- and what pinning the public URL closes."""
+    r = client.get("/.well-known/oauth-protected-resource", headers={"Host": SPOOFED})
+    assert SPOOFED in r.json()["resource"]
+
+
+# --- The fix: VAULT_MCP_PUBLIC_URL pins every advertised URL -------------------
+
+def test_public_url_pins_protected_resource_metadata(client, monkeypatch):
+    monkeypatch.setattr(config, "VAULT_MCP_PUBLIC_URL", PUBLIC)
+    r = client.get("/.well-known/oauth-protected-resource", headers=SPOOF_HEADERS)
+    body = r.json()
+    assert body["resource"] == PUBLIC
+    assert body["authorization_servers"] == [PUBLIC]
+    assert SPOOFED not in r.text
+
+
+def test_public_url_pins_authorization_server_metadata(client, monkeypatch):
+    monkeypatch.setattr(config, "VAULT_MCP_PUBLIC_URL", PUBLIC)
+    r = client.get("/.well-known/oauth-authorization-server", headers=SPOOF_HEADERS)
+    body = r.json()
+    assert body["issuer"] == PUBLIC
+    assert body["authorization_endpoint"] == f"{PUBLIC}/oauth/authorize"
+    assert body["token_endpoint"] == f"{PUBLIC}/oauth/token"
+    assert body["registration_endpoint"] == f"{PUBLIC}/oauth/register"
+    assert SPOOFED not in r.text
+
+
+def test_public_url_pins_www_authenticate_challenge(client, monkeypatch):
+    monkeypatch.setattr(config, "VAULT_MCP_PUBLIC_URL", PUBLIC)
+    r = client.get("/protected", headers=SPOOF_HEADERS)
+    assert r.status_code == 401
+    wa = r.headers["WWW-Authenticate"]
+    assert f'resource_metadata="{PUBLIC}/.well-known/oauth-protected-resource"' in wa
+    assert SPOOFED not in wa
+
+
+def test_public_url_trailing_slash_is_normalized(client, monkeypatch):
+    monkeypatch.setattr(config, "VAULT_MCP_PUBLIC_URL", PUBLIC + "/")
+    r = client.get("/.well-known/oauth-protected-resource", headers=SPOOF_HEADERS)
+    assert r.json()["resource"] == PUBLIC  # no doubled or trailing slash
+
+
+# --- Fallback preserved: unset public URL still uses the request base_url ------
+
+def test_falls_back_to_base_url_when_public_url_unset(client):
+    r = client.get("/.well-known/oauth-protected-resource", headers={"Host": "real.host"})
+    assert r.json()["resource"] == "http://real.host"
+
+
+# --- Proxy layer: uvicorn must not trust forwarded headers from any source ----
+
+def test_forwarded_allow_ips_default_is_not_wildcard():
+    """The uvicorn forwarded_allow_ips default must stay loopback-only so a remote
+    client cannot have its X-Forwarded-* headers honored (regression guard for the
+    `forwarded_allow_ips="*"` that made the advertised origin spoofable)."""
+    assert config.VAULT_MCP_FORWARDED_ALLOW_IPS != "*"
+    assert "127.0.0.1" in config.VAULT_MCP_FORWARDED_ALLOW_IPS


### PR DESCRIPTION
## Problem

`server.py` ran uvicorn with `proxy_headers=True, forwarded_allow_ips="*"`, which trusts `X-Forwarded-*` headers (including `X-Forwarded-Host` / `X-Forwarded-Proto`) from **any** source.

Because `request.base_url` is derived from those headers, every URL the server advertises from `base_url` is spoofable:

- `oauth.py` `oauth_metadata` — `issuer`, `authorization_endpoint`, `token_endpoint`, `registration_endpoint`
- `oauth.py` `oauth_protected_resource` — `resource`, `authorization_servers` (RFC 9728)
- `auth.py` `_www_authenticate` — the `WWW-Authenticate: Bearer ... resource_metadata="..."` header on 401s (added in #35)

An attacker who can reach the server could send `X-Forwarded-Host: evil.example` and make OAuth discovery advertise an attacker-controlled authorization server / resource URL — a token-redirection / phishing vector.

## Fix (two layers)

1. **Proxy layer.** `forwarded_allow_ips` now defaults to loopback (`127.0.0.1`) via the new `VAULT_MCP_FORWARDED_ALLOW_IPS`. The server binds loopback and is reached by Cloudflare Tunnel / Caddy over localhost, so loopback is the only trustworthy forwarder. **Never `*`.**
2. **App layer (defense in depth).** New optional `VAULT_MCP_PUBLIC_URL` pins the canonical origin for all three advertise sites; falls back to `request.base_url` when unset. Centralized in `config.advertised_base_url()`.

Both legitimate reverse-proxy paths keep working — Cloudflare Tunnel preserves the `Host` header, and Caddy connects from loopback so its `X-Forwarded-*` are still honored.

## Tests

`tests/test_forwarded_host.py` — a spoofed `Host` / `X-Forwarded-Host` does **not** change the advertised resource/authorization URLs (covers both OAuth metadata endpoints + the `WWW-Authenticate` challenge), the loopback-only `forwarded_allow_ips` default is asserted, and the unpinned `base_url` fallback is preserved.

```
uv run --with pytest --with pytest-asyncio pytest
57 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)