### PR TITLE
Persist DCR OAuth client registry across restarts

### DIFF
--- a/src/obsidian_vault_mcp/config.py
+++ b/src/obsidian_vault_mcp/config.py
@@ -24,6 +24,16 @@ VAULT_OAUTH_PASSWORD = os.environ.get("VAULT_OAUTH_PASSWORD", "")
 # browser authorization-code flow (it can still use the client_credentials grant).
 VAULT_OAUTH_REDIRECT_URIS = [u.strip() for u in os.environ.get("VAULT_OAUTH_REDIRECT_URIS", "").split(",") if u.strip()]
 
+# Where the dynamically-registered OAuth client registry is persisted. The registry is
+# otherwise in-memory and wiped on every restart, which breaks already-connected MCP
+# clients (they replay a client_id the restarted server no longer knows). Persisting it
+# keeps connectors working across restarts. It holds per-client secrets, so it is written
+# with 0600 perms (see oauth._save_clients). Override with OAUTH_CLIENTS_PATH.
+OAUTH_CLIENTS_PATH = Path(os.environ.get(
+    "OAUTH_CLIENTS_PATH",
+    Path.home() / ".local" / "share" / "vault-mcp" / "oauth_clients.json",
+))
+
 # Network bind address. Defaults to loopback so the server is NOT exposed on the LAN;
 # Cloudflare Tunnel reaches it over localhost. Set to 0.0.0.0 only if you deliberately
 # want direct network exposure.

--- a/src/obsidian_vault_mcp/oauth.py
+++ b/src/obsidian_vault_mcp/oauth.py
@@ -36,7 +36,9 @@ import base64
 import hashlib
 import hmac
 import html
+import json
 import logging
+import os
 import secrets
 import time
 from urllib.parse import urlencode, urlparse
@@ -53,9 +55,61 @@ logger = logging.getLogger(__name__)
 # Maps code -> {client_id, redirect_uri, code_challenge, code_challenge_method, expires_at}
 _auth_codes: dict[str, dict] = {}
 
-# In-memory store for dynamically registered clients.
+# Registry of dynamically registered clients.
 # Maps client_id -> {client_secret, redirect_uris: [...], created_at}
+# Persisted to config.OAUTH_CLIENTS_PATH so registrations survive a restart. An
+# in-memory-only registry is wiped on every restart, which breaks already-connected MCP
+# clients: they replay a client_id the restarted server no longer recognizes, so
+# /oauth/authorize rejects it with "Invalid or unregistered redirect_uri" and the only
+# recourse is removing and re-adding the connector.
 _clients: dict[str, dict] = {}
+
+
+def _load_clients() -> None:
+    """Populate _clients from the on-disk registry. Best-effort; never raises."""
+    path = config.OAUTH_CLIENTS_PATH
+    try:
+        with open(path, "r") as f:
+            data = json.load(f)
+    except FileNotFoundError:
+        return
+    except (OSError, json.JSONDecodeError) as e:
+        logger.warning("OAuth client registry unreadable at %s (%s); starting empty", path, e)
+        return
+    if isinstance(data, dict):
+        valid = {}
+        for cid, rec in data.items():
+            if (isinstance(cid, str) and isinstance(rec, dict)
+                    and isinstance(rec.get("client_secret"), str)
+                    and isinstance(rec.get("redirect_uris"), list)
+                    and all(isinstance(u, str) for u in rec["redirect_uris"])):
+                valid[cid] = rec
+        _clients.clear()
+        _clients.update(valid)
+        logger.info("Loaded %d registered OAuth client(s) from %s", len(_clients), path)
+
+
+def _save_clients() -> None:
+    """Persist _clients atomically with owner-only perms (it holds per-client secrets)."""
+    path = config.OAUTH_CLIENTS_PATH
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_name(f"{path.name}.tmp-{os.getpid()}")
+        # O_CREAT with 0o600 so the secrets are never briefly world-readable; fchmod
+        # forces 0600 even if a stale tmp from a crashed write pre-existed wider.
+        fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "w") as f:
+            json.dump(_clients, f)
+            f.flush()
+            os.fsync(f.fileno())  # durable before the atomic swap
+        os.replace(tmp, path)  # atomic on POSIX
+    except OSError as e:
+        logger.error("Could not persist OAuth client registry to %s (%s)", path, e)
+
+
+# Load any persisted registrations at import (process startup).
+_load_clients()
 
 
 def _cleanup_codes():
@@ -388,6 +442,7 @@ async def oauth_register(request: Request) -> JSONResponse:
         "redirect_uris": redirect_uris,
         "created_at": time.time(),
     }
