### PR TITLE
feat: daily-note tools (path, read, append) [Tier 1, #50]

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ Found a vulnerability? Please report it privately rather than opening a public i
 | `vault_list` | List directory contents with recursion depth, glob filtering, and file/dir toggles |
 | `vault_move` | Move or rename a file or directory within the vault |
 | `vault_delete` | Soft-delete a file by moving it to `.trash/` (requires explicit confirmation) |
+| `vault_daily_note_path` | Resolve today's daily-note path from the configured folder/format |
+| `vault_daily_note_read` | Read today's daily note; returns an error (does not create it) when missing |
+| `vault_daily_note_append` | Append to today's daily note, creating it from the template when missing |
 
 ## Prerequisites
 
@@ -119,6 +122,9 @@ All configuration is via environment variables:
 | `VAULT_OAUTH_CLIENT_ID` | No | `vault-mcp-client` | Client ID for the headless `client_credentials` grant |
 | `VAULT_OAUTH_CLIENT_SECRET` | No | (none) | Only required for the headless `client_credentials` grant. The Claude/ChatGPT browser flow uses dynamic client registration and does **not** need this. |
 | `VAULT_OAUTH_REDIRECT_URIS` | No | (none) | Comma-separated allowlist of redirect URIs for the static `VAULT_OAUTH_CLIENT_ID` when using the browser flow. Dynamically-registered clients (Claude/ChatGPT) carry their own; leave unset unless you connect a static client through `/oauth/authorize`. |
+| `VAULT_DAILY_NOTES_FOLDER` | No | (none) | Folder for the daily-note tools; empty means the vault root |
+| `VAULT_DAILY_NOTES_FORMAT` | No | `%Y-%m-%d` | `strftime` pattern for the daily-note filename |
+| `VAULT_DAILY_NOTES_TEMPLATE` | No | (none) | `strftime` template prepended when a daily note is first created |
 
 Generate secrets with: `python -c "import secrets; print(secrets.token_hex(32))"`
 

--- a/src/obsidian_vault_mcp/config.py
+++ b/src/obsidian_vault_mcp/config.py
@@ -6,6 +6,13 @@ VAULT_PATH = Path(os.environ.get("VAULT_PATH", os.path.expanduser("~/Obsidian/My
 VAULT_MCP_TOKEN = os.environ.get("VAULT_MCP_TOKEN", "")
 VAULT_MCP_PORT = int(os.environ.get("VAULT_MCP_PORT", "8420"))
 
+# Daily-note tools. FOLDER "" means the vault root; FORMAT/TEMPLATE are strftime
+# patterns. All optional with safe defaults; resolved paths still go through
+# resolve_vault_path.
+VAULT_DAILY_NOTES_FOLDER = os.environ.get("VAULT_DAILY_NOTES_FOLDER", "")
+VAULT_DAILY_NOTES_FORMAT = os.environ.get("VAULT_DAILY_NOTES_FORMAT", "%Y-%m-%d").strip() or "%Y-%m-%d"
+VAULT_DAILY_NOTES_TEMPLATE = os.environ.get("VAULT_DAILY_NOTES_TEMPLATE", "")
+
 # OAuth 2.0 client credentials (for Claude app integration)
 VAULT_OAUTH_CLIENT_ID = os.environ.get("VAULT_OAUTH_CLIENT_ID", "vault-mcp-client")
 VAULT_OAUTH_CLIENT_SECRET = os.environ.get("VAULT_OAUTH_CLIENT_SECRET", "")

--- a/src/obsidian_vault_mcp/models.py
+++ b/src/obsidian_vault_mcp/models.py
@@ -313,3 +313,15 @@ class VaultBatchFrontmatterUpdateInput(BaseModel):
             if "fields" not in item or not isinstance(item["fields"], dict):
                 raise ValueError(f"updates[{i}] must contain a 'fields' key with a dict value")
         return v
+
+
+class VaultDailyNoteAppendInput(BaseModel):
+    """Append content to today's daily note."""
+
+    model_config = ConfigDict(str_strip_whitespace=False, extra="forbid")
+
+    content: str = Field(
+        ...,
+        description="Content to append to today's daily note (the note is created from the template if missing)",
+        max_length=MAX_CONTENT_SIZE,
+    )

--- a/src/obsidian_vault_mcp/server.py
+++ b/src/obsidian_vault_mcp/server.py
@@ -75,6 +75,11 @@ from .tools.write import (
 )
 from .tools.search import vault_search as _vault_search, vault_search_frontmatter as _vault_search_frontmatter
 from .tools.manage import vault_list as _vault_list, vault_move as _vault_move, vault_delete as _vault_delete
+from .tools.daily import (
+    vault_daily_note_path as _vault_daily_note_path,
+    vault_daily_note_read as _vault_daily_note_read,
+    vault_daily_note_append as _vault_daily_note_append,
+)
 from .models import (
     VaultReadInput,
     VaultWriteInput,
@@ -87,6 +92,7 @@ from .models import (
     VaultListInput,
     VaultMoveInput,
     VaultDeleteInput,
+    VaultDailyNoteAppendInput,
 )
 
 
@@ -237,6 +243,37 @@ def vault_delete(path: str, confirm: bool = False) -> str:
     """Delete a file (move to .trash/)."""
     inp = VaultDeleteInput(path=path, confirm=confirm)
     return _vault_delete(inp.path, inp.confirm)
+
+
+@mcp.tool(
+    name="vault_daily_note_path",
+    description="Return today's daily-note path (server local date), derived from VAULT_DAILY_NOTES_FOLDER and VAULT_DAILY_NOTES_FORMAT. Does not read or create the file.",
+    annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True, "openWorldHint": False},
+)
+def vault_daily_note_path() -> str:
+    """Resolve today's daily-note path."""
+    return _vault_daily_note_path()
+
+
+@mcp.tool(
+    name="vault_daily_note_read",
+    description="Read today's daily note. Returns an error payload (does not create the note) when it does not exist.",
+    annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True, "openWorldHint": False},
+)
+def vault_daily_note_read() -> str:
+    """Read today's daily note."""
+    return _vault_daily_note_read()
+
+
+@mcp.tool(
+    name="vault_daily_note_append",
+    description="Append content to today's daily note, creating it from VAULT_DAILY_NOTES_TEMPLATE when missing. Token-efficient daily logging without resending the note body.",
+    annotations={"readOnlyHint": False, "destructiveHint": True, "idempotentHint": False, "openWorldHint": False},
+)
+def vault_daily_note_append(content: str) -> str:
+    """Append to today's daily note."""
+    inp = VaultDailyNoteAppendInput(content=content)
+    return _vault_daily_note_append(inp.content)
 
 
 def main():

--- a/src/obsidian_vault_mcp/tools/daily.py
+++ b/src/obsidian_vault_mcp/tools/daily.py
@@ -1,0 +1,112 @@
+"""Daily-note convenience tools.
+
+Resolve, read, and append to a date-stamped daily note. The path is built from
+the server's local date and three config knobs:
+
+- ``VAULT_DAILY_NOTES_FOLDER``   directory for daily notes ("" = vault root)
+- ``VAULT_DAILY_NOTES_FORMAT``   strftime pattern for the filename (default %Y-%m-%d)
+- ``VAULT_DAILY_NOTES_TEMPLATE`` strftime template prepended when the note is first created
+
+Pure filesystem: no plugin, no network. Writes go through the existing
+``vault_append`` path (atomic write); paths go through ``resolve_vault_path``.
+"""
+
+import json
+import logging
+from datetime import datetime
+from pathlib import PurePosixPath
+
+from .. import config
+from ..serialization import dumps
+from ..vault import read_file, resolve_vault_path
+from .write import vault_append
+
+logger = logging.getLogger(__name__)
+
+
+def _today():
+    """Return the server's current local date."""
+    return datetime.now().date()
+
+
+def _daily_note_path(for_date) -> str:
+    """Build the configured daily-note path for a date."""
+    filename = for_date.strftime(config.VAULT_DAILY_NOTES_FORMAT)
+    if not filename.lower().endswith((".md", ".markdown")):
+        filename = f"{filename}.md"
+    folder = config.VAULT_DAILY_NOTES_FOLDER.strip().strip("/\\")
+    if folder:
+        return str(PurePosixPath(folder) / filename)
+    return filename
+
+
+def _initial_content(content: str, for_date) -> str:
+    """Template (if any) prepended to the first content written to a new note."""
+    template = for_date.strftime(config.VAULT_DAILY_NOTES_TEMPLATE)
+    if not template:
+        return content
+    if content and not template.endswith("\n"):
+        return f"{template}\n{content}"
+    return f"{template}{content}"
+
+
+def vault_daily_note_path() -> str:
+    """Return today's daily-note path using the server's local date."""
+    day = _today()
+    try:
+        path = _daily_note_path(day)
+        resolve_vault_path(path)
+        return dumps({
+            "path": path,
+            "date": day.isoformat(),
+            "folder": config.VAULT_DAILY_NOTES_FOLDER,
+            "format": config.VAULT_DAILY_NOTES_FORMAT,
+        })
+    except ValueError as e:
+        return dumps({"error": str(e)})
+    except Exception as e:
+        logger.error(f"vault_daily_note_path error: {e}")
+        return dumps({"error": str(e)})
+
+
+def vault_daily_note_read() -> str:
+    """Read today's daily note. Returns an error payload when it does not exist
+    (does not create it)."""
+    day = _today()
+    path = _daily_note_path(day)
+    try:
+        content, metadata = read_file(path)
+        return dumps({"path": path, "date": day.isoformat(), "content": content, "metadata": metadata})
+    except FileNotFoundError:
+        return dumps({"error": f"Daily note not found: {path}", "path": path, "date": day.isoformat()})
+    except ValueError as e:
+        return dumps({"error": str(e), "path": path})
+    except Exception as e:
+        logger.error(f"vault_daily_note_read error for {path}: {e}")
+        return dumps({"error": str(e), "path": path})
+
+
+def vault_daily_note_append(content: str) -> str:
+    """Append to today's daily note, creating it (with the template) when missing."""
+    day = _today()
+    path = _daily_note_path(day)
+    try:
+        try:
+            read_file(path)
+            created = False
+            payload = content
+        except FileNotFoundError:
+            created = True
+            payload = _initial_content(content, day)
+
+        result = json.loads(vault_append(path, payload))
+        if "error" not in result:
+            result["date"] = day.isoformat()
+            result["daily_note"] = True
+            result["created"] = created
+        return dumps(result)
+    except ValueError as e:
+        return dumps({"error": str(e), "path": path})
+    except Exception as e:
+        logger.error(f"vault_daily_note_append error for {path}: {e}")
+        return dumps({"error": str(e), "path": path})

--- a/tests/test_daily_notes.py
+++ b/tests/test_daily_notes.py
@@ -1,0 +1,66 @@
+"""Daily-note tools: path resolution, read (no create), append (create+template)."""
+
+import json
+from datetime import datetime
+
+from obsidian_vault_mcp import config, server
+from obsidian_vault_mcp.tools.daily import (
+    vault_daily_note_append,
+    vault_daily_note_path,
+    vault_daily_note_read,
+)
+
+
+def _set_daily(monkeypatch, folder="", fmt="%Y-%m-%d", template=""):
+    monkeypatch.setattr(config, "VAULT_DAILY_NOTES_FOLDER", folder)
+    monkeypatch.setattr(config, "VAULT_DAILY_NOTES_FORMAT", fmt)
+    monkeypatch.setattr(config, "VAULT_DAILY_NOTES_TEMPLATE", template)
+
+
+def test_path_uses_format_and_folder(vault_dir, monkeypatch):
+    _set_daily(monkeypatch, folder="journal", fmt="%Y-%m-%d")
+    result = json.loads(vault_daily_note_path())
+    assert result["path"] == "journal/" + datetime.now().strftime("%Y-%m-%d") + ".md"
+    assert result["folder"] == "journal"
+
+
+def test_read_missing_returns_error_and_does_not_create(vault_dir, monkeypatch):
+    _set_daily(monkeypatch)
+    result = json.loads(vault_daily_note_read())
+    assert "error" in result and "not found" in result["error"].lower()
+    assert not (vault_dir / result["path"]).exists()
+
+
+def test_append_creates_with_template_then_appends(vault_dir, monkeypatch):
+    _set_daily(monkeypatch, template="# %Y-%m-%d\n")
+    first = json.loads(vault_daily_note_append("first line"))
+    assert first["created"] is True
+    assert first["daily_note"] is True
+
+    path = json.loads(vault_daily_note_path())["path"]
+    body = (vault_dir / path).read_text(encoding="utf-8")
+    assert body.startswith("# " + datetime.now().strftime("%Y-%m-%d"))
+    assert "first line" in body
+
+    second = json.loads(vault_daily_note_append("second line"))
+    assert second["created"] is False
+    body2 = (vault_dir / path).read_text(encoding="utf-8")
+    assert "first line" in body2 and "second line" in body2
+
+
+def test_read_after_append_returns_content(vault_dir, monkeypatch):
+    _set_daily(monkeypatch)
+    vault_daily_note_append("hello daily")
+    result = json.loads(vault_daily_note_read())
+    assert "error" not in result
+    assert "hello daily" in result["content"]
+
+
+def test_tools_registered_and_append_wired(vault_dir, monkeypatch):
+    for name in ("vault_daily_note_path", "vault_daily_note_read", "vault_daily_note_append"):
+        assert server.mcp._tool_manager.get_tool(name) is not None
+    _set_daily(monkeypatch)
+    # server wrapper validates input and reaches the helper end to end
+    result = json.loads(server.vault_daily_note_append("via wrapper"))
+    assert result["created"] is True
+    assert "via wrapper" in json.loads(vault_daily_note_read())["content"]


### PR DESCRIPTION
Adds the daily-note half of Tier 1 (#50). Three pure-filesystem tools for a date-stamped daily note. Self-contained: no new routes, no dependencies, no subprocess, no outbound requests.

## What it does

A *daily note* is a single markdown file per calendar day (a common Obsidian workflow: journaling, a running log, capturing tasks). These tools let an MCP client work with "today's note" without computing the path or resending the body each turn.

| Tool | What it does |
|------|--------------|
| `vault_daily_note_path` | Resolve today's daily-note path from the server's local date. Does not read or create. |
| `vault_daily_note_read` | Read today's note. Returns an error payload (does **not** create it) when missing. |
| `vault_daily_note_append` | Append to today's note; creates it from the template when missing. Token-efficient daily logging. |

The path is `<FOLDER>/<date>.md`, built from three optional config knobs (all with safe defaults, all `strftime`):

- `VAULT_DAILY_NOTES_FOLDER` -- folder for daily notes; empty = vault root
- `VAULT_DAILY_NOTES_FORMAT` -- filename pattern, default `%Y-%m-%d`
- `VAULT_DAILY_NOTES_TEMPLATE` -- prepended once, when the note is first created

## Example

With `VAULT_DAILY_NOTES_FOLDER=Journal`, `VAULT_DAILY_NOTES_TEMPLATE="# %Y-%m-%d\n\n"`:

```
vault_daily_note_append(content="- 09:14 shipped the daily-note PR")
# creates Journal/2026-06-13.md as:
#   # 2026-06-13
#
#   - 09:14 shipped the daily-note PR
# a later append the same day adds to it; created=false
```

## How it fits the bar

- **No new attack surface.** Tools only; they run behind the existing bearer middleware. No new config that is risky (the knobs are path-shaping, defaults are safe), no new dependencies, no subprocess, no outbound.
- **Paths** go through `resolve_vault_path` (the resolved daily path is validated like any other).
- **Writes** reuse `vault_append`, i.e. the existing atomic write path; `append` creates-if-missing via that same path.
- **`read` does not create** -- a missing note returns an error payload rather than silently materialising a file.

## Tests (`tests/test_daily_notes.py`, 5 cases)

Path resolution honours folder/format; `read` on a missing note errors and does not create; `append` creates with the template then appends on the second call (`created` flips to false); `read` returns appended content; tools are registered and the `append` wrapper reaches the helper end to end.

Full suite green on Linux: **185 passed, 1 skipped** (180 baseline + 5 new). (Run on Linux/macOS -- `tests/test_oauth.py` uses `os.fchmod`, unavailable on Windows; unrelated to this PR.)

## CONTRIBUTING checklist

- [x] One self-contained change, rebased on `main` (not stacked)
- [x] Full test suite passes locally (`pytest`) -- 185 passed, 1 skipped on Linux
- [x] New/abuse inputs covered by tests; the tool wiring is tested, not just helpers
- [x] Auth: no new route/mount (tools only, behind existing bearer middleware); fails closed
- [x] Paths go through `resolve_vault_path`; resolved path re-validated
- [x] No `shell=True` on request input; subprocess env scrubbed -- N/A (no subprocess)
- [x] Outbound requests don't follow redirects to private ranges; size capped -- N/A (no outbound)
- [x] No secrets/tokens/capability URLs in logs
- [x] New config has safe defaults and is off/inert by default (empty folder = root, default format); validated by the existing path guard
- [x] Bridge/optional deps fail soft; heavy deps optional -- N/A (stdlib only)
- [x] Writes go through the atomic write path (`vault_append`)
- [x] README updated (three tools in the tool table + three env vars in the config table)
