### PR TITLE
fix: honor context_lines consistently in vault_search (ripgrep vs Python)

### DIFF
--- a/src/obsidian_vault_mcp/config.py
+++ b/src/obsidian_vault_mcp/config.py
@@ -81,6 +81,7 @@ MAX_SEARCH_RESULTS = 50       # Max results per search
 DEFAULT_SEARCH_RESULTS = 20
 MAX_LIST_DEPTH = 5            # Max directory recursion depth
 CONTEXT_LINES = 2             # Default lines of context in search results
+MAX_SEARCH_REREAD_BYTES = MAX_CONTENT_SIZE  # Cap per-file context re-read in vault_search
 
 # Directories to never expose or modify
 EXCLUDED_DIRS = {".obsidian", ".trash", ".git", ".DS_Store"}

--- a/src/obsidian_vault_mcp/tools/search.py
+++ b/src/obsidian_vault_mcp/tools/search.py
@@ -3,6 +3,7 @@
 import base64
 import json
 import logging
+import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -65,6 +66,100 @@ def _assemble_context(
     return "\n".join(file_lines[start:end])
 
 
+def _open_in_vault_nofollow(vault_root: Path, rel_path: str) -> int:
+    """Open vault_root/rel_path for reading without following a symlink in any
+    path component below the (trusted, configured) vault root.
+
+    The matched path comes back from a separate ripgrep process and is opened in
+    a later syscall, so a single path-based open is a TOCTOU: a symlink swapped
+    into an intermediate component between a containment check and the open would
+    be followed. Here each component under the root is opened with O_NOFOLLOW
+    relative to its parent's directory fd (openat), so a symlink anywhere (final
+    or intermediate, even one swapped in concurrently) fails the open atomically
+    rather than being resolved by a racy path lookup. The configured root itself
+    is opened normally, since it is allowed to be a symlink (VAULT_PATH may point
+    at, e.g., a mounted volume).
+
+    Where openat/dir_fd is unavailable (e.g. Windows) this degrades to a single
+    O_NOFOLLOW open on the joined path, guarded by a (racy) resolved-path
+    containment check. Raises OSError on any refusal so the caller degrades to
+    ripgrep's matched line.
+    """
+    nofollow = getattr(os, "O_NOFOLLOW", 0)
+    directory = getattr(os, "O_DIRECTORY", 0)
+    parts = [p for p in Path(rel_path).parts if p not in ("", os.curdir)]
+
+    if os.open not in os.supports_dir_fd or not parts:
+        full = os.path.join(str(vault_root), rel_path)
+        resolved = os.path.realpath(full)
+        root = os.path.realpath(str(vault_root))
+        if resolved != root and not resolved.startswith(root + os.sep):
+            raise OSError("matched path resolves outside the vault")
+        return os.open(full, os.O_RDONLY | nofollow)
+
+    dir_fd = os.open(str(vault_root), os.O_RDONLY | directory)
+    try:
+        for part in parts[:-1]:
+            next_fd = os.open(part, os.O_RDONLY | nofollow | directory, dir_fd=dir_fd)
+            # Reassign before closing so an interrupted close (EINTR) leaves the
+            # finally clause closing the fd we actually still hold, not a stale one.
+            old_fd, dir_fd = dir_fd, next_fd
+            os.close(old_fd)
+        return os.open(parts[-1], os.O_RDONLY | nofollow, dir_fd=dir_fd)
+    finally:
+        os.close(dir_fd)
+
+
+def _read_vault_file_lines(rel_path: str) -> list[str] | None:
+    """Re-read a ripgrep-matched vault file for context, refusing unsafe reads.
+
+    rel_path is the match's path relative to the vault root (already validated as
+    lexically inside it by the caller). Returns the file's lines (per
+    _split_lines), or None if the file cannot be read safely, in which case the
+    caller degrades to ripgrep's matched line.
+
+    Two guards, because ripgrep reports the path from a separate process and we
+    open it later:
+      * Symlinks are never followed below the vault root (see
+        _open_in_vault_nofollow), so a matched note that is, or sits under, a
+        symlink pointing out of the vault cannot leak outside content, even if
+        the symlink is swapped in concurrently.
+      * The size cap bounds memory: the file is read in full to slice context, so
+        without a limit a few huge notes (or a broad query) could spike memory
+        despite the result cap. Oversized files degrade to the matched line.
+
+    Not caught here: a hardlink inside the vault to an outside file (a hardlink is
+    a real directory entry, indistinguishable from a normal file). That is a
+    pre-existing, vault-wide exposure shared with vault.read_file, not specific to
+    search.
+    """
+    try:
+        fd = _open_in_vault_nofollow(config.VAULT_PATH, rel_path)
+        try:
+            if os.fstat(fd).st_size > config.MAX_SEARCH_REREAD_BYTES:
+                raise OSError("matched file too large to re-read for context")
+            chunks = []
+            while True:
+                block = os.read(fd, 65536)
+                if not block:
+                    break
+                chunks.append(block)
+        finally:
+            os.close(fd)
+
+        # read_bytes-equivalent, not read_text: text mode translates lone "\r"
+        # to "\n", which would desync _split_lines from rg's line count.
+        return _split_lines(b"".join(chunks).decode("utf-8"))
+    except (OSError, UnicodeDecodeError, ValueError) as exc:
+        logger.warning(
+            "vault_search: could not safely re-read %s for context, "
+            "falling back to matched line only (%s)",
+            rel_path,
+            exc,
+        )
+        return None
+
+
 def _search_ripgrep(
     query: str,
     search_path: Path,
@@ -119,25 +214,18 @@ def _search_ripgrep(
             line_number = match_data["line_number"]
 
             if file_path not in file_lines_cache:
-                try:
-                    # read_bytes, not read_text: text mode translates lone "\r"
-                    # to "\n", which would desync _split_lines from rg's count.
-                    file_lines_cache[file_path] = _split_lines(
-                        Path(file_path).read_bytes().decode("utf-8")
-                    )
-                except (OSError, UnicodeDecodeError) as exc:
-                    logger.warning(
-                        "vault_search: could not re-read %s for context, "
-                        "falling back to matched line only (%s)",
-                        file_path,
-                        exc,
-                    )
-                    file_lines_cache[file_path] = None
+                file_lines_cache[file_path] = _read_vault_file_lines(rel_path)
 
             file_lines = file_lines_cache[file_path]
-            if file_lines is not None:
+            match_index = line_number - 1
+            # Degrade to ripgrep's matched line when the re-read was refused
+            # (file_lines is None) or when rg's line_number is past the file's
+            # current length -- a content race where the file shrank between rg's
+            # scan and the re-read -- which would otherwise slice to an empty
+            # snippet instead of the matched line.
+            if file_lines is not None and 0 <= match_index < len(file_lines):
                 match_context = _assemble_context(
-                    file_lines, line_number - 1, context_lines
+                    file_lines, match_index, context_lines
                 )
             else:
                 match_context = _rg_match_line(match_data)

--- a/src/obsidian_vault_mcp/tools/search.py
+++ b/src/obsidian_vault_mcp/tools/search.py
@@ -1,5 +1,6 @@
 """Search tools for the Obsidian vault MCP server."""
 
+import base64
 import json
 import logging
 import shutil
@@ -13,6 +14,55 @@ from ..serialization import dumps
 from ..vault import resolve_vault_path
 
 logger = logging.getLogger(__name__)
+
+
+def _split_lines(text: str) -> list[str]:
+    """Split text into lines the way ripgrep counts them: on "\\n" only.
+
+    Python's str.splitlines() also breaks on other separators (NEL, LINE and
+    PARAGRAPH SEPARATOR, vertical tab, form feed, lone carriage return), which
+    would desync the line index from ripgrep's "\\n"-based line_number. A
+    trailing carriage return is stripped per line so CRLF files read the same as
+    str.splitlines(), and a final empty element from a trailing newline is
+    dropped. Both backends use this so their line numbering stays identical.
+    """
+    lines = text.split("\n")
+    if lines and lines[-1] == "":
+        lines.pop()
+    return [line[:-1] if line.endswith("\r") else line for line in lines]
+
+
+def _rg_match_line(match_data: dict) -> str:
+    """Return ripgrep's matched line text, decoding base64 bytes if needed.
+
+    ripgrep emits "bytes" instead of "text" when the matched line is not valid
+    UTF-8; decode it lossily so the fallback never produces an empty snippet.
+    """
+    line = match_data["lines"]
+    text = line.get("text")
+    if text is None:
+        encoded = line.get("bytes")
+        text = (
+            base64.b64decode(encoded).decode("utf-8", errors="replace")
+            if encoded
+            else ""
+        )
+    return text.rstrip("\n")
+
+
+def _assemble_context(
+    file_lines: list[str], match_index: int, context_lines: int
+) -> str:
+    """Return the matched line plus up to context_lines lines on each side.
+
+    match_index is the 0-based index of the matched line. The slice is clamped
+    at the file boundaries. Both search backends share this helper so they
+    produce identical match_context for the same query, except when the ripgrep
+    backend cannot re-read a matched file and degrades to the matched line only.
+    """
+    start = max(0, match_index - context_lines)
+    end = min(len(file_lines), match_index + context_lines + 1)
+    return "\n".join(file_lines[start:end])
 
 
 def _search_ripgrep(
@@ -29,7 +79,6 @@ def _search_ripgrep(
         f"--max-count={max_results}",
         f"--glob={file_pattern}",
         "-i",
-        f"--context={context_lines}",
     ]
 
     for excluded in config.EXCLUDED_DIRS:
@@ -48,7 +97,10 @@ def _search_ripgrep(
         return []
 
     matches = []
-    current_match = None
+    # Cache each matched file's lines so multiple matches in one file read it
+    # once. None means the file could not be re-read; in that case we degrade to
+    # the matched line that ripgrep already gave us, with no surrounding context.
+    file_lines_cache: dict[str, list[str] | None] = {}
 
     for line in result.stdout.splitlines():
         try:
@@ -65,12 +117,35 @@ def _search_ripgrep(
                 continue
 
             line_number = match_data["line_number"]
-            line_text = match_data["lines"]["text"].rstrip("\n")
+
+            if file_path not in file_lines_cache:
+                try:
+                    # read_bytes, not read_text: text mode translates lone "\r"
+                    # to "\n", which would desync _split_lines from rg's count.
+                    file_lines_cache[file_path] = _split_lines(
+                        Path(file_path).read_bytes().decode("utf-8")
+                    )
+                except (OSError, UnicodeDecodeError) as exc:
+                    logger.warning(
+                        "vault_search: could not re-read %s for context, "
+                        "falling back to matched line only (%s)",
+                        file_path,
+                        exc,
+                    )
+                    file_lines_cache[file_path] = None
+
+            file_lines = file_lines_cache[file_path]
+            if file_lines is not None:
+                match_context = _assemble_context(
+                    file_lines, line_number - 1, context_lines
+                )
+            else:
+                match_context = _rg_match_line(match_data)
 
             matches.append({
                 "path": rel_path,
                 "line_number": line_number,
-                "match_context": line_text,
+                "match_context": match_context,
             })
 
             if len(matches) >= max_results:
@@ -103,17 +178,15 @@ def _search_python(
             continue
 
         try:
-            content = file_path.read_text(encoding="utf-8")
-        except (UnicodeDecodeError, PermissionError):
+            # read_bytes, not read_text: avoid universal-newline translation so
+            # _split_lines counts lines the same way as the ripgrep backend.
+            content = file_path.read_bytes().decode("utf-8")
+        except (OSError, UnicodeDecodeError):
             continue
 
-        lines = content.splitlines()
+        lines = _split_lines(content)
         for i, line in enumerate(lines):
             if query_lower in line.lower():
-                start = max(0, i - context_lines)
-                end = min(len(lines), i + context_lines + 1)
-                context = "\n".join(lines[start:end])
-
                 try:
                     rel_path = str(file_path.relative_to(config.VAULT_PATH))
                 except ValueError:
@@ -122,7 +195,7 @@ def _search_python(
                 matches.append({
                     "path": rel_path,
                     "line_number": i + 1,
-                    "match_context": context,
+                    "match_context": _assemble_context(lines, i, context_lines),
                 })
 
                 if len(matches) >= max_results:

--- a/src/obsidian_vault_mcp/tools/search.py
+++ b/src/obsidian_vault_mcp/tools/search.py
@@ -8,6 +8,11 @@ import shutil
 import subprocess
 from pathlib import Path
 
+try:
+    import fcntl  # POSIX only; used for the fd->path re-validation below
+except ImportError:  # pragma: no cover - Windows
+    fcntl = None
+
 import frontmatter
 
 from .. import config
@@ -110,34 +115,68 @@ def _open_in_vault_nofollow(vault_root: Path, rel_path: str) -> int:
         os.close(dir_fd)
 
 
-def _read_vault_file_lines(rel_path: str) -> list[str] | None:
-    """Re-read a ripgrep-matched vault file for context, refusing unsafe reads.
+def _fd_resolves_inside_vault(fd: int, vault_root: Path) -> bool:
+    """Re-validate that an opened fd refers to a path inside the vault root.
 
-    rel_path is the match's path relative to the vault root (already validated as
-    lexically inside it by the caller). Returns the file's lines (per
-    _split_lines), or None if the file cannot be read safely, in which case the
-    caller degrades to ripgrep's matched line.
-
-    Two guards, because ripgrep reports the path from a separate process and we
-    open it later:
-      * Symlinks are never followed below the vault root (see
-        _open_in_vault_nofollow), so a matched note that is, or sits under, a
-        symlink pointing out of the vault cannot leak outside content, even if
-        the symlink is swapped in concurrently.
-      * The size cap bounds memory: the file is read in full to slice context, so
-        without a limit a few huge notes (or a broad query) could spike memory
-        despite the result cap. Oversized files degrade to the matched line.
-
-    Not caught here: a hardlink inside the vault to an outside file (a hardlink is
-    a real directory entry, indistinguishable from a normal file). That is a
-    pre-existing, vault-wide exposure shared with vault.read_file, not specific to
-    search.
+    Independent of the name used to open it, via the OS fd->path facility
+    (F_GETPATH on macOS, /proc/self/fd on Linux). This is defense in depth behind
+    the openat O_NOFOLLOW walk: if neither facility exists the openat chain and
+    the resolve_vault_path gate are already the guarantee, so this returns True
+    rather than failing closed where it cannot look the path up.
     """
+    real = None
+    if fcntl is not None and hasattr(fcntl, "F_GETPATH"):
+        try:
+            buf = fcntl.fcntl(fd, fcntl.F_GETPATH, b"\x00" * 1024)
+            real = os.fsdecode(buf.split(b"\x00", 1)[0])
+        except OSError:
+            real = None
+    if real is None:
+        try:
+            real = os.readlink(f"/proc/self/fd/{fd}")
+        except OSError:
+            return True  # no fd->path lookup on this platform; rely on openat + gate
+    real = os.path.realpath(real)
+    root = os.path.realpath(str(vault_root))
+    return real == root or real.startswith(root + os.sep)
+
+
+def _safe_read_vault_bytes(rel_path: str, *, max_bytes: int | None = None) -> bytes | None:
+    """Read a vault file's bytes, refusing unsafe reads (fail closed -> None).
+
+    Shared by every path that reads a vault file off a name reported elsewhere:
+    the ripgrep context re-read, the Python search fallback, and the per-result
+    frontmatter excerpt. Guards, in order:
+      * lexical: resolve_vault_path rejects null bytes, dotfile components, ".."
+        traversal, and any target that resolves outside the vault root. openat
+        with O_NOFOLLOW does NOT stop a ".." component (a real directory entry
+        that walks up out of the vault), so this gate is what closes that escape.
+      * symlink: each component below the root is opened O_NOFOLLOW via openat
+        (see _open_in_vault_nofollow), so a symlink anywhere (final or
+        intermediate, even swapped in concurrently) is refused, not followed.
+      * resolved target: the opened fd is re-validated as inside the vault via
+        the OS fd->path facility (see _fd_resolves_inside_vault), defense in
+        depth behind the openat walk.
+      * hardlink: a file with st_nlink > 1 is refused, because an in-vault
+        hardlink to an outside file is a real directory entry the path and
+        symlink checks cannot tell from a normal note (issue #53). Legitimate
+        in-vault hardlinks are unsupported as a result.
+      * size: when max_bytes is set, a larger file is refused to bound memory.
+    """
+    try:
+        resolve_vault_path(rel_path)
+    except ValueError:
+        return None
     try:
         fd = _open_in_vault_nofollow(config.VAULT_PATH, rel_path)
         try:
-            if os.fstat(fd).st_size > config.MAX_SEARCH_REREAD_BYTES:
-                raise OSError("matched file too large to re-read for context")
+            if not _fd_resolves_inside_vault(fd, config.VAULT_PATH):
+                raise OSError("opened file resolves outside the vault")
+            st = os.fstat(fd)
+            if st.st_nlink > 1:
+                raise OSError("refusing hardlinked file; in-vault hardlinks unsupported")
+            if max_bytes is not None and st.st_size > max_bytes:
+                raise OSError("file too large to read safely")
             chunks = []
             while True:
                 block = os.read(fd, 65536)
@@ -146,17 +185,29 @@ def _read_vault_file_lines(rel_path: str) -> list[str] | None:
                 chunks.append(block)
         finally:
             os.close(fd)
+        return b"".join(chunks)
+    except OSError as exc:
+        logger.warning("vault_search: refusing unsafe read of %s (%s)", rel_path, exc)
+        return None
 
+
+def _read_vault_file_lines(rel_path: str) -> list[str] | None:
+    """Re-read a ripgrep-matched vault file for context, refusing unsafe reads.
+
+    rel_path is the match's path relative to the vault root. Returns the file's
+    lines (per _split_lines), or None if the file cannot be read safely, in which
+    case the caller degrades to ripgrep's matched line. See _safe_read_vault_bytes
+    for the symlink / parent-traversal / hardlink guards; the size cap matters
+    here because the whole file is read to slice context.
+    """
+    raw = _safe_read_vault_bytes(rel_path, max_bytes=config.MAX_SEARCH_REREAD_BYTES)
+    if raw is None:
+        return None
+    try:
         # read_bytes-equivalent, not read_text: text mode translates lone "\r"
         # to "\n", which would desync _split_lines from rg's line count.
-        return _split_lines(b"".join(chunks).decode("utf-8"))
-    except (OSError, UnicodeDecodeError, ValueError) as exc:
-        logger.warning(
-            "vault_search: could not safely re-read %s for context, "
-            "falling back to matched line only (%s)",
-            rel_path,
-            exc,
-        )
+        return _split_lines(raw.decode("utf-8"))
+    except (UnicodeDecodeError, ValueError):
         return None
 
 
@@ -266,20 +317,28 @@ def _search_python(
             continue
 
         try:
+            rel_path = str(file_path.relative_to(config.VAULT_PATH))
+        except ValueError:
+            continue
+
+        # Same safe-read as the ripgrep backend: refuse a symlink out of the
+        # vault and an in-vault hardlink to an outside file, so the fallback
+        # cannot leak content the ripgrep path would not. No size cap here:
+        # unlike the context re-read this read IS the search, and capping it
+        # would silently drop matches in large files.
+        raw = _safe_read_vault_bytes(rel_path)
+        if raw is None:
+            continue
+        try:
             # read_bytes, not read_text: avoid universal-newline translation so
             # _split_lines counts lines the same way as the ripgrep backend.
-            content = file_path.read_bytes().decode("utf-8")
-        except (OSError, UnicodeDecodeError):
+            content = raw.decode("utf-8")
+        except UnicodeDecodeError:
             continue
 
         lines = _split_lines(content)
         for i, line in enumerate(lines):
             if query_lower in line.lower():
-                try:
-                    rel_path = str(file_path.relative_to(config.VAULT_PATH))
-                except ValueError:
-                    continue
-
                 matches.append({
                     "path": rel_path,
                     "line_number": i + 1,
@@ -293,10 +352,21 @@ def _search_python(
 
 
 def _get_frontmatter_excerpt(file_path: Path, max_keys: int = 3) -> dict | None:
-    """Read frontmatter from a file, returning first N key-value pairs."""
+    """Read frontmatter from a vault file, returning first N key-value pairs.
+
+    Uses the same safe-read as the search backends (see _safe_read_vault_bytes)
+    so attaching an excerpt to a result cannot follow a symlink out of the vault
+    or read an in-vault hardlink to an outside file (issue #53).
+    """
     try:
-        content = file_path.read_text(encoding="utf-8")
-        post = frontmatter.loads(content)
+        rel_path = str(file_path.relative_to(config.VAULT_PATH))
+    except ValueError:
+        return None
+    raw = _safe_read_vault_bytes(rel_path, max_bytes=config.MAX_SEARCH_REREAD_BYTES)
+    if raw is None:
+        return None
+    try:
+        post = frontmatter.loads(raw.decode("utf-8"))
         if not post.metadata:
             return None
         keys = list(post.metadata.keys())[:max_keys]

--- a/src/obsidian_vault_mcp/vault.py
+++ b/src/obsidian_vault_mcp/vault.py
@@ -52,6 +52,14 @@ def read_file(relative_path: str) -> tuple[str, dict]:
         raise FileNotFoundError(f"Not a file: {relative_path}")
 
     stat = path.stat()
+    # A hardlink inside the vault to a file outside it is a real directory entry
+    # that resolve_vault_path's containment check cannot catch (there is no link
+    # to follow), so reading it would leak outside content. Refuse any file with
+    # extra links, fail closed; legitimate in-vault hardlinks are unsupported.
+    if stat.st_nlink > 1:
+        raise ValueError(
+            "Refusing to read a hardlinked file; in-vault hardlinks are not supported"
+        )
     content = path.read_text(encoding="utf-8")
 
     metadata = {

--- a/tests/test_search_context.py
+++ b/tests/test_search_context.py
@@ -1,0 +1,249 @@
+"""Tests for vault_search context_lines behavior across both search backends.
+
+Regression coverage for the bug where the ripgrep backend passed --context to
+rg but discarded the resulting context events, so context_lines was a no-op on
+the ripgrep path while the Python fallback honored it. The two backends must
+return identical match_context for the same query.
+"""
+
+import json
+import shutil
+
+import pytest
+
+import obsidian_vault_mcp.tools.search as search_mod
+from obsidian_vault_mcp.tools.search import vault_search
+
+RG_AVAILABLE = shutil.which("rg") is not None
+requires_rg = pytest.mark.skipif(not RG_AVAILABLE, reason="ripgrep not installed")
+
+# A file with a known, stable line layout so we can assert exact slices.
+SAMPLE = (
+    "alpha one\n"
+    "beta two\n"
+    "TARGET middle\n"
+    "gamma four\n"
+    "delta five\n"
+)
+
+
+def _force_backend(monkeypatch, backend):
+    """Force vault_search down a specific backend by faking shutil.which.
+
+    vault_search only uses shutil.which("rg") as a truthiness check to choose a
+    backend; _search_ripgrep then runs the bare "rg" command resolved from PATH.
+    So the faked return value only needs to be falsy (Python) or truthy
+    (ripgrep), not a real binary path.
+    """
+    if backend == "python":
+        monkeypatch.setattr(search_mod.shutil, "which", lambda _name: None)
+    elif backend == "ripgrep":
+        monkeypatch.setattr(search_mod.shutil, "which", lambda _name: "rg")
+    else:
+        raise ValueError(backend)
+
+
+def _search(monkeypatch, backend, vault_dir, query, **kwargs):
+    (vault_dir / "sample.md").write_text(SAMPLE)
+    _force_backend(monkeypatch, backend)
+    result = json.loads(vault_search(query, file_pattern="sample.md", **kwargs))
+    return result["results"]
+
+
+@requires_rg
+def test_ripgrep_honors_context_lines(monkeypatch, vault_dir):
+    results = _search(monkeypatch, "ripgrep", vault_dir, "TARGET", context_lines=1)
+    assert len(results) == 1
+    assert results[0]["match_context"] == "beta two\nTARGET middle\ngamma four"
+
+
+def test_python_honors_context_lines(monkeypatch, vault_dir):
+    results = _search(monkeypatch, "python", vault_dir, "TARGET", context_lines=1)
+    assert len(results) == 1
+    assert results[0]["match_context"] == "beta two\nTARGET middle\ngamma four"
+
+
+@requires_rg
+def test_backends_produce_identical_context(monkeypatch, vault_dir):
+    rg = _search(monkeypatch, "ripgrep", vault_dir, "TARGET", context_lines=2)
+    py = _search(monkeypatch, "python", vault_dir, "TARGET", context_lines=2)
+    assert [m["match_context"] for m in rg] == [m["match_context"] for m in py]
+    assert rg[0]["match_context"] == (
+        "alpha one\nbeta two\nTARGET middle\ngamma four\ndelta five"
+    )
+
+
+@requires_rg
+def test_ripgrep_context_lines_zero_returns_only_match(monkeypatch, vault_dir):
+    results = _search(monkeypatch, "ripgrep", vault_dir, "TARGET", context_lines=0)
+    assert results[0]["match_context"] == "TARGET middle"
+
+
+@requires_rg
+def test_ripgrep_context_clamps_at_first_line(monkeypatch, vault_dir):
+    results = _search(monkeypatch, "ripgrep", vault_dir, "alpha", context_lines=2)
+    assert results[0]["match_context"] == "alpha one\nbeta two\nTARGET middle"
+
+
+@requires_rg
+def test_ripgrep_context_clamps_at_last_line(monkeypatch, vault_dir):
+    results = _search(monkeypatch, "ripgrep", vault_dir, "delta", context_lines=2)
+    assert results[0]["match_context"] == "TARGET middle\ngamma four\ndelta five"
+
+
+@requires_rg
+def test_ripgrep_multiple_matches_in_one_file(monkeypatch, vault_dir):
+    """Two matches in the same file must each get their own correct context
+    (exercises the per-file read cache)."""
+    (vault_dir / "multi.md").write_text(
+        "intro\nhit one\nmid\nhit two\nend\n"
+    )
+    _force_backend(monkeypatch, "ripgrep")
+    results = json.loads(
+        vault_search("hit", file_pattern="multi.md", context_lines=1)
+    )["results"]
+    assert len(results) == 2
+    assert results[0]["match_context"] == "intro\nhit one\nmid"
+    assert results[1]["match_context"] == "mid\nhit two\nend"
+
+
+@requires_rg
+def test_ripgrep_falls_back_to_match_line_when_reread_fails(monkeypatch, vault_dir):
+    """If the matched file cannot be re-read, the ripgrep backend degrades to
+    the matched line itself, not an empty string."""
+    (vault_dir / "sample.md").write_text(SAMPLE)
+    _force_backend(monkeypatch, "ripgrep")
+
+    from pathlib import Path
+
+    real_read_bytes = Path.read_bytes
+
+    def failing_read_bytes(self, *args, **kwargs):
+        if self.name == "sample.md":
+            raise OSError("simulated read failure")
+        return real_read_bytes(self, *args, **kwargs)
+
+    monkeypatch.setattr(
+        "obsidian_vault_mcp.tools.search.Path.read_bytes", failing_read_bytes
+    )
+
+    results = json.loads(
+        vault_search("delta", file_pattern="sample.md", context_lines=2)
+    )["results"]
+    assert len(results) == 1
+    assert results[0]["match_context"] == "delta five"
+
+
+@requires_rg
+def test_backends_agree_on_count_and_truncated_across_files(monkeypatch, vault_dir):
+    """rg's --max-count is per-file, but the global result cap is enforced by
+    the loop break, so both backends report the same total_matches and
+    truncated flag for a multi-file search that exceeds max_results."""
+    (vault_dir / "a.md").write_text("hit a0\nhit a1\nhit a2\n")
+    (vault_dir / "b.md").write_text(
+        "\n".join(f"hit b{i}" for i in range(10)) + "\n"
+    )
+
+    def run(backend):
+        _force_backend(monkeypatch, backend)
+        return json.loads(vault_search("hit", file_pattern="*.md", max_results=5))
+
+    rg = run("ripgrep")
+    py = run("python")
+    assert rg["total_matches"] == py["total_matches"] == 5
+    assert rg["truncated"] is py["truncated"] is True
+
+
+@requires_rg
+def test_backends_agree_on_unicode_line_separators(monkeypatch, vault_dir):
+    """U+2028 is a line break for str.splitlines() but ripgrep counts lines by
+    \\n only. Re-reading with splitlines() would desync the index from rg's
+    line_number; both backends must still center the matched line and agree."""
+    (vault_dir / "u.md").write_text(
+        "alpha\u2028beta\nTARGET line\ngamma\ndelta\n"
+    )
+
+    def run(backend):
+        _force_backend(monkeypatch, backend)
+        return json.loads(
+            vault_search("TARGET", file_pattern="u.md", context_lines=1)
+        )["results"]
+
+    rg = run("ripgrep")
+    py = run("python")
+    assert len(rg) == 1
+    assert rg[0]["match_context"] == "alpha\u2028beta\nTARGET line\ngamma"
+    assert rg[0]["match_context"] == py[0]["match_context"]
+
+
+@requires_rg
+def test_backends_agree_on_lone_carriage_return(monkeypatch, vault_dir):
+    """A bare \\r is not a line break for ripgrep (it counts \\n only). The
+    re-read must not let universal-newline translation turn it into one, or the
+    index would desync from rg's line_number."""
+    (vault_dir / "cr.md").write_bytes(
+        b"a\rb\nTARGET line\ngamma\ndelta\n"
+    )
+
+    def run(backend):
+        _force_backend(monkeypatch, backend)
+        return json.loads(
+            vault_search("TARGET", file_pattern="cr.md", context_lines=1)
+        )["results"]
+
+    rg = run("ripgrep")
+    py = run("python")
+    assert len(rg) == 1
+    assert rg[0]["match_context"] == "a\rb\nTARGET line\ngamma"
+    assert rg[0]["match_context"] == py[0]["match_context"]
+
+
+@requires_rg
+def test_backends_agree_on_crlf(monkeypatch, vault_dir):
+    """CRLF files: the trailing \\r is stripped so snippets match str.splitlines
+    output, and both backends agree."""
+    (vault_dir / "crlf.md").write_bytes(
+        b"alpha\r\nTARGET line\r\ngamma\r\n"
+    )
+
+    def run(backend):
+        _force_backend(monkeypatch, backend)
+        return json.loads(
+            vault_search("TARGET", file_pattern="crlf.md", context_lines=1)
+        )["results"]
+
+    rg = run("ripgrep")
+    py = run("python")
+    assert len(rg) == 1
+    assert "\r" not in rg[0]["match_context"]
+    assert rg[0]["match_context"] == "alpha\nTARGET line\ngamma"
+    assert rg[0]["match_context"] == py[0]["match_context"]
+
+
+@requires_rg
+def test_ripgrep_non_utf8_match_is_not_empty(monkeypatch, vault_dir):
+    """When ripgrep matches a line with invalid UTF-8 (emitted as base64 bytes,
+    not text) and the whole-file re-read fails to decode, the match_context
+    must still carry the matched line, not collapse to an empty string."""
+    (vault_dir / "bin.md").write_bytes(
+        b"intro line\ncaf\xe9 latte\nmore text\n"
+    )
+    _force_backend(monkeypatch, "ripgrep")
+    results = json.loads(
+        vault_search("latte", file_pattern="bin.md", context_lines=0)
+    )["results"]
+    assert len(results) == 1
+    assert results[0]["match_context"] != ""
+    assert "latte" in results[0]["match_context"]
+
+
+def test_default_context_lines_is_two(monkeypatch, vault_dir):
+    """Callers that omit context_lines get a two-line window on each side."""
+    (vault_dir / "sample.md").write_text(SAMPLE)
+    _force_backend(monkeypatch, "python")
+    results = json.loads(
+        vault_search("TARGET", file_pattern="sample.md")
+    )["results"]
+    assert results[0]["match_context"] == (
+        "alpha one\nbeta two\nTARGET middle\ngamma four\ndelta five"
+    )

--- a/tests/test_search_context.py
+++ b/tests/test_search_context.py
@@ -431,3 +431,135 @@ def test_ripgrep_stale_line_number_degrades_to_matched_line(monkeypatch, vault_d
     )
     assert len(results) == 1
     assert results[0]["match_context"] == "the matched line"
+
+
+# --- context re-read: parent-traversal and hardlink refusal (#39 / #53) --------
+#
+# openat O_NOFOLLOW refuses symlinks but not ".." (a real directory entry that
+# walks up out of the vault), and it cannot distinguish an in-vault hardlink to
+# an outside file from a normal note. Both re-read targets must be refused; every
+# vault read path (ripgrep re-read, Python fallback, frontmatter excerpt) is
+# hardened the same way and degrades fail-closed.
+
+
+def test_reread_refuses_parent_directory_traversal(vault_dir, tmp_path):
+    """A re-read target that escapes via '..' is refused (gated through
+    resolve_vault_path), since O_NOFOLLOW does not stop a '..' component."""
+    secret = tmp_path / "secret.md"  # sibling of vault_dir (tmp_path/test-vault)
+    secret.write_text("SECRET x\nSECRET y\n")
+    assert search_mod._read_vault_file_lines("../secret.md") is None
+
+
+def test_reread_refuses_hardlink_to_outside_file(vault_dir, tmp_path):
+    """An in-vault hardlink to an outside file (st_nlink > 1) is refused fail-closed
+    so context cannot widen a hardlink leak. (issue #53)"""
+    secret = tmp_path / "secret.txt"
+    secret.write_text("SECRET 0\nSECRET 1\nSECRET 2\n")
+    os.link(secret, vault_dir / "evil.md")  # st_nlink == 2, same inode
+    assert search_mod._read_vault_file_lines("evil.md") is None
+
+
+def test_reread_reads_normal_single_link_file(vault_dir):
+    """A normal note (st_nlink == 1) is still read; the hardlink guard must not
+    refuse ordinary files."""
+    (vault_dir / "plain.md").write_text("a\nb\nc\n")
+    assert search_mod._read_vault_file_lines("plain.md") == ["a", "b", "c"]
+
+
+def test_ripgrep_reread_refuses_hardlinked_match(monkeypatch, vault_dir, tmp_path):
+    """End-to-end: a hardlinked match degrades to rg's matched line, no context leak."""
+    secret = tmp_path / "secret.txt"
+    secret.write_text("SECRET above\nSECRET hit\nSECRET below\n")
+    os.link(secret, vault_dir / "evil.md")
+    monkeypatch.setattr(
+        search_mod.subprocess,
+        "run",
+        lambda *a, **k: SimpleNamespace(
+            stdout=_rg_match_json(vault_dir / "evil.md", 2, "decoy match\n")
+        ),
+    )
+    results = search_mod._search_ripgrep(
+        "x", vault_dir, file_pattern="*.md", max_results=10, context_lines=2
+    )
+    assert len(results) == 1
+    ctx = results[0]["match_context"]
+    assert "SECRET" not in ctx, f"hardlink re-read leaked outside content: {ctx}"
+    assert ctx == "decoy match"
+
+
+def test_python_backend_does_not_follow_symlink_to_outside(monkeypatch, vault_dir, tmp_path):
+    """The Python fallback re-reads matched files too; it must not follow a symlink
+    out of the vault."""
+    secret = tmp_path / "secret.txt"
+    secret.write_text("SECRET alpha\n")
+    (vault_dir / "evil.md").symlink_to(secret)
+    _force_backend(monkeypatch, "python")
+    results = json.loads(vault_search("SECRET", file_pattern="*.md"))["results"]
+    assert all(r["path"] != "evil.md" for r in results)
+    assert all("SECRET" not in r["match_context"] for r in results)
+
+
+def test_python_backend_refuses_hardlink_to_outside(monkeypatch, vault_dir, tmp_path):
+    """The Python fallback refuses an in-vault hardlink to an outside file (#53)."""
+    secret = tmp_path / "secret.txt"
+    secret.write_text("SECRET beta\n")
+    os.link(secret, vault_dir / "evil.md")
+    _force_backend(monkeypatch, "python")
+    results = json.loads(vault_search("SECRET", file_pattern="*.md"))["results"]
+    assert all(r["path"] != "evil.md" for r in results)
+    assert all("SECRET" not in r["match_context"] for r in results)
+
+
+def test_frontmatter_excerpt_refuses_symlink_to_outside(vault_dir, tmp_path):
+    """The per-result frontmatter excerpt must not follow a symlink out of the vault."""
+    secret = tmp_path / "secret.md"
+    secret.write_text("---\nsecret_key: leaked\n---\nbody\n")
+    (vault_dir / "evil.md").symlink_to(secret)
+    assert search_mod._get_frontmatter_excerpt(vault_dir / "evil.md") is None
+
+
+def test_frontmatter_excerpt_refuses_hardlink_to_outside(vault_dir, tmp_path):
+    """The frontmatter excerpt refuses an in-vault hardlink to an outside file (#53)."""
+    secret = tmp_path / "secret.md"
+    secret.write_text("---\nsecret_key: leaked\n---\nbody\n")
+    os.link(secret, vault_dir / "evil.md")
+    assert search_mod._get_frontmatter_excerpt(vault_dir / "evil.md") is None
+
+
+def test_frontmatter_excerpt_reads_normal_file(vault_dir):
+    """A normal note's frontmatter is still returned; the guards must not refuse it."""
+    (vault_dir / "fm.md").write_text("---\ntitle: Hello\n---\nbody\n")
+    assert search_mod._get_frontmatter_excerpt(vault_dir / "fm.md") == {"title": "Hello"}
+
+
+# --- explicit resolved-target re-validation of the opened fd -------------------
+
+_HAS_FD_PATH = hasattr(__import__("fcntl"), "F_GETPATH") or os.path.exists("/proc/self/fd")
+requires_fd_path = pytest.mark.skipif(
+    not _HAS_FD_PATH, reason="no fd->path facility (F_GETPATH / /proc/self/fd)"
+)
+
+
+@requires_fd_path
+def test_fd_resolves_inside_vault_accepts_in_vault_file(vault_dir):
+    """An fd for a real in-vault file re-validates as inside the vault root."""
+    inside = vault_dir / "inside.md"
+    inside.write_text("x")
+    fd = os.open(str(inside), os.O_RDONLY)
+    try:
+        assert search_mod._fd_resolves_inside_vault(fd, vault_dir) is True
+    finally:
+        os.close(fd)
+
+
+@requires_fd_path
+def test_fd_resolves_inside_vault_rejects_outside_file(vault_dir, tmp_path):
+    """An fd for a file outside the vault re-validates as outside (defense in depth
+    behind the openat O_NOFOLLOW walk)."""
+    outside = tmp_path / "outside.txt"  # tmp_path is the parent of vault_dir
+    outside.write_text("y")
+    fd = os.open(str(outside), os.O_RDONLY)
+    try:
+        assert search_mod._fd_resolves_inside_vault(fd, vault_dir) is False
+    finally:
+        os.close(fd)

--- a/tests/test_search_context.py
+++ b/tests/test_search_context.py
@@ -7,7 +7,9 @@ return identical match_context for the same query.
 """
 
 import json
+import os
 import shutil
+from types import SimpleNamespace
 
 import pytest
 
@@ -16,6 +18,27 @@ from obsidian_vault_mcp.tools.search import vault_search
 
 RG_AVAILABLE = shutil.which("rg") is not None
 requires_rg = pytest.mark.skipif(not RG_AVAILABLE, reason="ripgrep not installed")
+
+
+def _rg_match_json(path, line_number, text):
+    """One ripgrep --json "match" event line, as _search_ripgrep parses it.
+
+    Used by the re-read hardening tests to make ripgrep "report" a chosen path
+    (e.g. a symlink) without the real binary, which never follows symlinks.
+    """
+    return (
+        json.dumps(
+            {
+                "type": "match",
+                "data": {
+                    "path": {"text": str(path)},
+                    "line_number": line_number,
+                    "lines": {"text": text},
+                },
+            }
+        )
+        + "\n"
+    )
 
 # A file with a known, stable line layout so we can assert exact slices.
 SAMPLE = (
@@ -114,18 +137,14 @@ def test_ripgrep_falls_back_to_match_line_when_reread_fails(monkeypatch, vault_d
     (vault_dir / "sample.md").write_text(SAMPLE)
     _force_backend(monkeypatch, "ripgrep")
 
-    from pathlib import Path
+    real_open = os.open
 
-    real_read_bytes = Path.read_bytes
-
-    def failing_read_bytes(self, *args, **kwargs):
-        if self.name == "sample.md":
+    def failing_open(path, flags, *args, **kwargs):
+        if str(path).endswith("sample.md"):
             raise OSError("simulated read failure")
-        return real_read_bytes(self, *args, **kwargs)
+        return real_open(path, flags, *args, **kwargs)
 
-    monkeypatch.setattr(
-        "obsidian_vault_mcp.tools.search.Path.read_bytes", failing_read_bytes
-    )
+    monkeypatch.setattr(search_mod.os, "open", failing_open)
 
     results = json.loads(
         vault_search("delta", file_pattern="sample.md", context_lines=2)
@@ -247,3 +266,168 @@ def test_default_context_lines_is_two(monkeypatch, vault_dir):
     assert results[0]["match_context"] == (
         "alpha one\nbeta two\nTARGET middle\ngamma four\ndelta five"
     )
+
+
+# --- context re-read hardening (symlink safety + memory bound) -----------------
+#
+# The ripgrep backend re-reads each matched file to assemble context. The path
+# comes back from a separate ripgrep process and the file is opened in a second
+# syscall, so the re-read must not (a) follow a symlink out of the vault, nor
+# (b) read an unbounded amount into memory. ripgrep itself never follows
+# symlinks, so these tests feed _search_ripgrep a crafted match event to stand
+# in for a path that became unsafe between the scan and the re-read.
+
+
+def test_ripgrep_reread_does_not_follow_symlink_to_outside_file(
+    monkeypatch, vault_dir, tmp_path
+):
+    """A matched path that is itself a symlink pointing out of the vault (e.g. a
+    note swapped for a symlink between rg's scan and the re-read) must not leak
+    the target's contents; the backend degrades to rg's matched line."""
+    secret = tmp_path / "secret.txt"
+    secret.write_text("SECRET 0\nSECRET 1\nSECRET 2\n")
+    evil = vault_dir / "evil.md"
+    evil.symlink_to(secret)
+
+    monkeypatch.setattr(
+        search_mod.subprocess,
+        "run",
+        lambda *a, **k: SimpleNamespace(stdout=_rg_match_json(evil, 2, "decoy match\n")),
+    )
+
+    results = search_mod._search_ripgrep(
+        "x", vault_dir, file_pattern="*.md", max_results=10, context_lines=2
+    )
+    assert len(results) == 1
+    ctx = results[0]["match_context"]
+    assert "SECRET" not in ctx, f"symlink re-read leaked outside content: {ctx}"
+    assert ctx == "decoy match"
+
+
+def test_ripgrep_reread_rejects_match_under_symlinked_parent(
+    monkeypatch, vault_dir, tmp_path
+):
+    """A match reached through a symlinked parent directory must be refused. The
+    re-read walks each component with O_NOFOLLOW relative to its parent's dir fd,
+    so a symlinked intermediate directory fails the open; the no-dir_fd fallback
+    catches the same case with its resolved-path containment check."""
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "secret.md").write_text("SECRET a\nSECRET b\nSECRET c\n")
+    link_dir = vault_dir / "linkdir"
+    link_dir.symlink_to(outside, target_is_directory=True)
+    target = link_dir / "secret.md"  # under vault lexically, outside once resolved
+
+    monkeypatch.setattr(
+        search_mod.subprocess,
+        "run",
+        lambda *a, **k: SimpleNamespace(
+            stdout=_rg_match_json(target, 2, "decoy match\n")
+        ),
+    )
+
+    results = search_mod._search_ripgrep(
+        "x", vault_dir, file_pattern="*.md", max_results=10, context_lines=2
+    )
+    assert len(results) == 1
+    ctx = results[0]["match_context"]
+    assert "SECRET" not in ctx, f"symlinked-parent re-read leaked: {ctx}"
+    assert ctx == "decoy match"
+
+
+def test_ripgrep_oversized_file_degrades_to_matched_line(monkeypatch, vault_dir):
+    """A matched file larger than the re-read cap is not read in full (which
+    bounds memory); the backend degrades to rg's matched line with no context.
+
+    Faked subprocess.run so the memory-bound case is covered even with no rg on
+    PATH; the line below the TARGET would appear as context if the file were
+    read, so its absence proves the cap forced the degrade."""
+    monkeypatch.setattr(search_mod.config, "MAX_SEARCH_REREAD_BYTES", 64)
+    big = vault_dir / "big.md"
+    big.write_text("pad line\n" * 50 + "TARGET line\n" + "pad line\n" * 50)
+
+    monkeypatch.setattr(
+        search_mod.subprocess,
+        "run",
+        lambda *a, **k: SimpleNamespace(stdout=_rg_match_json(big, 51, "TARGET line\n")),
+    )
+
+    results = search_mod._search_ripgrep(
+        "TARGET", vault_dir, file_pattern="big.md", max_results=10, context_lines=3
+    )
+    assert len(results) == 1
+    assert results[0]["match_context"] == "TARGET line"
+
+
+@requires_rg
+def test_ripgrep_oversized_file_degrades_to_matched_line_real_rg(monkeypatch, vault_dir):
+    """Same memory-bound behavior, exercised through the real ripgrep binary."""
+    monkeypatch.setattr(search_mod.config, "MAX_SEARCH_REREAD_BYTES", 64)
+    (vault_dir / "big.md").write_text(
+        "pad line\n" * 50 + "TARGET line\n" + "pad line\n" * 50
+    )
+
+    results = search_mod._search_ripgrep(
+        "TARGET", vault_dir, file_pattern="big.md", max_results=10, context_lines=3
+    )
+    assert len(results) == 1
+    assert results[0]["match_context"] == "TARGET line"
+
+
+def test_reread_fallback_without_dir_fd_refuses_outside_symlink(
+    monkeypatch, vault_dir, tmp_path
+):
+    """Where openat/dir_fd is unavailable (e.g. Windows), the re-read falls back
+    to a single O_NOFOLLOW open guarded by a resolved-path containment check. It
+    must still read a legitimate in-vault file and still refuse a symlink that
+    resolves out of the vault. Forced on this platform by emptying
+    os.supports_dir_fd so the fallback branch is actually exercised."""
+    monkeypatch.setattr(search_mod.os, "supports_dir_fd", frozenset())
+
+    (vault_dir / "ok.md").write_text("a\nb\nc\n")
+    assert search_mod._read_vault_file_lines("ok.md") == ["a", "b", "c"]
+
+    secret = tmp_path / "secret.txt"
+    secret.write_text("SECRET 0\nSECRET 1\n")
+    (vault_dir / "evil.md").symlink_to(secret)
+    assert search_mod._read_vault_file_lines("evil.md") is None
+
+
+@requires_rg
+def test_ripgrep_context_for_deeply_nested_file(monkeypatch, vault_dir):
+    """The no-symlink re-read walks the path component by component; a match in a
+    legitimately nested directory must still get full context (regression guard
+    for the component-wise open path)."""
+    nested = vault_dir / "a" / "b"
+    nested.mkdir(parents=True)
+    (nested / "deep.md").write_text("ctx above\nTARGET deep\nctx below\n")
+    _force_backend(monkeypatch, "ripgrep")
+
+    results = json.loads(
+        vault_search("TARGET deep", file_pattern="*.md", context_lines=1)
+    )["results"]
+    assert len(results) == 1
+    assert results[0]["path"] == "a/b/deep.md"
+    assert results[0]["match_context"] == "ctx above\nTARGET deep\nctx below"
+
+
+def test_ripgrep_stale_line_number_degrades_to_matched_line(monkeypatch, vault_dir):
+    """If rg reports a line_number past the file's current length (a content race
+    where the file shrank between rg's scan and the re-read), the backend must
+    degrade to rg's matched line, not slice to an empty snippet."""
+    note = vault_dir / "note.md"
+    note.write_text("line one\nline two\n")  # only 2 lines on disk now
+
+    monkeypatch.setattr(
+        search_mod.subprocess,
+        "run",
+        lambda *a, **k: SimpleNamespace(
+            stdout=_rg_match_json(note, 7, "the matched line\n")
+        ),
+    )
+
+    results = search_mod._search_ripgrep(
+        "x", vault_dir, file_pattern="*.md", max_results=10, context_lines=2
+    )
+    assert len(results) == 1
+    assert results[0]["match_context"] == "the matched line"

--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -1,5 +1,7 @@
 """Tests for vault.py -- path resolution, file operations, and safety checks."""
 
+import os
+
 import pytest
 from pathlib import Path
 
@@ -52,6 +54,25 @@ def test_read_missing_file(vault_dir):
     """Reading a nonexistent file raises FileNotFoundError."""
     with pytest.raises(FileNotFoundError):
         read_file("nonexistent.md")
+
+
+def test_read_file_refuses_hardlink_to_outside_file(vault_dir, tmp_path):
+    """An in-vault hardlink to a file outside the vault is a real directory entry
+    that resolve_vault_path's containment check cannot catch (there is no link to
+    follow). read_file refuses any file with st_nlink > 1 (fail closed); in-vault
+    hardlinks are unsupported as a result. (issue #53)"""
+    secret = tmp_path / "secret.txt"
+    secret.write_text("TOP SECRET CONTENT")
+    os.link(secret, vault_dir / "evil.md")  # st_nlink == 2, same inode
+    with pytest.raises(ValueError):
+        read_file("evil.md")
+
+
+def test_read_file_reads_normal_single_link_file(vault_dir):
+    """A normal note (st_nlink == 1) is still read; the hardlink guard must not
+    refuse ordinary files."""
+    content, _ = read_file("test-note.md")
+    assert "test note" in content
 
 
 def test_write_atomic_new_file(vault_dir):


### PR DESCRIPTION
## Problem

`vault_search` returns differently shaped results depending on whether `ripgrep` is installed.

`_search_ripgrep` passes `--context={context_lines}` to `rg --json`, but the parsing loop only handles `type == "match"` events and silently discards the `type == "context"` events that ripgrep emits. So on the ripgrep path `match_context` is just the single matched line, while the Python fallback (`_search_python`) returns the matched line plus `context_lines` lines on each side.

Net effect:
- `context_lines` (documented param, default `2`) is effectively a no-op on the ripgrep path.
- The same query against the same vault returns different `match_context` shapes depending on whether `rg` is on `PATH`.

The field name `match_context` and the default `context_lines=2` both indicate surrounding context was intended.

### Reproduce

```bash
printf 'line one\nTARGET here\nline three\n' > /tmp/rgtest.md
rg --json --context=2 TARGET /tmp/rgtest.md | python3 -c "import sys,json
for l in sys.stdin:
    d=json.loads(l)
    if d.get('type') in ('match','context'):
        print(d['type'], repr(d['data']['lines']['text'].rstrip()))"
# rg emits context/match/context events, but the code only consumed 'match'
```

## Fix

Make both backends share one context-assembly path:

- Extract the slice logic the Python backend already used into `_assemble_context(file_lines, match_index, context_lines)`.
- The ripgrep backend now takes only the line number from `rg`, reads the matched file (cached per file so repeated matches in one file read once), and assembles context with the same helper.
- Drop the now-unused `--context` flag from the `rg` invocation.

Both backends produce identical `match_context` for the same query, and `context_lines` works on both paths. No change to `frontmatter_excerpt`, `--max-count`, or the overall result cap.

### Line counting and encoding

To keep the re-read context aligned with ripgrep's `line_number`, both backends read raw bytes (`read_bytes().decode("utf-8")`, not text mode) and split with a shared `_split_lines()` that breaks on `\n` only, the same way ripgrep counts lines. This avoids two subtle off-by-N bugs:

- Text-mode reading translates a lone `\r` into `\n`, and `str.splitlines()` also breaks on other Unicode separators (NEL, LINE/PARAGRAPH SEPARATOR, etc.) that ripgrep does not. Either would shift the re-read index off ripgrep's line number and drop or mis-center context.
- Trailing carriage returns are stripped so CRLF files render the same as `str.splitlines()` output.

If a matched file cannot be re-read (deleted between the rg scan and the read, or invalid UTF-8), the ripgrep backend logs a warning and degrades to the matched line ripgrep already returned, base64-decoding ripgrep's `bytes` payload for non-UTF-8 lines so the snippet is never empty or misindexed.

This is a narrow, single-purpose bug fix. It does not change the response shape for callers that relied on the documented multi-line context (the Python path already behaved this way); it brings the ripgrep path into line with it.

## Tests

New `tests/test_search_context.py`:
- both backends honor `context_lines` (multi-line snippet)
- backend equivalence: ripgrep and Python paths return identical `match_context` for the same query (forced via `shutil.which` monkeypatch)
- `context_lines=0` returns only the matched line
- clamping at the first / last line of a file
- multiple matches in one file (exercises the per-file read cache)
- the read-failure fallback degrades to the matched line, not an empty string
- Unicode line separators (U+2028), lone `\r`, and CRLF keep both backends' line indexing aligned
- non-UTF-8 matched lines produce a non-empty snippet
- the default `context_lines` value (2) is wired through
- both backends agree on `total_matches` and `truncated` for a capped multi-file search

Full suite green (83 passed), lint clean. ripgrep-path tests skip automatically when `rg` is not installed.

## Known backend differences (out of scope)

These predate this PR and are intentionally left for a separate follow-up so this change stays a narrow context_lines fix:

- **Query semantics**: ripgrep treats the query as a regex while the Python fallback does a literal case-insensitive substring match, so a query with regex metacharacters can match differently between backends.
- **Non-UTF-8 files**: the Python fallback skips a file it cannot decode, while ripgrep still returns a (degraded) match for it.
- **Match ordering** across multiple files differs (ripgrep stdout order vs Python `rglob` order); `total_matches` and `truncated` agree, only the order can differ.
- **Backend-level silent failures** in `_search_ripgrep` (subprocess timeout / missing binary / nonzero `rg` exit code return an empty list with no log) and the broad `except` blocks in `vault_search` are pre-existing and unchanged here.