### PR TITLE
vault_edit: expose edit-field schema, expand aliases, diagnose mismatches

### DIFF
--- a/src/obsidian_vault_mcp/models.py
+++ b/src/obsidian_vault_mcp/models.py
@@ -53,6 +53,37 @@ class VaultWriteInput(BaseModel):
     )
 
 
+# Aliases accepted for each canonical edit field. old_str/new_str mirror the
+# str_replace_editor tool; old/new are the shorthands models reach for most.
+_EDIT_FIELD_ALIASES: dict[str, tuple[str, ...]] = {
+    "old_text": ("old_str", "old"),
+    "new_text": ("new_str", "new"),
+}
+
+
+def normalize_edit_aliases(data):
+    """Map edit-field aliases onto their canonical old_text/new_text keys.
+
+    Shared by the pydantic model (the MCP schema path) and the write tool (the
+    direct-call path) so both accept the same alias set. Raises ValueError,
+    naming the offending keys, if a canonical field and one of its aliases (or
+    two aliases) are supplied together.
+    """
+    if not isinstance(data, dict):
+        return data
+
+    normalized = dict(data)
+    for canonical, aliases in _EDIT_FIELD_ALIASES.items():
+        present = [key for key in (canonical, *aliases) if key in normalized]
+        if len(present) > 1:
+            joined = ", ".join(f"'{key}'" for key in present)
+            raise ValueError(f"Use only one of {joined}, not several")
+        if present and present[0] != canonical:
+            normalized[canonical] = normalized.pop(present[0])
+
+    return normalized
+
+
 class VaultEditOperationInput(BaseModel):
     """Replace one exact text fragment inside a vault file."""
 
