### PR TITLE
Optional post-write hook for external sync/backup/webhooks

### DIFF
--- a/src/obsidian_vault_mcp/config.py
+++ b/src/obsidian_vault_mcp/config.py
@@ -74,6 +74,13 @@ def advertised_base_url(request_base_url: str) -> str:
     """
     return (VAULT_MCP_PUBLIC_URL or request_base_url).rstrip("/")
 
+# Optional post-write hook. When set, this shell command runs fire-and-forget in
+# a daemon thread after each successful vault mutation, with MCP_OPERATION (e.g.
+# "created"/"updated"/"moved"/"deleted") and MCP_PATHS (colon-separated, vault-
+# relative) injected into its environment. Empty = disabled (no-op, the default).
+# It executes an operator-configured command, so only set it to something you trust.
+VAULT_MCP_POST_WRITE_CMD = os.environ.get("VAULT_MCP_POST_WRITE_CMD", "")
+
 # Safety limits
 MAX_CONTENT_SIZE = 1_000_000  # 1MB max write size
 MAX_BATCH_SIZE = 20           # Max files per batch operation

--- a/src/obsidian_vault_mcp/hooks.py
+++ b/src/obsidian_vault_mcp/hooks.py
@@ -1,0 +1,83 @@
+"""Generic post-write hook dispatcher.
+
+After any vault mutation, tools call fire_post_write() with a human-readable
+operation string and the list of affected vault-relative paths.
+
+If ``VAULT_MCP_POST_WRITE_CMD`` is set, that shell command is executed
+fire-and-forget in a daemon thread.  Two environment variables are injected:
+
+    MCP_OPERATION   — e.g. "created", "updated", "deleted"
+    MCP_PATHS       — colon-separated vault-relative paths
+
+If the variable is not set, fire_post_write() is a no-op.
+"""
+
+import logging
+import os
+import subprocess
+import threading
+from collections.abc import Sequence
+
+from .config import VAULT_MCP_POST_WRITE_CMD
+
+logger = logging.getLogger(__name__)
+
+_PATH_SEP = ":"
+
+
+def _run_cmd(cmd: str, operation: str, paths: list[str]) -> None:
+    """Execute the configured post-write shell command.
+
+    Called inside a daemon thread — never raises, only logs.
+    """
+    env = os.environ.copy()
+    env["MCP_OPERATION"] = operation
+    env["MCP_PATHS"] = _PATH_SEP.join(paths)
+
+    try:
+        result = subprocess.run(
+            cmd,
+            shell=True,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        if result.returncode != 0:
+            logger.warning(
+                "post-write hook exited %d: %s",
+                result.returncode,
+                result.stderr.strip(),
+            )
+        else:
+            logger.debug("post-write hook ok: %s %s", operation, paths)
+    except subprocess.TimeoutExpired:
+        logger.warning("post-write hook timed out: %s %s", operation, paths)
+    except Exception as exc:
+        logger.warning("post-write hook error: %s", exc)
+
+
+def fire_post_write(operation: str, paths: Sequence[str]) -> None:
+    """Dispatch a post-write hook fire-and-forget.
+
+    Does nothing if ``VAULT_MCP_POST_WRITE_CMD`` is not configured.
+
+    Args:
+        operation: Human-readable verb describing the mutation
+                   (e.g. "created", "updated", "deleted", "moved").
+        paths:     Vault-relative paths of the affected files.
+    """
+    if not VAULT_MCP_POST_WRITE_CMD:
+        return
+
+    path_list = list(paths)
+    if not path_list:
+        return
+
+    t = threading.Thread(
+        target=_run_cmd,
+        args=(VAULT_MCP_POST_WRITE_CMD, operation, path_list),
+        daemon=True,
+        name="mcp-post-write",
+    )
+    t.start()

--- a/src/obsidian_vault_mcp/tools/manage.py
+++ b/src/obsidian_vault_mcp/tools/manage.py
@@ -3,6 +3,7 @@
 import json
 import logging
 
+from ..hooks import fire_post_write
 from ..vault import list_directory, move_path, delete_path, resolve_vault_path
 
 logger = logging.getLogger(__name__)
@@ -38,6 +39,7 @@ def vault_move(source: str, destination: str, create_dirs: bool = True) -> str:
     """Move a file or directory within the vault."""
     try:
         moved = move_path(source, destination, create_dirs=create_dirs)
+        fire_post_write("moved", [source, destination])
         return json.dumps({"source": source, "destination": destination, "moved": moved})
     except ValueError as e:
         return json.dumps({"error": str(e), "source": source, "destination": destination})
@@ -56,6 +58,7 @@ def vault_delete(path: str, confirm: bool = False) -> str:
 
     try:
         deleted = delete_path(path)
+        fire_post_write("deleted", [path])
         return json.dumps({"path": path, "deleted": deleted})
     except ValueError as e:
         return json.dumps({"error": str(e), "path": path})

--- a/src/obsidian_vault_mcp/tools/write.py
+++ b/src/obsidian_vault_mcp/tools/write.py
@@ -6,6 +6,7 @@ import logging
 
 import frontmatter
 
+from ..hooks import fire_post_write
 from ..vault import resolve_vault_path, read_file, write_file_atomic
 
 logger = logging.getLogger(__name__)
@@ -33,6 +34,8 @@ def vault_write(path: str, content: str, create_dirs: bool = True, merge_frontma
                 logger.warning(f"Frontmatter merge failed for {path}, writing as-is: {e}")
 
         is_new, size = write_file_atomic(path, content, create_dirs=create_dirs)
+
+        fire_post_write("created" if is_new else "updated", [path])
 
         return json.dumps({"path": path, "created": is_new, "size": size})
     except ValueError as e:
@@ -119,6 +122,7 @@ def vault_edit(path: str, edits: list[dict], dry_run: bool = False) -> str:
         changed = content != original_content
         if changed:
             write_file_atomic(path, content, create_dirs=False)
+            fire_post_write("updated", [path])
 
         return json.dumps({
             "path": path,
@@ -188,6 +192,7 @@ def vault_append(
         changed = new_content != existing_content
         if changed:
             _, size = write_file_atomic(path, new_content, create_dirs=create_dirs)
+            fire_post_write("created" if created else "updated", [path])
         else:
             size = len(existing_content.encode("utf-8"))
 
@@ -222,6 +227,7 @@ def vault_append(
 def vault_batch_frontmatter_update(updates: list[dict]) -> str:
     """Update frontmatter fields on multiple files without changing body content."""
     results = []
+    updated_paths: list[str] = []
 
     for update in updates:
         file_path = update.get("path", "")
@@ -238,11 +244,14 @@ def vault_batch_frontmatter_update(updates: list[dict]) -> str:
             write_file_atomic(file_path, new_content, create_dirs=False)
 
             results.append({"path": file_path, "updated": True})
+            updated_paths.append(file_path)
         except FileNotFoundError:
             results.append({"path": file_path, "updated": False, "error": "File not found"})
         except ValueError as e:
             results.append({"path": file_path, "updated": False, "error": str(e)})
         except Exception as e:
             results.append({"path": file_path, "updated": False, "error": str(e)})
+
+    fire_post_write("updated", updated_paths)
 
     return json.dumps({"results": results})

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -1,0 +1,66 @@
+"""Post-write hook: passes operation/paths via env, no-op when unset."""
+
+from obsidian_vault_mcp import hooks
+
+
+def test_run_cmd_injects_operation_and_paths(monkeypatch):
+    captured = {}
+
+    def fake_run(cmd, shell, env, capture_output, text, timeout):
+        captured["cmd"] = cmd
+        captured["shell"] = shell
+        captured["env"] = env
+
+        class R:
+            returncode = 0
+            stderr = ""
+
+        return R()
+
+    monkeypatch.setattr(hooks.subprocess, "run", fake_run)
+    hooks._run_cmd("echo hi", "created", ["a.md", "b.md"])
+
+    assert captured["cmd"] == "echo hi"
+    assert captured["shell"] is True
+    assert captured["env"]["MCP_OPERATION"] == "created"
+    assert captured["env"]["MCP_PATHS"] == "a.md:b.md"
+
+
+def test_fire_post_write_noop_when_unset(monkeypatch):
+    monkeypatch.setattr(hooks, "VAULT_MCP_POST_WRITE_CMD", "")
+
+    def fake_thread(*a, **k):
+        raise AssertionError("should not spawn a thread when unset")
+
+    monkeypatch.setattr(hooks.threading, "Thread", fake_thread)
+    hooks.fire_post_write("created", ["a.md"])  # must not raise
+
+
+def test_fire_post_write_noop_when_no_paths(monkeypatch):
+    monkeypatch.setattr(hooks, "VAULT_MCP_POST_WRITE_CMD", "echo hi")
+
+    def fake_thread(*a, **k):
+        raise AssertionError("should not spawn a thread with no paths")
+
+    monkeypatch.setattr(hooks.threading, "Thread", fake_thread)
+    hooks.fire_post_write("updated", [])  # empty path list -> no-op
+
+
+def test_fire_post_write_spawns_daemon_thread_when_configured(monkeypatch):
+    spawned = {}
+
+    class FakeThread:
+        def __init__(self, target, args, daemon, name):
+            spawned["args"] = args
+            spawned["daemon"] = daemon
+
+        def start(self):
+            spawned["started"] = True
+
+    monkeypatch.setattr(hooks, "VAULT_MCP_POST_WRITE_CMD", "echo hi")
+    monkeypatch.setattr(hooks.threading, "Thread", FakeThread)
+    hooks.fire_post_write("moved", ["a.md", "b.md"])
+
+    assert spawned["started"] is True
+    assert spawned["daemon"] is True
+    assert spawned["args"] == ("echo hi", "moved", ["a.md", "b.md"])


### PR DESCRIPTION
Closes #47.

**Problem:** nothing reacts to a mutation without polling (git sync, backup, webhook).

**Fix:** optional dispatcher. Set `VAULT_MCP_POST_WRITE_CMD` and it runs after each successful mutation, fire-and-forget in a daemon thread, with:
- `MCP_OPERATION`: created / updated / moved / deleted
- `MCP_PATHS`: colon-separated vault-relative paths

No-op when unset (default). Daemon thread with a timeout, logs on failure, so it can't block or fail a tool call. Generic runner, not a single-use flag.

**Call sites:** success path of `vault_write` / `vault_edit` / `vault_append` / `vault_batch_frontmatter_update` (write.py), `vault_move` / `vault_delete` (manage.py).

**Security:** runs an operator-configured shell command. Left the README alone; will add a docs note where you prefer.

**Tests:** 76 pass, 4 new (`test_hooks.py`): env injection, no-op unset, no-op empty paths, thread spawn.
