### PR TITLE
Make MCP mount path configurable (default /)

### DIFF
--- a/src/obsidian_vault_mcp/auth.py
+++ b/src/obsidian_vault_mcp/auth.py
@@ -19,6 +19,14 @@ _AUTH_EXEMPT_PATHS = {
     "/oauth/register",
 }
 
+# (method, path) pairs exempt from auth. The MCP spec 2025-06-18 probe on / must
+# answer GET/HEAD without credentials. This is ONLY active when MCP is mounted off
+# root (VAULT_MCP_PATH != "/"); when MCP is at root the transport owns GET/HEAD /
+# and must stay fully authenticated, so the set is empty and behaviour is unchanged.
+_AUTH_EXEMPT_METHOD_PATHS = (
+    {("GET", "/"), ("HEAD", "/")} if config.VAULT_MCP_PATH != "/" else set()
+)
+
 
 def _www_authenticate(request: Request, error: str) -> str:
     """RFC 9728 challenge header pointing clients at the protected-resource metadata.
@@ -40,6 +48,9 @@ class BearerAuthMiddleware(BaseHTTPMiddleware):
 
     async def dispatch(self, request: Request, call_next):
         if request.url.path in _AUTH_EXEMPT_PATHS:
+            return await call_next(request)
+
+        if (request.method, request.url.path) in _AUTH_EXEMPT_METHOD_PATHS:
             return await call_next(request)
 
         if not VAULT_MCP_TOKEN:

--- a/src/obsidian_vault_mcp/config.py
+++ b/src/obsidian_vault_mcp/config.py
@@ -6,6 +6,13 @@ VAULT_PATH = Path(os.environ.get("VAULT_PATH", os.path.expanduser("~/Obsidian/My
 VAULT_MCP_TOKEN = os.environ.get("VAULT_MCP_TOKEN", "")
 VAULT_MCP_PORT = int(os.environ.get("VAULT_MCP_PORT", "8420"))
 
+# HTTP path the MCP transport is mounted at. Defaults to "/" so connectors that
+# POST to the root complete the handshake (#19) -- changing this default would
+# break that, so leave it unless you deliberately host under a path prefix.
+# Setting it (e.g. "/mcp") lets the server live alongside other services on one
+# hostname behind a reverse proxy that cannot rewrite paths (Cloudflare Tunnel).
+VAULT_MCP_PATH = os.environ.get("VAULT_MCP_PATH", "/")
+
 # OAuth 2.0 client credentials (for Claude app integration)
 VAULT_OAUTH_CLIENT_ID = os.environ.get("VAULT_OAUTH_CLIENT_ID", "vault-mcp-client")
 VAULT_OAUTH_CLIENT_SECRET = os.environ.get("VAULT_OAUTH_CLIENT_SECRET", "")

--- a/src/obsidian_vault_mcp/server.py
+++ b/src/obsidian_vault_mcp/server.py
@@ -17,6 +17,7 @@ from .config import (
     VAULT_MCP_ALLOWED_HOSTS,
     VAULT_MCP_FORWARDED_ALLOW_IPS,
     VAULT_MCP_HOST,
+    VAULT_MCP_PATH,
     VAULT_MCP_PORT,
     VAULT_MCP_TOKEN,
     VAULT_PATH,
@@ -46,9 +47,10 @@ mcp = FastMCP(
     "obsidian_web_mcp",
     stateless_http=True,
     json_response=True,
-    # Serve MCP at "/" (not the /mcp default) so connectors that POST to the root
-    # complete the handshake instead of 404ing (#19).
-    streamable_http_path="/",
+    # Mount path for the MCP transport. Defaults to "/" (via VAULT_MCP_PATH) so
+    # connectors that POST to the root complete the handshake instead of 404ing
+    # (#19); set VAULT_MCP_PATH to host under a prefix like "/mcp".
+    streamable_http_path=VAULT_MCP_PATH,
     lifespan=lifespan,
     transport_security=TransportSecuritySettings(
         enable_dns_rebinding_protection=True,
@@ -262,10 +264,26 @@ def main():
 
     # Build the Starlette app with auth middleware and OAuth endpoints
     try:
+        from starlette.responses import Response
+        from starlette.routing import Route
+
         from .auth import BearerAuthMiddleware
         from .oauth import oauth_routes
 
         app = mcp.streamable_http_app()
+
+        # MCP spec 2025-06-18 probe: GET/HEAD / answers with the protocol version.
+        # Only mount it when MCP is NOT at root -- otherwise the transport owns
+        # GET/HEAD / and this route would shadow it. (auth.py exempts GET/HEAD /
+        # from bearer auth under the same VAULT_MCP_PATH != "/" guard.)
+        if VAULT_MCP_PATH != "/":
+            async def mcp_root_probe(request):
+                return Response(
+                    status_code=200,
+                    headers={"MCP-Protocol-Version": "2025-06-18"},
+                )
+
+            app.routes.insert(0, Route("/", mcp_root_probe, methods=["GET", "HEAD"]))
 
         # Mount OAuth routes (these are excluded from bearer auth via the middleware)
         for route in oauth_routes:

--- a/tests/test_mcp_path.py
+++ b/tests/test_mcp_path.py
@@ -1,0 +1,55 @@
+"""VAULT_MCP_PATH defaults to / and the spec-probe auth exemption is guarded.
+
+The probe route itself is mounted in server.main() (needs a running app), so it
+is not unit-tested here; the testable contract is (a) the config default/override
+and (b) that auth only exempts GET/HEAD / when MCP is mounted off root.
+"""
+
+import importlib
+
+from obsidian_vault_mcp import auth, config
+
+
+def _reload(monkeypatch, value):
+    """Reload config (+auth, which snapshots the path) with VAULT_MCP_PATH set/unset."""
+    if value is None:
+        monkeypatch.delenv("VAULT_MCP_PATH", raising=False)
+    else:
+        monkeypatch.setenv("VAULT_MCP_PATH", value)
+    importlib.reload(config)
+    importlib.reload(auth)
+
+
+def test_path_defaults_to_root(monkeypatch):
+    try:
+        _reload(monkeypatch, None)
+        assert config.VAULT_MCP_PATH == "/"
+    finally:
+        _reload(monkeypatch, None)
+
+
+def test_path_override(monkeypatch):
+    try:
+        _reload(monkeypatch, "/mcp")
+        assert config.VAULT_MCP_PATH == "/mcp"
+    finally:
+        _reload(monkeypatch, None)
+
+
+def test_probe_not_exempt_at_root(monkeypatch):
+    """Default mount (/) keeps GET/HEAD / fully authenticated."""
+    try:
+        _reload(monkeypatch, None)
+        assert auth._AUTH_EXEMPT_METHOD_PATHS == set()
+    finally:
+        _reload(monkeypatch, None)
+
+
+def test_probe_exempt_when_off_root(monkeypatch):
+    """Hosting under a prefix frees / for the unauthenticated spec probe."""
+    try:
+        _reload(monkeypatch, "/mcp")
+        assert ("GET", "/") in auth._AUTH_EXEMPT_METHOD_PATHS
+        assert ("HEAD", "/") in auth._AUTH_EXEMPT_METHOD_PATHS
+    finally:
+        _reload(monkeypatch, None)


### PR DESCRIPTION
Closes #46.

**Problem:** `streamable_http_path` is hardcoded to `/` (#19), so the server can't sit under a prefix like `/mcp`. cloudflared can't strip paths (cloudflare/cloudflared#563), so the prefix has to come from the app.

**Fix:** `VAULT_MCP_PATH`, default `/`. Default stays byte-identical; #19's root mount holds.

Both gated on `VAULT_MCP_PATH != "/"`:
- Mount the MCP-spec `GET/HEAD /` probe so root still answers once the transport moves off it.
- `auth.py` exempts `GET/HEAD /` from bearer auth. Empty set at `/`, so root stays authenticated by default.

**Tests:** 76 pass, 4 new (`test_mcp_path.py`). The probe route mounts in `main()`; verified by hand.

The `auth.py` exemption is the security-adjacent touch flagged in #46 — happy to split it into a follow-up if you'd rather keep this PR to the path config alone.
