### PR TITLE
feat: Obsidian Canvas tools (read, add node, add edge) [Tier 1, #50]

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ Found a vulnerability? Please report it privately rather than opening a public i
 | `vault_list` | List directory contents with recursion depth, glob filtering, and file/dir toggles |
 | `vault_move` | Move or rename a file or directory within the vault |
 | `vault_delete` | Soft-delete a file by moving it to `.trash/` (requires explicit confirmation) |
+| `vault_canvas_read` | Read an Obsidian `.canvas` file and return its parsed nodes and edges |
+| `vault_canvas_add_node` | Append a node to a `.canvas` file (created if missing); generates an id when omitted and preserves unknown node fields |
+| `vault_canvas_add_edge` | Append an edge to an existing `.canvas` file; both endpoints must reference existing node ids |
 
 ## Prerequisites
 

--- a/src/obsidian_vault_mcp/models.py
+++ b/src/obsidian_vault_mcp/models.py
@@ -313,3 +313,89 @@ class VaultBatchFrontmatterUpdateInput(BaseModel):
             if "fields" not in item or not isinstance(item["fields"], dict):
                 raise ValueError(f"updates[{i}] must contain a 'fields' key with a dict value")
         return v
+
+
+def _validate_alnum_id(value: str | None) -> str | None:
+    if value is not None and not value.isalnum():
+        raise ValueError("id must be alphanumeric when provided")
+    return value
+
+
+class CanvasNodeInput(BaseModel):
+    """A single Obsidian Canvas node.
+
+    extra='allow' preserves Obsidian-specific fields (text, file, color, label,
+    subpath, ...) so appending a node never strips data on the round-trip.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    id: str | None = Field(default=None, description="Optional alphanumeric node id; generated when omitted")
+    type: str = Field(..., min_length=1, description="Canvas node type, e.g. text, file, link, or group")
+    x: int | float = Field(..., description="Canvas x coordinate")
+    y: int | float = Field(..., description="Canvas y coordinate")
+    width: int | float = Field(..., gt=0, description="Node width")
+    height: int | float = Field(..., gt=0, description="Node height")
+
+    @field_validator("id")
+    @classmethod
+    def _node_id_alnum(cls, v: str | None) -> str | None:
+        return _validate_alnum_id(v)
+
+
+class CanvasEdgeInput(BaseModel):
+    """A single Obsidian Canvas edge. extra='allow' preserves color/label/etc."""
+
+    model_config = ConfigDict(extra="allow")
+
+    id: str | None = Field(default=None, description="Optional alphanumeric edge id; generated when omitted")
+    fromNode: str = Field(..., min_length=1, description="Existing source node id")
+    fromSide: Literal["top", "right", "bottom", "left"] = Field(..., description="One of: top, right, bottom, left")
+    toNode: str = Field(..., min_length=1, description="Existing target node id")
+    toSide: Literal["top", "right", "bottom", "left"] = Field(..., description="One of: top, right, bottom, left")
+
+    @field_validator("id")
+    @classmethod
+    def _edge_id_alnum(cls, v: str | None) -> str | None:
+        return _validate_alnum_id(v)
+
+
+class VaultCanvasReadInput(BaseModel):
+    """Read and parse an Obsidian .canvas file."""
+
+    model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
+
+    path: str = Field(
+        ...,
+        description="Relative path to a .canvas file from the vault root",
+        min_length=1,
+        max_length=500,
+    )
+
+
+class VaultCanvasAddNodeInput(BaseModel):
+    """Append a node to a .canvas file."""
+
+    model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
+
+    path: str = Field(
+        ...,
+        description="Relative path to a .canvas file (created if missing)",
+        min_length=1,
+        max_length=500,
+    )
+    node: CanvasNodeInput = Field(..., description="Node to append")
+
+
+class VaultCanvasAddEdgeInput(BaseModel):
+    """Append an edge to an existing .canvas file."""
+
+    model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
+
+    path: str = Field(
+        ...,
+        description="Relative path to an existing .canvas file",
+        min_length=1,
+        max_length=500,
+    )
+    edge: CanvasEdgeInput = Field(..., description="Edge to append; fromNode/toNode must already exist")

--- a/src/obsidian_vault_mcp/server.py
+++ b/src/obsidian_vault_mcp/server.py
@@ -75,6 +75,11 @@ from .tools.write import (
 )
 from .tools.search import vault_search as _vault_search, vault_search_frontmatter as _vault_search_frontmatter
 from .tools.manage import vault_list as _vault_list, vault_move as _vault_move, vault_delete as _vault_delete
+from .tools.canvas import (
+    vault_canvas_read as _vault_canvas_read,
+    vault_canvas_add_node as _vault_canvas_add_node,
+    vault_canvas_add_edge as _vault_canvas_add_edge,
+)
 from .models import (
     VaultReadInput,
     VaultWriteInput,
@@ -87,6 +92,9 @@ from .models import (
     VaultListInput,
     VaultMoveInput,
     VaultDeleteInput,
+    VaultCanvasReadInput,
+    VaultCanvasAddNodeInput,
+    VaultCanvasAddEdgeInput,
 )
 
 
@@ -237,6 +245,46 @@ def vault_delete(path: str, confirm: bool = False) -> str:
     """Delete a file (move to .trash/)."""
     inp = VaultDeleteInput(path=path, confirm=confirm)
     return _vault_delete(inp.path, inp.confirm)
+
+
+@mcp.tool(
+    name="vault_canvas_read",
+    description="Read an Obsidian .canvas file and return its parsed nodes and edges.",
+    annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True, "openWorldHint": False},
+)
+def vault_canvas_read(path: str) -> str:
+    """Read an Obsidian Canvas file."""
+    inp = VaultCanvasReadInput(path=path)
+    return _vault_canvas_read(inp.path)
+
+
+@mcp.tool(
+    name="vault_canvas_add_node",
+    description=(
+        "Append a node to an Obsidian .canvas file, creating the file if it does not exist. Requires type, x, y, "
+        "width, height; an alphanumeric id is generated when omitted. Unknown node fields are preserved."
+    ),
+    annotations={"readOnlyHint": False, "destructiveHint": True, "idempotentHint": False, "openWorldHint": False},
+)
+def vault_canvas_add_node(path: str, node: dict) -> str:
+    """Append a node to a Canvas file."""
+    inp = VaultCanvasAddNodeInput(path=path, node=node)
+    return _vault_canvas_add_node(inp.path, inp.node.model_dump(exclude_none=True, mode="json"))
+
+
+@mcp.tool(
+    name="vault_canvas_add_edge",
+    description=(
+        "Append an edge to an existing Obsidian .canvas file. Requires fromNode, toNode, and fromSide/toSide "
+        "(top, right, bottom, left); both endpoints must reference existing node ids. An alphanumeric id is "
+        "generated when omitted."
+    ),
+    annotations={"readOnlyHint": False, "destructiveHint": True, "idempotentHint": False, "openWorldHint": False},
+)
+def vault_canvas_add_edge(path: str, edge: dict) -> str:
+    """Append an edge to a Canvas file."""
+    inp = VaultCanvasAddEdgeInput(path=path, edge=edge)
+    return _vault_canvas_add_edge(inp.path, inp.edge.model_dump(exclude_none=True, mode="json"))
 
 
 def main():

--- a/src/obsidian_vault_mcp/tools/canvas.py
+++ b/src/obsidian_vault_mcp/tools/canvas.py
@@ -1,0 +1,154 @@
+"""Canvas tools for the Obsidian vault MCP server.
+
+Read and append to Obsidian ``.canvas`` files. These are pure-filesystem JSON
+operations: no plugin, no network, no subprocess, no new config. Writes go
+through the atomic write path so Obsidian Sync never sees a partial file, and
+unknown node/edge fields are preserved so round-tripping a canvas is lossless.
+"""
+
+import json
+import logging
+import secrets
+import string
+
+from ..serialization import dumps
+from ..vault import read_file, resolve_vault_path, write_file_atomic
+
+logger = logging.getLogger(__name__)
+
+_CANVAS_ID_ALPHABET = string.ascii_letters + string.digits
+_CANVAS_ID_LENGTH = 16
+
+
+def _require_canvas_path(path: str) -> None:
+    """Validate the vault path and enforce the ``.canvas`` extension.
+
+    ``resolve_vault_path`` raises ValueError on traversal, dotfiles, or null
+    bytes; we re-use it so canvas paths get the same guard as every other tool.
+    """
+    resolve_vault_path(path)
+    if not path.lower().endswith(".canvas"):
+        raise ValueError("Canvas path must end with .canvas")
+
+
+def _load_canvas(path: str, *, must_exist: bool) -> dict:
+    """Load and structurally validate a ``.canvas`` JSON document."""
+    _require_canvas_path(path)
+    try:
+        content, _ = read_file(path)
+    except FileNotFoundError:
+        if must_exist:
+            raise ValueError(f"Canvas file not found: {path}") from None
+        return {"nodes": [], "edges": []}
+
+    try:
+        payload = json.loads(content)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid Canvas JSON: {exc.msg}") from exc
+
+    if not isinstance(payload, dict):
+        raise ValueError("Canvas file must contain a JSON object")
+    nodes = payload.get("nodes", [])
+    edges = payload.get("edges", [])
+    if not isinstance(nodes, list) or not isinstance(edges, list):
+        raise ValueError("Canvas file must contain 'nodes' and 'edges' arrays")
+    if not all(isinstance(item, dict) for item in nodes):
+        raise ValueError("Canvas nodes must be JSON objects")
+    if not all(isinstance(item, dict) for item in edges):
+        raise ValueError("Canvas edges must be JSON objects")
+    payload["nodes"] = nodes
+    payload["edges"] = edges
+    return payload
+
+
+def _existing_ids(items: list[dict]) -> set:
+    return {item["id"] for item in items if isinstance(item.get("id"), str)}
+
+
+def _generate_id(taken: set) -> str:
+    while True:
+        candidate = "".join(secrets.choice(_CANVAS_ID_ALPHABET) for _ in range(_CANVAS_ID_LENGTH))
+        if candidate not in taken:
+            return candidate
+
+
+def _canvas_body(canvas: dict) -> str:
+    """Serialize the canvas back to disk as indented JSON (Obsidian's format)."""
+    return json.dumps(canvas, ensure_ascii=False, indent=2) + "\n"
+
+
+def vault_canvas_read(path: str) -> str:
+    """Read and parse an Obsidian ``.canvas`` file."""
+    try:
+        canvas = _load_canvas(path, must_exist=True)
+        return dumps({"path": path, "nodes": canvas["nodes"], "edges": canvas["edges"]})
+    except ValueError as e:
+        return dumps({"error": str(e), "path": path})
+    except Exception as e:
+        logger.error(f"vault_canvas_read error for {path}: {e}")
+        return dumps({"error": str(e), "path": path})
+
+
+def vault_canvas_add_node(path: str, node: dict) -> str:
+    """Append a node to a ``.canvas`` file, creating the file when it is missing."""
+    try:
+        canvas = _load_canvas(path, must_exist=False)
+        node = dict(node)
+        taken = _existing_ids(canvas["nodes"]) | _existing_ids(canvas["edges"])
+        node_id = node.get("id")
+        if node_id is None:
+            node["id"] = _generate_id(taken)
+        elif node_id in taken:
+            return dumps({"error": f"Node id already exists: {node_id}", "path": path})
+
+        canvas["nodes"].append(node)
+        is_new, size = write_file_atomic(path, _canvas_body(canvas), create_dirs=True)
+        return dumps({
+            "path": path,
+            "created": is_new,
+            "size": size,
+            "node": node,
+            "nodes": canvas["nodes"],
+            "edges": canvas["edges"],
+        })
+    except ValueError as e:
+        return dumps({"error": str(e), "path": path})
+    except Exception as e:
+        logger.error(f"vault_canvas_add_node error for {path}: {e}")
+        return dumps({"error": str(e), "path": path})
+
+
+def vault_canvas_add_edge(path: str, edge: dict) -> str:
+    """Append an edge to an existing ``.canvas`` file."""
+    try:
+        canvas = _load_canvas(path, must_exist=True)
+        edge = dict(edge)
+        node_ids = _existing_ids(canvas["nodes"])
+        if edge["fromNode"] not in node_ids or edge["toNode"] not in node_ids:
+            return dumps({
+                "error": "fromNode and toNode must reference existing canvas node ids",
+                "path": path,
+            })
+
+        taken = node_ids | _existing_ids(canvas["edges"])
+        edge_id = edge.get("id")
+        if edge_id is None:
+            edge["id"] = _generate_id(taken)
+        elif edge_id in taken:
+            return dumps({"error": f"Edge id already exists: {edge_id}", "path": path})
+
+        canvas["edges"].append(edge)
+        is_new, size = write_file_atomic(path, _canvas_body(canvas), create_dirs=True)
+        return dumps({
+            "path": path,
+            "created": is_new,
+            "size": size,
+            "edge": edge,
+            "nodes": canvas["nodes"],
+            "edges": canvas["edges"],
+        })
+    except ValueError as e:
+        return dumps({"error": str(e), "path": path})
+    except Exception as e:
+        logger.error(f"vault_canvas_add_edge error for {path}: {e}")
+        return dumps({"error": str(e), "path": path})

--- a/tests/test_canvas.py
+++ b/tests/test_canvas.py
@@ -1,0 +1,151 @@
+"""Tests for the Obsidian Canvas tools (read / add node / add edge).
+
+Covers the happy path, abuse inputs (path traversal, wrong extension, malformed
+JSON, dangling edge references, schema violations) and the server wiring seam.
+"""
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from obsidian_vault_mcp import server
+from obsidian_vault_mcp.models import VaultCanvasAddNodeInput, VaultCanvasAddEdgeInput
+from obsidian_vault_mcp.tools.canvas import (
+    vault_canvas_add_edge,
+    vault_canvas_add_node,
+    vault_canvas_read,
+)
+
+
+def _write_canvas(vault_dir, name, payload):
+    (vault_dir / name).write_text(json.dumps(payload), encoding="utf-8")
+
+
+# --- read ------------------------------------------------------------------
+
+
+def test_canvas_read_parses_nodes_and_edges(vault_dir):
+    _write_canvas(vault_dir, "board.canvas", {
+        "nodes": [{"id": "n1", "type": "text", "x": 0, "y": 0, "width": 100, "height": 60, "text": "hi"}],
+        "edges": [],
+    })
+    result = json.loads(vault_canvas_read("board.canvas"))
+    assert "error" not in result
+    assert result["nodes"][0]["id"] == "n1"
+    assert result["nodes"][0]["text"] == "hi"
+    assert result["edges"] == []
+
+
+def test_canvas_read_missing_file_errors(vault_dir):
+    result = json.loads(vault_canvas_read("nope.canvas"))
+    assert "error" in result and "not found" in result["error"].lower()
+
+
+def test_canvas_read_rejects_non_canvas_extension(vault_dir):
+    result = json.loads(vault_canvas_read("test-note.md"))
+    assert "error" in result and ".canvas" in result["error"]
+
+
+def test_canvas_read_rejects_path_traversal(vault_dir):
+    result = json.loads(vault_canvas_read("../escape.canvas"))
+    assert "error" in result
+
+
+def test_canvas_read_rejects_malformed_json(vault_dir):
+    (vault_dir / "broken.canvas").write_text("{not json", encoding="utf-8")
+    result = json.loads(vault_canvas_read("broken.canvas"))
+    assert "error" in result and "JSON" in result["error"]
+
+
+# --- add node --------------------------------------------------------------
+
+
+def test_add_node_creates_file_and_generates_id(vault_dir):
+    result = json.loads(vault_canvas_add_node(
+        "new.canvas", {"type": "text", "x": 10, "y": 20, "width": 200, "height": 80, "text": "hello"}
+    ))
+    assert result["created"] is True
+    assert (vault_dir / "new.canvas").exists()
+    assert result["node"]["id"]  # generated
+    # round-trips through read, extra field preserved
+    read_back = json.loads(vault_canvas_read("new.canvas"))
+    assert read_back["nodes"][0]["text"] == "hello"
+    assert read_back["nodes"][0]["x"] == 10  # int preserved, not coerced to 10.0
+
+
+def test_add_node_appends_to_existing(vault_dir):
+    _write_canvas(vault_dir, "b.canvas", {"nodes": [{"id": "a1", "type": "text", "x": 0, "y": 0, "width": 50, "height": 50}], "edges": []})
+    result = json.loads(vault_canvas_add_node("b.canvas", {"type": "group", "x": 1, "y": 1, "width": 300, "height": 300}))
+    assert result["created"] is False
+    assert len(result["nodes"]) == 2
+
+
+def test_add_node_rejects_duplicate_id(vault_dir):
+    _write_canvas(vault_dir, "c.canvas", {"nodes": [{"id": "dup", "type": "text", "x": 0, "y": 0, "width": 50, "height": 50}], "edges": []})
+    result = json.loads(vault_canvas_add_node("c.canvas", {"id": "dup", "type": "text", "x": 5, "y": 5, "width": 50, "height": 50}))
+    assert "error" in result and "already exists" in result["error"]
+
+
+def test_add_node_invalid_schema_rejected_by_model(vault_dir):
+    # missing required dimensions / non-positive width are rejected at validation
+    with pytest.raises(ValidationError):
+        VaultCanvasAddNodeInput(path="x.canvas", node={"type": "text", "x": 0, "y": 0})
+    with pytest.raises(ValidationError):
+        VaultCanvasAddNodeInput(path="x.canvas", node={"type": "text", "x": 0, "y": 0, "width": 0, "height": 10})
+    with pytest.raises(ValidationError):
+        VaultCanvasAddNodeInput(path="x.canvas", node={"id": "not alnum!", "type": "text", "x": 0, "y": 0, "width": 1, "height": 1})
+
+
+# --- add edge --------------------------------------------------------------
+
+
+def test_add_edge_appends_with_reference_check(vault_dir):
+    _write_canvas(vault_dir, "g.canvas", {
+        "nodes": [
+            {"id": "n1", "type": "text", "x": 0, "y": 0, "width": 50, "height": 50},
+            {"id": "n2", "type": "text", "x": 100, "y": 0, "width": 50, "height": 50},
+        ],
+        "edges": [],
+    })
+    result = json.loads(vault_canvas_add_edge(
+        "g.canvas", {"fromNode": "n1", "fromSide": "right", "toNode": "n2", "toSide": "left"}
+    ))
+    assert "error" not in result
+    assert len(result["edges"]) == 1
+    assert result["edge"]["id"]  # generated
+
+
+def test_add_edge_rejects_unknown_node_reference(vault_dir):
+    _write_canvas(vault_dir, "h.canvas", {"nodes": [{"id": "n1", "type": "text", "x": 0, "y": 0, "width": 50, "height": 50}], "edges": []})
+    result = json.loads(vault_canvas_add_edge(
+        "h.canvas", {"fromNode": "n1", "fromSide": "right", "toNode": "ghost", "toSide": "left"}
+    ))
+    assert "error" in result and "existing canvas node ids" in result["error"]
+
+
+def test_add_edge_requires_existing_file(vault_dir):
+    result = json.loads(vault_canvas_add_edge(
+        "missing.canvas", {"fromNode": "n1", "fromSide": "right", "toNode": "n2", "toSide": "left"}
+    ))
+    assert "error" in result and "not found" in result["error"].lower()
+
+
+def test_add_edge_invalid_side_rejected_by_model(vault_dir):
+    with pytest.raises(ValidationError):
+        VaultCanvasAddEdgeInput(path="x.canvas", edge={"fromNode": "n1", "fromSide": "sideways", "toNode": "n2", "toSide": "left"})
+
+
+# --- server wiring (the @mcp.tool seam, not just the helper) ---------------
+
+
+def test_canvas_tools_registered_and_wired(vault_dir):
+    # tools are registered on the FastMCP server
+    for name in ("vault_canvas_read", "vault_canvas_add_node", "vault_canvas_add_edge"):
+        assert server.mcp._tool_manager.get_tool(name) is not None
+    # the server-level wrapper validates input and reaches the helper end to end
+    result = json.loads(server.vault_canvas_add_node(
+        "wired.canvas", {"type": "text", "x": 0, "y": 0, "width": 120, "height": 60, "text": "via wrapper"}
+    ))
+    assert result["created"] is True
+    assert (vault_dir / "wired.canvas").exists()


### PR DESCRIPTION
Adds the Canvas half of Tier 1 (#50). Three pure-filesystem tools for Obsidian `.canvas` files. Self-contained: no new routes, no config, no dependencies, no subprocess, no outbound requests.

## What it does

An Obsidian `.canvas` file is a JSON document of `nodes` and `edges` (the visual-thinking / whiteboard view). These tools let an MCP client read and grow a canvas without round-tripping the whole JSON blob through the model.

| Tool | What it does |
|------|--------------|
| `vault_canvas_read` | Read a `.canvas` file, return parsed `nodes` + `edges` |
| `vault_canvas_add_node` | Append a node (creates the file if missing); generates an alphanumeric id when omitted; preserves unknown node fields |
| `vault_canvas_add_edge` | Append an edge to an existing canvas; `fromNode`/`toNode` must reference existing node ids |

## Example

```
vault_canvas_add_node(path="boards/plan.canvas",
                      node={"type": "text", "text": "Kickoff", "x": 0, "y": 0, "width": 240, "height": 120})
# -> creates boards/plan.canvas, returns the node with a generated "id"

vault_canvas_add_edge(path="boards/plan.canvas",
                      edge={"fromNode": "<id-1>", "fromSide": "right", "toNode": "<id-2>", "toSide": "left"})
# -> appends the edge; errors if either node id does not exist
```

Coordinates accept `int | float` so ints are not coerced to floats, and node/edge models use `extra="allow"` so Obsidian-specific fields (text, file, color, label, ...) survive an append. Round-tripping a canvas through read -> add -> read is lossless.

## How it fits the bar

- **No new attack surface.** Tools only (behind the existing bearer middleware); no new routes, config, dependencies (stdlib `json`), subprocess, or outbound.
- **Paths** go through `resolve_vault_path` plus a `.canvas` extension check.
- **Writes** go through `write_file_atomic`, so Obsidian Sync never sees a partial file.

## Tests (`tests/test_canvas.py`, 14 cases)

Happy path (read, add node with id-gen, add edge with reference check), abuse inputs (path traversal, non-`.canvas` extension, malformed JSON, dangling edge reference, schema violations via the model), and the server wiring seam (tools registered + the `@mcp.tool` wrapper reaches the helper end to end).

Full suite green on Linux: **194 passed, 1 skipped** (180 baseline + 14 new). (Run on Linux/macOS -- `tests/test_oauth.py` uses `os.fchmod`, unavailable on Windows; unrelated to this PR.)

## CONTRIBUTING checklist

- [x] One self-contained change, rebased on `main` (not stacked)
- [x] Full test suite passes locally (`pytest`) -- 194 passed, 1 skipped on Linux
- [x] New/abuse inputs covered by tests; the tool wiring is tested, not just helpers
- [x] Auth: no new route/mount (tools only, behind existing bearer middleware); fails closed
- [x] Paths go through `resolve_vault_path`; resolved path re-validated
- [x] No `shell=True` on request input; subprocess env scrubbed -- N/A (no subprocess)
- [x] Outbound requests don't follow redirects to private ranges; size capped -- N/A (no outbound)
- [x] No secrets/tokens/capability URLs in logs
- [x] New config validated at startup, fails closed, off by default if risky -- N/A (no new config)
- [x] Bridge/optional deps fail soft; heavy deps optional -- N/A (stdlib only)
- [x] Writes go through the atomic write path
- [x] README updated (three tools added to the tool table)