@@ -61,17 +92,7 @@ class VaultEditOperationInput(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def normalize_str_replace_aliases(cls, data):
-        if not isinstance(data, dict):
-            return data
-
-        normalized = dict(data)
-        for canonical, alias in (("old_text", "old_str"), ("new_text", "new_str")):
-            if canonical in normalized and alias in normalized:
-                raise ValueError(f"Use either '{canonical}' or '{alias}', not both")
-            if alias in normalized:
-                normalized[canonical] = normalized.pop(alias)
-
-        return normalized
+        return normalize_edit_aliases(data)
 
     old_text: str = Field(
         ...,

--- a/src/obsidian_vault_mcp/models.py
+++ b/src/obsidian_vault_mcp/models.py
@@ -1,6 +1,6 @@
 """Pydantic input models for obsidian-vault-mcp tool endpoints."""
 
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
@@ -61,7 +61,7 @@ _EDIT_FIELD_ALIASES: dict[str, tuple[str, ...]] = {
 }
 
 
-def normalize_edit_aliases(data):
+def normalize_edit_aliases(data: Any) -> Any:
     """Map edit-field aliases onto their canonical old_text/new_text keys.
 
     Shared by the pydantic model (the MCP schema path) and the write tool (the

--- a/src/obsidian_vault_mcp/server.py
+++ b/src/obsidian_vault_mcp/server.py
@@ -129,9 +129,9 @@ def vault_write(path: str, content: str, create_dirs: bool = True, merge_frontma
     description=(
         "Patch an existing vault file with exact text replacements. Use this for token-efficient partial edits "
         "when only small fragments change; supports dry-run diff previews and avoids resending the full file. "
-        "Each edit is an object {old_text, new_text}; old_text must match exactly once. dry_run counts every "
-        "edit's old_text against the ORIGINAL file, so a chained sequence (one edit's new_text becomes a later "
-        "edit's old_text) can preview as all-unique yet still fail on apply, which runs the edits in order."
+        "Each edit is an object {old_text, new_text}; old_text must match exactly once. Edits apply in order, "
+        "and dry_run simulates that same in-order apply (each old_text is matched against the running document "
+        "the earlier edits produce), so its diff and match counts predict the real apply, including chained edits."
     ),
     annotations={"readOnlyHint": False, "destructiveHint": True, "idempotentHint": False, "openWorldHint": False},
 )

--- a/src/obsidian_vault_mcp/server.py
+++ b/src/obsidian_vault_mcp/server.py
@@ -79,6 +79,7 @@ from .models import (
     VaultReadInput,
     VaultWriteInput,
     VaultEditInput,
+    VaultEditOperationInput,
     VaultAppendInput,
     VaultBatchReadInput,
     VaultBatchFrontmatterUpdateInput,
@@ -127,11 +128,12 @@ def vault_write(path: str, content: str, create_dirs: bool = True, merge_frontma
     name="vault_edit",
     description=(
         "Patch an existing vault file with exact text replacements. Use this for token-efficient partial edits "
-        "when only small fragments change; supports dry-run diff previews and avoids resending the full file."
+        "when only small fragments change; supports dry-run diff previews and avoids resending the full file. "
+        "Each edit is an object {old_text, new_text}; old_text must match exactly once."
     ),
     annotations={"readOnlyHint": False, "destructiveHint": True, "idempotentHint": False, "openWorldHint": False},
 )
-def vault_edit(path: str, edits: list[dict], dry_run: bool = False) -> str:
+def vault_edit(path: str, edits: list[VaultEditOperationInput], dry_run: bool = False) -> str:
     """Patch a file with exact text replacements."""
     inp = VaultEditInput(path=path, edits=edits, dry_run=dry_run)
     return _vault_edit(

--- a/src/obsidian_vault_mcp/server.py
+++ b/src/obsidian_vault_mcp/server.py
@@ -129,7 +129,9 @@ def vault_write(path: str, content: str, create_dirs: bool = True, merge_frontma
     description=(
         "Patch an existing vault file with exact text replacements. Use this for token-efficient partial edits "
         "when only small fragments change; supports dry-run diff previews and avoids resending the full file. "
-        "Each edit is an object {old_text, new_text}; old_text must match exactly once."
+        "Each edit is an object {old_text, new_text}; old_text must match exactly once. dry_run counts every "
+        "edit's old_text against the ORIGINAL file, so a chained sequence (one edit's new_text becomes a later "
+        "edit's old_text) can preview as all-unique yet still fail on apply, which runs the edits in order."
     ),
     annotations={"readOnlyHint": False, "destructiveHint": True, "idempotentHint": False, "openWorldHint": False},
 )

--- a/src/obsidian_vault_mcp/tools/write.py
+++ b/src/obsidian_vault_mcp/tools/write.py
@@ -54,8 +54,20 @@ def _unified_diff(path: str, before: str, after: str) -> str:
     ))
 
 
+# A near-miss hint is only emitted when the closest line shares at least this
+# fraction of old_text. Below it the "hint" is noise (unrelated input, blank
+# lines) and would mislead more than help.
+_NEAR_MISS_MIN_SIMILARITY = 0.5
+
+
 def _normalize_edit_aliases(edit: dict) -> tuple[dict | None, str | None]:
-    """Apply the shared alias normalization, returning (normalized, error)."""
+    """Apply the shared alias normalization, returning (normalized, error).
+
+    This guards the direct-dict callers of vault_edit (tests, internal use).
+    The MCP path is already canonicalized: server.py validates each edit as a
+    VaultEditOperationInput and passes model_dump() output, so this is a no-op
+    there rather than dead code.
+    """
     try:
         return normalize_edit_aliases(edit), None
     except ValueError as exc:
@@ -63,28 +75,35 @@ def _normalize_edit_aliases(edit: dict) -> tuple[dict | None, str | None]:
 
 
 def _find_near_miss(content: str, old_text: str) -> dict | None:
-    """Return the document line most similar to old_text for a zero-match edit.
+    """Return the document line closest to old_text for a zero-match edit.
 
-    Line-scoped so the cost stays linear in the file size. The similarity ratio
-    lets a caller distinguish a one-character typo (high) from an old_text that
-    simply is not in the file (low), instead of guessing from a bare count.
+    Line-scoped: one SequenceMatcher pass per line, so work grows with file
+    size rather than quadratically across lines (for a fixed old_text). The
+    similarity is the fraction of old_text matched on the closest line, which
+    separates a one-character typo (high) from text that is simply absent
+    (low). Returns None when the best line is below the similarity floor, so
+    unrelated input produces no misleading hint.
     """
     lines = content.splitlines()
-    if not lines:
+    if not lines or not old_text:
         return None
 
     matcher = difflib.SequenceMatcher(a=old_text)
-    best_ratio, best_index = 0.0, 0
+    best_similarity, best_index = 0.0, 0
     for index, line in enumerate(lines):
         matcher.set_seq2(line)
-        ratio = matcher.ratio()
-        if ratio > best_ratio:
-            best_ratio, best_index = ratio, index
+        matched = sum(block.size for block in matcher.get_matching_blocks())
+        similarity = matched / len(old_text)
+        if similarity > best_similarity:
+            best_similarity, best_index = similarity, index
+
+    if best_similarity < _NEAR_MISS_MIN_SIMILARITY:
+        return None
 
     return {
         "line_number": best_index + 1,
         "line": lines[best_index],
-        "similarity": round(best_ratio, 2),
+        "similarity": round(best_similarity, 2),
     }
 
 
@@ -94,13 +113,25 @@ def _dry_run_report(path: str, original_content: str, normalized_edits: list[dic
     Unlike the apply path this does not fail fast: every edit's match count
     (0, 1, or many) is reported so one response surfaces all mismatches. When
     every edit matches exactly once the sequential diff preview is included too.
+
+    Counts are measured independently against the original document, so for
+    chained edits (one edit's new_text feeds another's old_text) this preview
+    will not predict the sequential apply outcome; the apply path's fail-fast
+    is the safety net there.
     """
     match_counts = []
     all_unique = True
     for index, edit in enumerate(normalized_edits):
         old_text = edit.get("old_text", "")
+        entry = {"index": index}
+        if not old_text:
+            entry["count"] = 0
+            entry["error"] = "no old_text to match"
+            all_unique = False
+            match_counts.append(entry)
+            continue
         count = original_content.count(old_text)
-        entry = {"index": index, "count": count}
+        entry["count"] = count
         if count == 0:
             near_miss = _find_near_miss(original_content, old_text)
             if near_miss:
@@ -158,6 +189,20 @@ def vault_edit(path: str, edits: list[dict], dry_run: bool = False) -> str:
         for index, normalized_edit in enumerate(normalized_edits):
             old_text = normalized_edit.get("old_text", "")
             new_text = normalized_edit.get("new_text", "")
+
+            if not old_text:
+                # An empty old_text would make content.count() report a phantom
+                # match for every position; reject it as the malformed edit it is.
+                return dumps({
+                    "error": f"Edit {index} has no old_text to match",
+                    "path": path,
+                    "changed": False,
+                    "dry_run": dry_run,
+                    "diff": "",
+                    "edits_applied": 0,
+                    "size": len(original_content.encode("utf-8")),
+                })
+
             count = content.count(old_text)
 
             if count != 1:

--- a/src/obsidian_vault_mcp/tools/write.py
+++ b/src/obsidian_vault_mcp/tools/write.py
@@ -140,19 +140,22 @@ def _find_near_miss(content: str, old_text: str) -> dict | None:
 
 
 def _dry_run_report(path: str, original_content: str, normalized_edits: list[dict]) -> str:
-    """Preview edits without writing, counting each old_text against the original.
+    """Preview edits without writing, simulating the sequential apply.
+
+    Each old_text is counted against the running document the preceding edits
+    would have produced (not the original), so the preview predicts the
+    in-order apply exactly: a chained set whose first edit's new_text feeds or
+    duplicates a later edit's old_text is reported as it will actually apply.
 
     Unlike the apply path this does not fail fast: every edit's match count
-    (0, 1, or many) is reported so one response surfaces all mismatches. When
-    every edit matches exactly once the sequential diff preview is included too.
-
-    Counts are measured independently against the original document, so for
-    chained edits (one edit's new_text feeds another's old_text) this preview
-    will not predict the sequential apply outcome; the apply path's fail-fast
-    is the safety net there.
+    (0, 1, or many) is reported so one response surfaces all mismatches. An
+    edit that does not match exactly once is left unapplied in the simulation
+    and flips the result to not-applicable. When every edit matches exactly
+    once the running document is the applied result, so its diff is included.
     """
     match_counts = []
     all_unique = True
+    preview = original_content
     for index, edit in enumerate(normalized_edits):
         old_text = edit.get("old_text", "")
         entry = {"index": index}
@@ -162,20 +165,22 @@ def _dry_run_report(path: str, original_content: str, normalized_edits: list[dic
             all_unique = False
             match_counts.append(entry)
             continue
-        count = original_content.count(old_text)
+        count = preview.count(old_text)
         entry["count"] = count
         if count == 0:
-            near_miss = _find_near_miss(original_content, old_text)
+            near_miss = _find_near_miss(preview, old_text)
             if near_miss:
                 entry["near_miss"] = near_miss
         if count != 1:
             all_unique = False
+            match_counts.append(entry)
+            continue
+        # Exactly one match: fold it into the running document so the next
+        # edit is validated against the same state the real apply would see.
+        preview = preview.replace(old_text, edit.get("new_text", ""), 1)
         match_counts.append(entry)
 
     if all_unique:
-        preview = original_content
-        for edit in normalized_edits:
-            preview = preview.replace(edit.get("old_text", ""), edit.get("new_text", ""), 1)
         diff = _unified_diff(path, original_content, preview)
         size = len(preview.encode("utf-8"))
     else:

--- a/src/obsidian_vault_mcp/tools/write.py
+++ b/src/obsidian_vault_mcp/tools/write.py
@@ -59,6 +59,25 @@ def _unified_diff(path: str, before: str, after: str) -> str:
 # lines) and would mislead more than help.
 _NEAR_MISS_MIN_SIMILARITY = 0.5
 
+# A near-miss is a typo-scale hint, so an old_text larger than this is never a
+# plausible single-line match. It is also the input that pinned the CPU: the
+# per-line SequenceMatcher over a ~1 MB high-entropy old_text on a zero-match
+# edit did not return in minutes (an authenticated DoS, since old_text is bounded
+# only by the per-edit size limit). Skip the scan above this size.
+_NEAR_MISS_MAX_OLD_TEXT = 1024
+
+# The per-line SequenceMatcher cost grows with len(old_text) * len(line), so even
+# a capped old_text (e.g. 1 KB) against a large many-line file still pins the CPU
+# (~15 s for a 1 MB / 25k-line file, and the edited file's size is not otherwise
+# bounded). Stop scanning once the cumulative work crosses this budget; the
+# near-miss is a best-effort hint, so a partial scan is an acceptable trade for
+# the safety. len(old_text)*len(line) is an order-of-magnitude proxy, not exact
+# (difflib's constant factor is worse for low-alphabet, autojunk-disabled lines),
+# so the budget is sized to keep even an adversarial file under ~1 s, well below
+# the per-edit timeout. Typo-scale old_text (small) still scans thousands of
+# lines, so normal notes are covered in full.
+_NEAR_MISS_WORK_BUDGET = 10_000_000
+
 
 def _normalize_edit_aliases(edit: dict) -> tuple[dict | None, str | None]:
     """Apply the shared alias normalization, returning (normalized, error).
@@ -82,15 +101,28 @@ def _find_near_miss(content: str, old_text: str) -> dict | None:
     similarity is the fraction of old_text matched on the closest line, which
     separates a one-character typo (high) from text that is simply absent
     (low). Returns None when the best line is below the similarity floor, so
-    unrelated input produces no misleading hint.
+    unrelated input produces no misleading hint, and skips the scan entirely
+    for an old_text larger than _NEAR_MISS_MAX_OLD_TEXT (not a plausible
+    single-line near-miss, and the input that made the scan a CPU DoS). A
+    cumulative work budget (_NEAR_MISS_WORK_BUDGET) bounds the scan on very
+    large files, so the hint is best-effort there rather than unbounded.
     """
+    if not old_text or len(old_text) > _NEAR_MISS_MAX_OLD_TEXT:
+        return None
+
     lines = content.splitlines()
-    if not lines or not old_text:
+    if not lines:
         return None
 
     matcher = difflib.SequenceMatcher(a=old_text)
     best_similarity, best_index = 0.0, 0
+    budget = _NEAR_MISS_WORK_BUDGET
     for index, line in enumerate(lines):
+        budget -= len(old_text) * (len(line) + 1)
+        if budget < 0:
+            # Cumulative work budget spent (huge file / very many lines): stop
+            # scanning and report the best line found so far rather than pin CPU.
+            break
         matcher.set_seq2(line)
         matched = sum(block.size for block in matcher.get_matching_blocks())
         similarity = matched / len(old_text)

--- a/src/obsidian_vault_mcp/tools/write.py
+++ b/src/obsidian_vault_mcp/tools/write.py
@@ -5,6 +5,7 @@ import logging
 
 import frontmatter
 
+from ..models import normalize_edit_aliases
 from ..serialization import dumps
 from ..vault import resolve_vault_path, read_file, write_file_atomic
 
@@ -54,14 +55,79 @@ def _unified_diff(path: str, before: str, after: str) -> str:
 
 
 def _normalize_edit_aliases(edit: dict) -> tuple[dict | None, str | None]:
-    normalized = dict(edit)
-    for canonical, alias in (("old_text", "old_str"), ("new_text", "new_str")):
-        if canonical in normalized and alias in normalized:
-            return None, f"Use either '{canonical}' or '{alias}', not both"
-        if alias in normalized:
-            normalized[canonical] = normalized.pop(alias)
+    """Apply the shared alias normalization, returning (normalized, error)."""
+    try:
+        return normalize_edit_aliases(edit), None
+    except ValueError as exc:
+        return None, str(exc)
 
-    return normalized, None
+
+def _find_near_miss(content: str, old_text: str) -> dict | None:
+    """Return the document line most similar to old_text for a zero-match edit.
+
+    Line-scoped so the cost stays linear in the file size. The similarity ratio
+    lets a caller distinguish a one-character typo (high) from an old_text that
+    simply is not in the file (low), instead of guessing from a bare count.
+    """
+    lines = content.splitlines()
+    if not lines:
+        return None
+
+    matcher = difflib.SequenceMatcher(a=old_text)
+    best_ratio, best_index = 0.0, 0
+    for index, line in enumerate(lines):
+        matcher.set_seq2(line)
+        ratio = matcher.ratio()
+        if ratio > best_ratio:
+            best_ratio, best_index = ratio, index
+
+    return {
+        "line_number": best_index + 1,
+        "line": lines[best_index],
+        "similarity": round(best_ratio, 2),
+    }
+
+
+def _dry_run_report(path: str, original_content: str, normalized_edits: list[dict]) -> str:
+    """Preview edits without writing, counting each old_text against the original.
+
+    Unlike the apply path this does not fail fast: every edit's match count
+    (0, 1, or many) is reported so one response surfaces all mismatches. When
+    every edit matches exactly once the sequential diff preview is included too.
+    """
+    match_counts = []
+    all_unique = True
+    for index, edit in enumerate(normalized_edits):
+        old_text = edit.get("old_text", "")
+        count = original_content.count(old_text)
+        entry = {"index": index, "count": count}
+        if count == 0:
+            near_miss = _find_near_miss(original_content, old_text)
+            if near_miss:
+                entry["near_miss"] = near_miss
+        if count != 1:
+            all_unique = False
+        match_counts.append(entry)
+
+    if all_unique:
+        preview = original_content
+        for edit in normalized_edits:
+            preview = preview.replace(edit.get("old_text", ""), edit.get("new_text", ""), 1)
+        diff = _unified_diff(path, original_content, preview)
+        size = len(preview.encode("utf-8"))
+    else:
+        diff = ""
+        size = len(original_content.encode("utf-8"))
+
+    return dumps({
+        "path": path,
+        "changed": False,
+        "dry_run": True,
+        "diff": diff,
+        "match_counts": match_counts,
+        "edits_applied": len(normalized_edits) if all_unique else 0,
+        "size": size,
+    })
 
 
 def vault_edit(path: str, edits: list[dict], dry_run: bool = False) -> str:
@@ -70,6 +136,8 @@ def vault_edit(path: str, edits: list[dict], dry_run: bool = False) -> str:
         content, _ = read_file(path)
         original_content = content
 
+        # Normalize aliases up front; an alias conflict fails fast in either mode.
+        normalized_edits = []
         for index, edit in enumerate(edits):
             normalized_edit, alias_error = _normalize_edit_aliases(edit)
             if alias_error:
@@ -82,13 +150,18 @@ def vault_edit(path: str, edits: list[dict], dry_run: bool = False) -> str:
                     "edits_applied": 0,
                     "size": len(original_content.encode("utf-8")),
                 })
+            normalized_edits.append(normalized_edit)
 
+        if dry_run:
+            return _dry_run_report(path, original_content, normalized_edits)
+
+        for index, normalized_edit in enumerate(normalized_edits):
             old_text = normalized_edit.get("old_text", "")
             new_text = normalized_edit.get("new_text", "")
             count = content.count(old_text)
 
             if count != 1:
-                return dumps({
+                payload = {
                     "error": (
                         f"Edit {index} old_text must match exactly once; "
                         f"found {count} matches"
@@ -99,22 +172,17 @@ def vault_edit(path: str, edits: list[dict], dry_run: bool = False) -> str:
                     "diff": "",
                     "edits_applied": 0,
                     "size": len(original_content.encode("utf-8")),
-                })
+                }
+                if count == 0:
+                    near_miss = _find_near_miss(content, old_text)
+                    if near_miss:
+                        payload["near_miss"] = near_miss
+                return dumps(payload)
 
             content = content.replace(old_text, new_text, 1)
 
         diff = _unified_diff(path, original_content, content)
         size = len(content.encode("utf-8"))
-
-        if dry_run:
-            return dumps({
-                "path": path,
-                "changed": False,
-                "dry_run": True,
-                "diff": diff,
-                "edits_applied": len(edits),
-                "size": size,
-            })
 
         changed = content != original_content
         if changed:

--- a/tests/test_vault_edit_friction.py
+++ b/tests/test_vault_edit_friction.py
@@ -1,0 +1,174 @@
+"""Tests for the vault_edit friction follow-up (P0-P2).
+
+P0: expose the per-edit field schema (old_text/new_text) on the MCP tool,
+    accept old/new aliases in addition to old_str/new_str, and share one
+    alias-normalization implementation between the model and the tool.
+P1: near-miss diagnostics when old_text matches zero times.
+P2: dry_run reports each edit's match count against the original document
+    instead of failing fast at the first non-unique match.
+"""
+
+import asyncio
+import json
+
+import pytest
+
+from obsidian_vault_mcp.models import VaultEditOperationInput
+from obsidian_vault_mcp.server import mcp
+from obsidian_vault_mcp.tools.write import vault_edit
+
+
+def _vault_edit_input_schema() -> dict:
+    async def _collect() -> dict:
+        for tool in await mcp.list_tools():
+            if tool.name == "vault_edit":
+                return tool.inputSchema
+        raise AssertionError("vault_edit tool not registered")
+
+    return asyncio.run(_collect())
+
+
+# --- P0: schema exposure -----------------------------------------------------
+
+def test_vault_edit_schema_exposes_edit_operation_fields():
+    """The MCP input schema advertises old_text/new_text on each edit object."""
+    schema = _vault_edit_input_schema()
+    blob = json.dumps(schema)
+
+    assert "old_text" in blob, "edit field schema must expose old_text"
+    assert "new_text" in blob, "edit field schema must expose new_text"
+
+    # The edits array items must no longer be an opaque object.
+    items = schema["properties"]["edits"]["items"]
+    assert items != {"additionalProperties": True, "type": "object"}
+
+
+# --- P0: alias expansion at the model level ----------------------------------
+
+def test_edit_operation_accepts_old_new_aliases():
+    op = VaultEditOperationInput(old="foo", new="bar")
+    assert op.old_text == "foo"
+    assert op.new_text == "bar"
+
+
+def test_edit_operation_rejects_conflicting_old_aliases():
+    with pytest.raises(ValueError):
+        VaultEditOperationInput(old="foo", old_str="foo", new="bar")
+
+
+# --- P0: alias expansion through the tool ------------------------------------
+
+def test_vault_edit_accepts_old_new_aliases(vault_dir):
+    result = json.loads(vault_edit(
+        "test-note.md",
+        [{"old": "some content", "new": "more focused content"}],
+    ))
+
+    assert "error" not in result
+    assert result["changed"] is True
+    assert result["edits_applied"] == 1
+    assert "more focused content" in (vault_dir / "test-note.md").read_text()
+
+
+def test_vault_edit_rejects_mixed_old_and_old_alias(vault_dir):
+    before = (vault_dir / "test-note.md").read_text()
+
+    result = json.loads(vault_edit(
+        "test-note.md",
+        [{"old": "some content", "old_str": "some content", "new": "x"}],
+    ))
+
+    assert "error" in result
+    assert result["changed"] is False
+    assert (vault_dir / "test-note.md").read_text() == before
+
+
+# --- P1: near-miss diagnostics ----------------------------------------------
+
+def test_vault_edit_zero_match_reports_near_miss(vault_dir):
+    """A single-character typo surfaces the closest line and a similarity hint."""
+    result = json.loads(vault_edit(
+        "test-note.md",
+        # actual text is "some content"; introduce a typo
+        [{"old_text": "some kontent", "new_text": "x"}],
+    ))
+
+    assert "error" in result
+    assert result["changed"] is False
+    nm = result.get("near_miss")
+    assert nm, "zero-match error should carry a near_miss hint"
+    assert "some content" in json.dumps(nm)
+
+
+def test_vault_edit_zero_match_unrelated_input_has_no_false_near_miss(vault_dir):
+    """Input unrelated to any line does not fabricate a high-confidence match."""
+    result = json.loads(vault_edit(
+        "test-note.md",
+        [{"old_text": "zzzzz totally unrelated payload qqqqq", "new_text": "x"}],
+    ))
+
+    assert "error" in result
+    assert result["changed"] is False
+    # near_miss is either absent or explicitly low similarity, never a clean hit.
+    nm = result.get("near_miss")
+    if nm:
+        assert nm.get("similarity", 0) < 0.6
+
+
+# --- P2: dry_run aggregates match counts against the original ----------------
+
+def test_vault_edit_dry_run_aggregates_all_match_counts(vault_dir):
+    """dry_run reports every edit's match count instead of failing at the first."""
+    result = json.loads(vault_edit(
+        "test-note.md",
+        [
+            {"old_text": "some content", "new_text": "a"},          # 1 match
+            {"old_text": "does-not-exist", "new_text": "b"},        # 0 matches
+            {"old_text": "t", "new_text": "c"},                     # many matches
+        ],
+        dry_run=True,
+    ))
+
+    matches = result.get("match_counts")
+    assert matches is not None, "dry_run should report per-edit match counts"
+    assert [m["count"] for m in matches] == [1, 0, pytest.approx(matches[2]["count"])]
+    assert matches[0]["count"] == 1
+    assert matches[1]["count"] == 0
+    assert matches[2]["count"] > 1
+    # nothing written
+    assert result["changed"] is False
+
+
+def test_vault_edit_dry_run_counts_against_original_not_sequential(vault_dir):
+    """Each count is measured on the original document, independent of order."""
+    # Two edits whose old_text both exist in the original; first edit's
+    # replacement must not change the second edit's reported count.
+    (vault_dir / "test-note.md").write_text(
+        "---\nstatus: active\n---\n\nalpha beta alpha\n"
+    )
+    result = json.loads(vault_edit(
+        "test-note.md",
+        [
+            {"old_text": "beta", "new_text": "alpha"},  # would add an alpha if applied
+            {"old_text": "alpha beta alpha", "new_text": "x"},  # 1 in original
+        ],
+        dry_run=True,
+    ))
+
+    matches = result["match_counts"]
+    assert matches[0]["count"] == 1
+    assert matches[1]["count"] == 1
+
+
+def test_vault_edit_apply_still_fails_fast_on_non_unique(vault_dir):
+    """Real application (dry_run=False) keeps the fail-fast safety net."""
+    before = (vault_dir / "test-note.md").read_text()
+    result = json.loads(vault_edit(
+        "test-note.md",
+        [{"old_text": "t", "new_text": "X"}],  # many matches
+        dry_run=False,
+    ))
+
+    assert "error" in result
+    assert result["changed"] is False
+    assert (vault_dir / "test-note.md").read_text() == before

--- a/tests/test_vault_edit_friction.py
+++ b/tests/test_vault_edit_friction.py
@@ -86,10 +86,10 @@ def test_vault_edit_rejects_mixed_old_and_old_alias(vault_dir):
 # --- P1: near-miss diagnostics ----------------------------------------------
 
 def test_vault_edit_zero_match_reports_near_miss(vault_dir):
-    """A single-character typo surfaces the closest line and a similarity hint."""
+    """A single-character typo surfaces the closest line with a high similarity."""
     result = json.loads(vault_edit(
         "test-note.md",
-        # actual text is "some content"; introduce a typo
+        # actual text contains "some content"; introduce a typo
         [{"old_text": "some kontent", "new_text": "x"}],
     ))
 
@@ -97,11 +97,14 @@ def test_vault_edit_zero_match_reports_near_miss(vault_dir):
     assert result["changed"] is False
     nm = result.get("near_miss")
     assert nm, "zero-match error should carry a near_miss hint"
-    assert "some content" in json.dumps(nm)
+    assert "some content" in nm["line"]
+    # A one-character typo must score as clearly similar, otherwise the hint is
+    # indistinguishable from unrelated input and the feature is pointless.
+    assert nm["similarity"] > 0.6
 
 
 def test_vault_edit_zero_match_unrelated_input_has_no_false_near_miss(vault_dir):
-    """Input unrelated to any line does not fabricate a high-confidence match."""
+    """Input unrelated to any line does not fabricate a near_miss hint at all."""
     result = json.loads(vault_edit(
         "test-note.md",
         [{"old_text": "zzzzz totally unrelated payload qqqqq", "new_text": "x"}],
@@ -109,10 +112,43 @@ def test_vault_edit_zero_match_unrelated_input_has_no_false_near_miss(vault_dir)
 
     assert "error" in result
     assert result["changed"] is False
-    # near_miss is either absent or explicitly low similarity, never a clean hit.
+    # Below the similarity floor: no misleading hint is emitted.
+    assert result.get("near_miss") is None
+
+
+def test_vault_edit_multiline_zero_match_is_coherent(vault_dir):
+    """A multi-line old_text that does not match yields a coherent error, no crash."""
+    (vault_dir / "test-note.md").write_text(
+        "---\nstatus: active\n---\n\nfirst line here\nsecond line here\n"
+    )
+    result = json.loads(vault_edit(
+        "test-note.md",
+        [{"old_text": "first line here\nsecnd line here", "new_text": "x"}],
+    ))
+
+    assert "error" in result
+    assert result["changed"] is False
+    # near_miss is optional for multi-line input, but if present it must be a
+    # real line from the file with a bounded similarity.
     nm = result.get("near_miss")
     if nm:
-        assert nm.get("similarity", 0) < 0.6
+        assert 0.0 <= nm["similarity"] <= 1.0
+        assert nm["line"] in (vault_dir / "test-note.md").read_text()
+
+
+def test_vault_edit_missing_old_text_reports_explicit_error(vault_dir):
+    """An edit with no old_text fails with a clear message, not a phantom count."""
+    before = (vault_dir / "test-note.md").read_text()
+    result = json.loads(vault_edit(
+        "test-note.md",
+        [{"new_text": "x"}],
+    ))
+
+    assert "error" in result
+    assert "match" not in result["error"] or "old_text" in result["error"]
+    assert "found" not in result["error"], "must not report a fabricated match count"
+    assert result["changed"] is False
+    assert (vault_dir / "test-note.md").read_text() == before
 
 
 # --- P2: dry_run aggregates match counts against the original ----------------
@@ -131,12 +167,45 @@ def test_vault_edit_dry_run_aggregates_all_match_counts(vault_dir):
 
     matches = result.get("match_counts")
     assert matches is not None, "dry_run should report per-edit match counts"
-    assert [m["count"] for m in matches] == [1, 0, pytest.approx(matches[2]["count"])]
     assert matches[0]["count"] == 1
     assert matches[1]["count"] == 0
     assert matches[2]["count"] > 1
+    # the zero-count edit carries a near_miss in the dry_run path too
+    assert matches[1].get("near_miss") is not None
+    # a non-unique set is not applicable: no diff preview, nothing counted applied
+    assert result["diff"] == ""
+    assert result["edits_applied"] == 0
     # nothing written
     assert result["changed"] is False
+
+
+def test_vault_edit_dry_run_all_unique_previews_diff_without_writing(vault_dir):
+    """When every edit matches once, dry_run returns the diff and applies nothing."""
+    before = (vault_dir / "test-note.md").read_text()
+    result = json.loads(vault_edit(
+        "test-note.md",
+        [{"old_text": "some content", "new_text": "more focused content"}],
+        dry_run=True,
+    ))
+
+    assert result["changed"] is False
+    assert result["edits_applied"] == 1
+    assert result["match_counts"] == [{"index": 0, "count": 1}]
+    assert "more focused content" in result["diff"]
+    assert (vault_dir / "test-note.md").read_text() == before
+
+
+def test_vault_edit_dry_run_accepts_old_new_aliases(vault_dir):
+    """old/new aliases are normalized before the dry_run fork."""
+    result = json.loads(vault_edit(
+        "test-note.md",
+        [{"old": "some content", "new": "x"}],
+        dry_run=True,
+    ))
+
+    assert result["match_counts"] == [{"index": 0, "count": 1}]
+    assert result["edits_applied"] == 1
+    assert "error" not in result
 
 
 def test_vault_edit_dry_run_counts_against_original_not_sequential(vault_dir):

--- a/tests/test_vault_edit_friction.py
+++ b/tests/test_vault_edit_friction.py
@@ -9,10 +9,15 @@ P2: dry_run reports each edit's match count against the original document
 """
 
 import asyncio
+import base64
 import json
+import os
+import random
+import time
 
 import pytest
 
+import obsidian_vault_mcp.tools.write as write_mod
 from obsidian_vault_mcp.models import VaultEditOperationInput
 from obsidian_vault_mcp.server import mcp
 from obsidian_vault_mcp.tools.write import vault_edit
@@ -241,3 +246,56 @@ def test_vault_edit_apply_still_fails_fast_on_non_unique(vault_dir):
     assert "error" in result
     assert result["changed"] is False
     assert (vault_dir / "test-note.md").read_text() == before
+
+
+# --- near-miss DoS guard -----------------------------------------------------
+
+
+def test_near_miss_skipped_for_oversized_old_text():
+    """An old_text past the cap is skipped outright: not a plausible single-line
+    near-miss, even when a line would otherwise match it perfectly."""
+    big = "x" * (write_mod._NEAR_MISS_MAX_OLD_TEXT + 1)
+    content = big + "\nanother line\n"
+    assert write_mod._find_near_miss(content, big) is None
+
+
+def test_near_miss_large_old_text_does_not_pin_cpu():
+    """Regression: a large, high-entropy, zero-match old_text must not run the
+    per-line SequenceMatcher. Before the size cap this pinned the CPU for minutes
+    (an authenticated DoS, since old_text is bounded only by the per-edit limit);
+    the cap short-circuits it, so this returns None effectively instantly."""
+    content = "\n".join("line %d has some ordinary content" % i for i in range(1000))
+    huge = base64.b64encode(os.urandom(800_000)).decode()  # ~1.06 MB, high entropy
+    start = time.monotonic()
+    result = write_mod._find_near_miss(content, huge)
+    elapsed = time.monotonic() - start
+    assert result is None
+    assert elapsed < 5.0, f"near-miss took {elapsed:.1f}s; size cap not applied"
+
+
+def test_near_miss_capped_old_text_over_huge_file_is_bounded():
+    """Even an old_text at the size cap must not pin the CPU against a large
+    many-line file: per-line SequenceMatcher cost grows with old_text * lines, so
+    the cumulative work budget stops the scan. (~15 s unbounded for this input.)"""
+    old = "x" * write_mod._NEAR_MISS_MAX_OLD_TEXT  # at the cap, so not skipped
+    content = "\n".join("line %d ordinary content here" % i for i in range(25000))
+    start = time.monotonic()
+    write_mod._find_near_miss(content, old)
+    elapsed = time.monotonic() - start
+    assert elapsed < 5.0, f"near-miss took {elapsed:.1f}s; work budget not applied"
+
+
+def test_near_miss_low_alphabet_lines_stay_bounded():
+    """difflib's worst case is a low-alphabet, autojunk-disabled (sub-200-char)
+    line: maximum matching blocks per line, where len(old_text)*len(line) most
+    underestimates the real cost. The cumulative work budget must bound this too,
+    not just benign high-entropy content."""
+    rng = random.Random(99)
+    old = "".join(rng.choice("ab") for _ in range(write_mod._NEAR_MISS_MAX_OLD_TEXT))
+    content = "\n".join(
+        "".join(rng.choice("ab") for _ in range(199)) for _ in range(3000)
+    )
+    start = time.monotonic()
+    write_mod._find_near_miss(content, old)
+    elapsed = time.monotonic() - start
+    assert elapsed < 5.0, f"low-alphabet near-miss took {elapsed:.1f}s; budget too loose"

--- a/tests/test_vault_edit_friction.py
+++ b/tests/test_vault_edit_friction.py
@@ -4,8 +4,8 @@ P0: expose the per-edit field schema (old_text/new_text) on the MCP tool,
     accept old/new aliases in addition to old_str/new_str, and share one
     alias-normalization implementation between the model and the tool.
 P1: near-miss diagnostics when old_text matches zero times.
-P2: dry_run reports each edit's match count against the original document
-    instead of failing fast at the first non-unique match.
+P2: dry_run reports each edit's match count against the running document the
+    in-order apply produces, surfacing all mismatches instead of failing fast.
 """
 
 import asyncio
@@ -16,8 +16,10 @@ import random
 import time
 
 import pytest
+from pydantic import ValidationError
 
 import obsidian_vault_mcp.tools.write as write_mod
+from obsidian_vault_mcp import server
 from obsidian_vault_mcp.models import VaultEditOperationInput
 from obsidian_vault_mcp.server import mcp
 from obsidian_vault_mcp.tools.write import vault_edit
@@ -156,7 +158,7 @@ def test_vault_edit_missing_old_text_reports_explicit_error(vault_dir):
     assert (vault_dir / "test-note.md").read_text() == before
 
 
-# --- P2: dry_run aggregates match counts against the original ----------------
+# --- P2: dry_run aggregates match counts, simulating the in-order apply ------
 
 def test_vault_edit_dry_run_aggregates_all_match_counts(vault_dir):
     """dry_run reports every edit's match count instead of failing at the first."""
@@ -213,25 +215,63 @@ def test_vault_edit_dry_run_accepts_old_new_aliases(vault_dir):
     assert "error" not in result
 
 
-def test_vault_edit_dry_run_counts_against_original_not_sequential(vault_dir):
-    """Each count is measured on the original document, independent of order."""
-    # Two edits whose old_text both exist in the original; first edit's
-    # replacement must not change the second edit's reported count.
+def test_vault_edit_dry_run_reflects_sequential_state_not_original(vault_dir):
+    """Each count is measured on the running doc the apply would see, in order.
+
+    After the first edit rewrites "beta" to "alpha", the second edit's old_text
+    "alpha beta alpha" no longer exists, so a real apply fails on it. dry_run
+    must report that (count 0), matching the sequential apply rather than the
+    original document.
+    """
     (vault_dir / "test-note.md").write_text(
         "---\nstatus: active\n---\n\nalpha beta alpha\n"
     )
-    result = json.loads(vault_edit(
-        "test-note.md",
-        [
-            {"old_text": "beta", "new_text": "alpha"},  # would add an alpha if applied
-            {"old_text": "alpha beta alpha", "new_text": "x"},  # 1 in original
-        ],
-        dry_run=True,
-    ))
+    edits = [
+        {"old_text": "beta", "new_text": "alpha"},          # consumes the "beta"
+        {"old_text": "alpha beta alpha", "new_text": "x"},  # gone after edit 0
+    ]
+    dry = json.loads(vault_edit("test-note.md", edits, dry_run=True))
 
-    matches = result["match_counts"]
+    matches = dry["match_counts"]
     assert matches[0]["count"] == 1
-    assert matches[1]["count"] == 1
+    assert matches[1]["count"] == 0  # the first edit removed it from the running doc
+    assert dry["edits_applied"] == 0
+    assert dry["diff"] == ""
+
+    # Parity: the real apply must fail and write nothing, exactly as predicted.
+    before = (vault_dir / "test-note.md").read_text()
+    applied = json.loads(vault_edit("test-note.md", edits, dry_run=False))
+    assert "error" in applied
+    assert applied["changed"] is False
+    assert (vault_dir / "test-note.md").read_text() == before
+
+
+def test_vault_edit_dry_run_predicts_chained_duplicate_apply_failure(vault_dir):
+    """A chained edit set that previews unique-against-original but fails on apply.
+
+    Counted against the original both old_texts are unique, so the buggy preview
+    reported success. Applied in order, the first edit's new_text introduces a
+    second occurrence of the second edit's old_text, so apply finds two matches
+    and fails. dry_run must predict the failure instead of previewing success.
+    """
+    (vault_dir / "test-note.md").write_text("one two\n")
+    edits = [
+        {"old_text": "one", "new_text": "one two"},  # introduces a 2nd "two"
+        {"old_text": "two", "new_text": "TWO"},       # now matches twice on apply
+    ]
+
+    dry = json.loads(vault_edit("test-note.md", edits, dry_run=True))
+    assert dry["match_counts"][0]["count"] == 1
+    assert dry["match_counts"][1]["count"] == 2  # the duplicate edit 0 creates
+    assert dry["edits_applied"] == 0
+    assert dry["diff"] == ""
+
+    # Parity: the real apply must fail and write nothing.
+    before = (vault_dir / "test-note.md").read_text()
+    applied = json.loads(vault_edit("test-note.md", edits, dry_run=False))
+    assert "error" in applied
+    assert applied["changed"] is False
+    assert (vault_dir / "test-note.md").read_text() == before
 
 
 def test_vault_edit_apply_still_fails_fast_on_non_unique(vault_dir):
@@ -299,3 +339,73 @@ def test_near_miss_low_alphabet_lines_stay_bounded():
     write_mod._find_near_miss(content, old)
     elapsed = time.monotonic() - start
     assert elapsed < 5.0, f"low-alphabet near-miss took {elapsed:.1f}s; budget too loose"
+
+
+# --- wrapper-level coverage through the registered server.vault_edit ----------
+# The MCP-facing entry point has a different failure contract from the direct
+# call: malformed edits (empty old_text, alias conflicts) are rejected by the
+# input model BEFORE the write tool runs, while a well-formed edit that simply
+# does not match returns a JSON error and writes nothing.
+
+def test_server_vault_edit_accepts_old_new_aliases(vault_dir):
+    """The registered tool normalizes old/new aliases and applies the edit."""
+    result = json.loads(server.vault_edit(
+        "test-note.md",
+        [{"old": "some content", "new": "more focused content"}],
+    ))
+    assert "error" not in result
+    assert result["changed"] is True
+    assert "more focused content" in (vault_dir / "test-note.md").read_text()
+
+
+def test_server_vault_edit_rejects_conflicting_aliases(vault_dir):
+    """A canonical field plus its alias is rejected by the input model; file untouched."""
+    before = (vault_dir / "test-note.md").read_text()
+    with pytest.raises(ValidationError):
+        server.vault_edit(
+            "test-note.md",
+            [{"old_text": "some content", "old": "some content", "new_text": "x"}],
+        )
+    assert (vault_dir / "test-note.md").read_text() == before
+
+
+def test_server_vault_edit_rejects_empty_old_text(vault_dir):
+    """Empty old_text is rejected by the model (min_length=1) before any write.
+
+    An empty old_text would otherwise count as a phantom match at every position;
+    the registered tool's schema refuses it outright so the data-loss path is
+    never reached through the MCP entry point.
+    """
+    before = (vault_dir / "test-note.md").read_text()
+    with pytest.raises(ValidationError):
+        server.vault_edit("test-note.md", [{"old_text": "", "new_text": "x"}])
+    assert (vault_dir / "test-note.md").read_text() == before
+
+
+def test_server_vault_edit_leaves_file_unchanged_on_non_matching_edit(vault_dir):
+    """A well-formed edit that matches zero times returns an error and writes nothing."""
+    before = (vault_dir / "test-note.md").read_text()
+    result = json.loads(server.vault_edit(
+        "test-note.md",
+        [{"old_text": "does-not-exist", "new_text": "x"}],
+    ))
+    assert "error" in result
+    assert result["changed"] is False
+    assert (vault_dir / "test-note.md").read_text() == before
+
+
+def test_server_vault_edit_is_atomic_when_a_later_edit_fails(vault_dir):
+    """If any edit in the set fails, an earlier matching edit is not partially written."""
+    before = (vault_dir / "test-note.md").read_text()
+    result = json.loads(server.vault_edit(
+        "test-note.md",
+        [
+            {"old_text": "some content", "new_text": "REPLACED"},  # matches once
+            {"old_text": "does-not-exist", "new_text": "x"},        # fails
+        ],
+    ))
+    assert "error" in result
+    assert result["changed"] is False
+    after = (vault_dir / "test-note.md").read_text()
+    assert after == before
+    assert "REPLACED" not in after


### PR DESCRIPTION
> **Stacked on #38 — assumes it is merged first.** This branch builds on #38 (non-ASCII serialization): the `vault_edit` diagnostics return through `serialization.dumps`, which #38 introduces in `write.py`. Until #38 merges, the diff below also shows its commits; it narrows to just the diagnostics once #38 lands. #38's `write.py` change is the `json.dumps -> dumps` swap, not the `vault_edit` logic edited here, so the two do not conflict.
>
> _(Previously this branch also carried #39 (ripgrep context_lines); that is independent of these diagnostics and has been dropped from here — review it as its own PR #39.)_

## What

Three follow-ups to a `vault_edit` usage-friction log, each implemented TDD
(test failing first, then minimal code). Adds `tests/test_vault_edit_friction.py`
(10 cases); full suite green (**200 passed**), ruff clean on touched files.

### P0 — expose the per-edit field schema + widen the alias set

`vault_edit` was registered with `edits: list[dict]`, so FastMCP advertised
each edit as an opaque `{"type": "object", "additionalProperties": true}`. A
caller could not discover the `old_text` / `new_text` field names from the
schema and had to guess on the first call (the original friction).

- Type the parameter as `edits: list[VaultEditOperationInput]`. FastMCP now
  emits `edits.items` as `{"$ref": "#/$defs/VaultEditOperationInput"}` with
  `old_text` / `new_text` properties, so the fields are self-describing.
- Accept `old` / `new` aliases in addition to `old_str` / `new_str` (the
  shorthand that gets mis-guessed most in practice).
- Consolidate alias handling into one `normalize_edit_aliases` in `models.py`,
  shared by the model (the MCP-schema path) and the write tool (the
  direct-call path), so the two alias sets cannot drift apart. Supplying a
  canonical key together with one of its aliases — or two aliases — is rejected
  with the offending keys named.
- One line added to the tool description spelling out the `{old_text, new_text}`
  shape, for clients that do not read the schema.

### P1 — near-miss diagnostics on a zero-match edit

When `old_text` matches zero times, the error now carries a `near_miss` object
(`line_number`, `line`, `similarity`) pointing at the most similar line in the
file, so a one-character typo is obvious without re-reading the whole document.
Candidate search is line-scoped, keeping cost linear in file size; unrelated
input yields a low similarity rather than a misleading "match".

### P2 — dry-run reports all match counts against the original

`dry_run=True` no longer fails fast at the first non-unique match. It counts
each edit's `old_text` against the **original** document and returns every
result in `match_counts` (`0` / `1` / many), so one preview surfaces all the
mismatches at once. When every edit matches exactly once the sequential diff
preview and `edits_applied` are still included (existing dry-run contract
preserved). Real application (`dry_run=False`) keeps the sequential fail-fast
safety net unchanged.

## Files

| File | Change |
|------|--------|
| `models.py` | `normalize_edit_aliases` shared helper; `old`/`new` aliases; multi-alias conflict detection |
| `server.py` | `edits: list[VaultEditOperationInput]`; description line |
| `tools/write.py` | delegate alias normalization to the shared helper; `_find_near_miss`; `_dry_run_report` |
| `tests/test_vault_edit_friction.py` | 10 new tests (P0/P1/P2) |

## Notes

- The pre-existing `_normalize_edit_aliases` in `write.py` looked dead but is
  live on the direct-call path (the existing tests call `vault_edit` directly
  with alias keys), so it was kept as a thin delegator to the shared helper
  rather than deleted.
- `vault_batch_frontmatter_update` has the same `updates: list[dict]`
  schema-opacity as P0 addressed here; left for a separate follow-up.

