### PR TITLE
Optional heartbeat to a push URL for uptime monitoring

### DIFF
--- a/src/obsidian_vault_mcp/config.py
+++ b/src/obsidian_vault_mcp/config.py
@@ -74,6 +74,13 @@ def advertised_base_url(request_base_url: str) -> str:
     """
     return (VAULT_MCP_PUBLIC_URL or request_base_url).rstrip("/")
 
+# Optional liveness heartbeat. When VAULT_MCP_HEARTBEAT_URL is set, the server GETs
+# it every VAULT_MCP_HEARTBEAT_INTERVAL seconds from a daemon thread, for push-style
+# uptime monitors (Uptime Kuma, Healthchecks.io, Cronitor, ...). Empty = disabled
+# (the default); failures are logged, never fatal.
+VAULT_MCP_HEARTBEAT_URL = os.environ.get("VAULT_MCP_HEARTBEAT_URL", "")
+VAULT_MCP_HEARTBEAT_INTERVAL = int(os.environ.get("VAULT_MCP_HEARTBEAT_INTERVAL", "60"))
+
 # Safety limits
 MAX_CONTENT_SIZE = 1_000_000  # 1MB max write size
 MAX_BATCH_SIZE = 20           # Max files per batch operation

--- a/src/obsidian_vault_mcp/server.py
+++ b/src/obsidian_vault_mcp/server.py
@@ -8,6 +8,9 @@ import atexit
 import json
 import logging
 import sys
+import threading
+import time
+import urllib.request
 from contextlib import asynccontextmanager
 
 from mcp.server.fastmcp import FastMCP
@@ -16,6 +19,8 @@ from mcp.server.transport_security import TransportSecuritySettings
 from .config import (
     VAULT_MCP_ALLOWED_HOSTS,
     VAULT_MCP_FORWARDED_ALLOW_IPS,
+    VAULT_MCP_HEARTBEAT_INTERVAL,
+    VAULT_MCP_HEARTBEAT_URL,
     VAULT_MCP_HOST,
     VAULT_MCP_PORT,
     VAULT_MCP_TOKEN,
@@ -27,6 +32,27 @@ logger = logging.getLogger(__name__)
 
 # Global frontmatter index instance
 frontmatter_index = FrontmatterIndex()
+
+
+def _heartbeat_ping(url: str) -> None:
+    """Send a single liveness GET. Split out from the loop so it is unit-testable."""
+    with urllib.request.urlopen(url, timeout=10) as resp:
+        resp.read()
+
+
+def _heartbeat_forever(url: str, interval: int) -> None:
+    """Ping ``url`` every ``interval`` seconds for the process lifetime.
+
+    Runs in a daemon thread started from main() -- NOT the per-request MCP lifespan,
+    which fires on every request and would spawn a heartbeat per session. Failures
+    are logged and swallowed so a flaky monitor can never take the server down.
+    """
+    while True:
+        try:
+            _heartbeat_ping(url)
+        except Exception as e:
+            logger.warning("Heartbeat failed: %s", e)
+        time.sleep(interval)
 
 
 @asynccontextmanager
@@ -259,6 +285,17 @@ def main():
     logger.info(f"Starting vault MCP server. Vault: {VAULT_PATH}")
     frontmatter_index.start()
     atexit.register(frontmatter_index.stop)
+
+    # Optional liveness heartbeat. Daemon thread tied to the process (not the
+    # per-request lifespan), started only when configured. No-op when unset.
+    if VAULT_MCP_HEARTBEAT_URL:
+        threading.Thread(
+            target=_heartbeat_forever,
+            args=(VAULT_MCP_HEARTBEAT_URL, VAULT_MCP_HEARTBEAT_INTERVAL),
+            daemon=True,
+            name="heartbeat",
+        ).start()
+        logger.info("Heartbeat enabled (interval: %ds)", VAULT_MCP_HEARTBEAT_INTERVAL)
 
     # Build the Starlette app with auth middleware and OAuth endpoints
     try:

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -1,0 +1,43 @@
+"""Heartbeat pings the configured URL and never raises on failure."""
+
+from obsidian_vault_mcp import server
+
+
+def test_ping_hits_url(monkeypatch):
+    seen = {}
+
+    class FakeResp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def read(self):
+            return b""
+
+    def fake_urlopen(url, timeout):
+        seen["url"] = url
+        seen["timeout"] = timeout
+        return FakeResp()
+
+    monkeypatch.setattr(server.urllib.request, "urlopen", fake_urlopen)
+    server._heartbeat_ping("http://monitor.example/push")
+    assert seen["url"] == "http://monitor.example/push"
+
+
+def test_loop_swallows_errors(monkeypatch):
+    """A failing ping is logged and the loop proceeds to sleep, never propagating."""
+    def boom(url):
+        raise OSError("down")
+
+    def stop(_):
+        raise KeyboardInterrupt  # break out of the otherwise-infinite loop
+
+    monkeypatch.setattr(server, "_heartbeat_ping", boom)
+    monkeypatch.setattr(server.time, "sleep", stop)
+
+    try:
+        server._heartbeat_forever("http://x", 1)
+    except KeyboardInterrupt:
+        pass  # reaching sleep proves the OSError from the ping was swallowed


### PR DESCRIPTION
Closes #48.

**Problem:** no liveness signal for push-style uptime monitors.

**Fix:** set `VAULT_MCP_HEARTBEAT_URL` and a daemon thread GETs it every `VAULT_MCP_HEARTBEAT_INTERVAL`s (default 60). No-op when unset. Failed pings get logged and swallowed, so a flaky monitor can't take the server down.

The thread starts in `main()` (process lifetime), not the per-request lifespan; with `stateless_http=True` that would spawn one heartbeat per session (same reasoning as the index, #28).

`_heartbeat_ping` is split from the loop, so the GET and the error-swallowing loop test without a network or a real sleep.

**Tests:** 74 pass, 2 new (`test_heartbeat.py`).