+    _save_clients()  # survive restarts; otherwise this registration is lost on reboot
 
     return JSONResponse({
         "client_id": client_id,

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -18,7 +18,7 @@ TOKEN = "test-vault-token-do-not-leak"
 
 
 @pytest.fixture(autouse=True)
-def reset_state(monkeypatch):
+def reset_state(monkeypatch, tmp_path):
     """Fresh in-memory stores + known config for every test."""
     oauth._clients.clear()
     oauth._auth_codes.clear()
@@ -28,6 +28,9 @@ def reset_state(monkeypatch):
     monkeypatch.setattr(config, "VAULT_OAUTH_CLIENT_ID", "vault-mcp-client")
     monkeypatch.setattr(config, "VAULT_OAUTH_CLIENT_SECRET", "configured-server-secret")
     monkeypatch.setattr(config, "VAULT_OAUTH_REDIRECT_URIS", [])
+    # Persist the client registry to a throwaway path so tests never touch the real
+    # on-disk registry.
+    monkeypatch.setattr(config, "OAUTH_CLIENTS_PATH", tmp_path / "oauth_clients.json")
     yield
 
 
@@ -274,3 +277,37 @@ def test_oauth_protected_resource_metadata(client):
 def test_protected_resource_path_is_auth_exempt():
     from obsidian_vault_mcp.auth import _AUTH_EXEMPT_PATHS
     assert "/.well-known/oauth-protected-resource" in _AUTH_EXEMPT_PATHS
+
+
+# --- Registry persistence across restart --------------------------------------
+
+def test_registration_persists_across_restart(client):
+    """A DCR client survives a server restart (in-memory wipe) via the on-disk
+    registry. Without this, a restart leaves the connected client replaying a
+    client_id the server no longer knows -> 'Invalid or unregistered redirect_uri'."""
+    client_id, redirect = _register(client)
+    assert config.OAUTH_CLIENTS_PATH.exists()
+
+    # Simulate a restart: drop in-memory state, reload from disk.
+    oauth._clients.clear()
+    assert client_id not in oauth._clients
+    oauth._load_clients()
+
+    assert client_id in oauth._clients
+    # redirect_uri validation passes again post-reload, so /oauth/authorize won't 400.
+    assert oauth._redirect_uri_ok(client_id, redirect) is True
+
+
+def test_registry_file_is_owner_only(client):
+    """The persisted registry holds per-client secrets; it must be 0600."""
+    _register(client)
+    mode = config.OAUTH_CLIENTS_PATH.stat().st_mode & 0o777
+    assert mode == 0o600
+
+
+def test_load_clients_tolerates_corrupt_file(client):
+    """A garbage registry file must not crash startup; load is best-effort."""
+    config.OAUTH_CLIENTS_PATH.write_text("{not valid json")
+    oauth._clients.clear()
+    oauth._load_clients()  # must not raise
+    assert oauth._clients == {}


### PR DESCRIPTION
## Problem

The dynamically-registered OAuth client registry (`_clients` in `oauth.py`) was an in-memory dict. Every server restart wiped it, which breaks **already-connected** MCP clients: the client (e.g. the Claude app) replays a `client_id` from a prior dynamic registration, but the restarted server has no record of it, so `/oauth/authorize` rejects the request with:

```
{"error":"invalid_request","error_description":"Invalid or unregistered redirect_uri."}
```

The only recourse was removing and re-adding the connector after every restart — and for any KeepAlive/auto-restart deployment, that's on every crash or reboot.

## Fix

Persist `_clients` to disk:

- **Path:** `~/.local/share/vault-mcp/oauth_clients.json`, overridable via `OAUTH_CLIENTS_PATH`.
- **Loaded** once at import (process startup); **saved** on each successful `/oauth/register`.
- **Secure-by-default write:** the file holds per-client secrets, so it's created `0600` (via `O_CREAT` mode + explicit `fchmod`), written atomically (`tmp` file + `os.replace`), and `fsync`'d before the swap.
- **Tolerant load:** missing file → start empty; corrupt/garbage JSON → log and start empty (never crashes startup); each record is schema-validated (`client_secret: str`, `redirect_uris: list[str]`) before being trusted.

## Not changed

No change to the auth/validation path — the `redirect_uri` allowlist, `client_id` binding at token exchange, PKCE S256, the interactive login gate, and origin pinning are all untouched. This only restores/persists registrations; it does not alter who is allowed to authorize.

## Testing

`60 passed` (57 prior + 3 new):
- `test_registration_persists_across_restart` — register → simulate restart (clear in-memory, reload from disk) → client still known and `redirect_uri` still validates.
- `test_registry_file_is_owner_only` — persisted file is `0600`.
- `test_load_clients_tolerates_corrupt_file` — garbage JSON doesn't crash load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
