### PR TITLE
feat: append-only JSONL audit log for vault mutations [#50]

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ All configuration is via environment variables:
 | `VAULT_DAILY_NOTES_TEMPLATE` | No | (none) | `strftime` template prepended when a daily note is first created |
 | `VAULT_MCP_HEARTBEAT_URL` | No | (none) | Optional push URL for an uptime monitor (Uptime Kuma, Healthchecks.io, ...). When set, a daemon thread GETs it on an interval. Must be `http(s)`; redirects are not followed and the URL is treated as a secret (never logged in full). Empty = disabled. |
 | `VAULT_MCP_HEARTBEAT_INTERVAL` | No | `60` | Seconds between heartbeat pings. Must be a positive integer; a bad value fails closed at startup. Only used when `VAULT_MCP_HEARTBEAT_URL` is set. |
-| `VAULT_AUDIT_LOG_PATH` | No | (none) | Append-only JSONL audit log of vault mutations. When set, every mutation appends one record; empty disables auditing. The raw bearer token is never written -- only its SHA-256 hash. Validated as writable at startup (an unwritable path **fails the server closed**). See [Audit logging](#audit-logging). |
+| `VAULT_AUDIT_LOG_PATH` | No | (none) | Append-only JSONL audit log of vault mutations. When set, every mutation appends one record; empty disables auditing. The raw bearer token is never written -- only its SHA-256 hash. Must resolve **outside** the vault and be writable; otherwise the server **fails closed** at startup. See [Audit logging](#audit-logging). |
 | `VAULT_AUDIT_LOG_INCLUDE_READS` | No | `false` | Also record read/search operations (`1`/`true`/`yes`/`on`). Off by default; mutations are always logged once the audit log is enabled. |
 
 Generate secrets with: `python -c "import secrets; print(secrets.token_hex(32))"`
@@ -152,12 +152,20 @@ raw token is never written), `client_id` (a best-effort User-Agent hint), `opera
 {"checksum_after":"9f86d0…","checksum_before":null,"client_id":"claude","error":null,"operation":"vault_write","operation_status":"success","request_id":"a1b2…","size_after":42,"size_before":null,"target_path":"notes/today.md","timestamp":"2026-06-14T18:30:00+00:00","token_id_hash":"5e88…"}
 ```
 
-The log path is validated at startup: if it is set but not writable, the server refuses to
-start rather than silently dropping records (fail-closed). A write failure at runtime is
-logged and counted but never alters the tool result -- the audit trail cannot break a write.
-The `GET /health` endpoint (no auth required) reports audit status under an `audit` key:
-whether it is enabled, the log path, whether reads are included, the last write time, and 24h
-write-error and byte counts.
+**Put the log outside the vault.** `VAULT_AUDIT_LOG_PATH` must resolve outside `VAULT_PATH`.
+A log inside the vault would be just another file the vault tools can reach, so an
+authenticated caller could overwrite it (`vault_write`) or move it (`vault_delete`) and
+defeat the append-only premise. The server validates this at startup and **refuses to start
+(fail-closed)** if the path is not writable or resolves inside the vault.
+
+**Threat model — the log is best-effort at runtime, not tamper-evident.** A write failure
+at runtime is logged to the server log but never alters the tool result (the audit trail
+must not be able to break a write), so a record can be dropped silently; the server log is
+the only signal. Batch mutations emit one record per file with that file's own status, so a
+partial failure is never recorded as a whole-batch success. The unauthenticated `GET /health`
+endpoint reports only `{"status": "ok", "audit": {"enabled": <bool>}}` — it deliberately does
+not expose the log path or write counters (which would leak host filesystem layout and a
+vault-activity side-channel to anonymous callers over the tunnel).
 
 ## Connecting to Claude
 

--- a/README.md
+++ b/README.md
@@ -131,8 +131,33 @@ All configuration is via environment variables:
 | `VAULT_DAILY_NOTES_TEMPLATE` | No | (none) | `strftime` template prepended when a daily note is first created |
 | `VAULT_MCP_HEARTBEAT_URL` | No | (none) | Optional push URL for an uptime monitor (Uptime Kuma, Healthchecks.io, ...). When set, a daemon thread GETs it on an interval. Must be `http(s)`; redirects are not followed and the URL is treated as a secret (never logged in full). Empty = disabled. |
 | `VAULT_MCP_HEARTBEAT_INTERVAL` | No | `60` | Seconds between heartbeat pings. Must be a positive integer; a bad value fails closed at startup. Only used when `VAULT_MCP_HEARTBEAT_URL` is set. |
+| `VAULT_AUDIT_LOG_PATH` | No | (none) | Append-only JSONL audit log of vault mutations. When set, every mutation appends one record; empty disables auditing. The raw bearer token is never written -- only its SHA-256 hash. Validated as writable at startup (an unwritable path **fails the server closed**). See [Audit logging](#audit-logging). |
+| `VAULT_AUDIT_LOG_INCLUDE_READS` | No | `false` | Also record read/search operations (`1`/`true`/`yes`/`on`). Off by default; mutations are always logged once the audit log is enabled. |
 
 Generate secrets with: `python -c "import secrets; print(secrets.token_hex(32))"`
+
+## Audit logging
+
+Set `VAULT_AUDIT_LOG_PATH` to a file path to record every vault mutation as an append-only
+JSON line. Auditing is **off by default**; with no path set there is no overhead. Reads and
+searches are logged too when `VAULT_AUDIT_LOG_INCLUDE_READS` is on (off by default, since
+reads are high-volume).
+
+Each record carries: `timestamp` (UTC), `token_id_hash` (SHA-256 of the bearer token -- the
+raw token is never written), `client_id` (a best-effort User-Agent hint), `operation`,
+`target_path`, `size_before`/`size_after`, `checksum_before`/`checksum_after` (SHA-256),
+`request_id`, `operation_status`, and `error`. Example line:
+
+```json
+{"checksum_after":"9f86d0…","checksum_before":null,"client_id":"claude","error":null,"operation":"vault_write","operation_status":"success","request_id":"a1b2…","size_after":42,"size_before":null,"target_path":"notes/today.md","timestamp":"2026-06-14T18:30:00+00:00","token_id_hash":"5e88…"}
+```
+
+The log path is validated at startup: if it is set but not writable, the server refuses to
+start rather than silently dropping records (fail-closed). A write failure at runtime is
+logged and counted but never alters the tool result -- the audit trail cannot break a write.
+The `GET /health` endpoint (no auth required) reports audit status under an `audit` key:
+whether it is enabled, the log path, whether reads are included, the last write time, and 24h
+write-error and byte counts.
 
 ## Connecting to Claude
 

--- a/src/obsidian_vault_mcp/audit.py
+++ b/src/obsidian_vault_mcp/audit.py
@@ -1,0 +1,250 @@
+"""Append-only JSON-lines audit log for vault mutations.
+
+When VAULT_AUDIT_LOG_PATH is set, every vault mutation appends one JSON record to that
+file: a UTC timestamp, a SHA-256 hash of the bearer token (never the token itself), the
+operation, the target path, and the size + checksum of the target before and after the
+change. Read/search operations are logged too when VAULT_AUDIT_LOG_INCLUDE_READS is on.
+
+Auditing is off unless a log path is configured. A failure to write a record is logged
+and counted but never alters the tool result -- the audit trail must not be able to break
+a write. The log path is validated as writable at startup (see server.main), so a
+misconfigured path fails the server closed rather than silently dropping records.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import uuid
+from collections import deque
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from . import config
+from .context import current_request_context
+from .serialization import dumps
+from .vault import resolve_vault_path
+
+logger = logging.getLogger(__name__)
+
+# Operations that change the vault. Always audited when a log path is configured.
+MUTATION_OPERATIONS = {
+    "vault_write",
+    "vault_edit",
+    "vault_append",
+    "vault_batch_frontmatter_update",
+    "vault_move",
+    "vault_delete",
+    "vault_canvas_add_node",
+    "vault_canvas_add_edge",
+    "vault_daily_note_append",
+}
+
+# Read/search operations. Audited only when VAULT_AUDIT_LOG_INCLUDE_READS is enabled.
+READ_OPERATIONS = {
+    "vault_read",
+    "vault_batch_read",
+    "vault_search",
+    "vault_search_frontmatter",
+    "vault_list",
+    "vault_canvas_read",
+    "vault_daily_note_read",
+}
+
+_AUDIT_WINDOW = timedelta(hours=24)
+_audit_write_events: deque[dict[str, Any]] = deque()
+
+
+def audit_enabled() -> bool:
+    """True when append-only audit logging is configured."""
+    return bool(config.VAULT_AUDIT_LOG_PATH)
+
+
+def read_audit_enabled() -> bool:
+    """True when read/search operations should also be audited."""
+    return audit_enabled() and bool(config.VAULT_AUDIT_LOG_INCLUDE_READS)
+
+
+def should_audit_operation(operation: str) -> bool:
+    """True when this operation should emit a record under the current config.
+
+    False whenever auditing is off, so the wrapper is a true passthrough (no snapshot
+    work) on the default path.
+    """
+    if not audit_enabled():
+        return False
+    return operation in MUTATION_OPERATIONS or (
+        operation in READ_OPERATIONS and read_audit_enabled()
+    )
+
+
+def audit_log_path() -> Path:
+    return Path(config.VAULT_AUDIT_LOG_PATH).expanduser()
+
+
+def audit_path_writable(path: Path | None = None) -> bool:
+    """True when the audit log can be written (creating intermediate dirs if needed).
+
+    An existing log must be a writable file. Otherwise the log is creatable when the
+    nearest existing ancestor is a writable directory -- write_audit_record mkdirs the
+    intermediate dirs. A path whose parent is a regular file is rejected.
+    """
+    path = path or audit_log_path()
+    try:
+        if path.exists():
+            return path.is_file() and os.access(path, os.W_OK)
+        ancestor = path.parent
+        while not ancestor.exists():
+            if ancestor.parent == ancestor:
+                return False
+            ancestor = ancestor.parent
+        return ancestor.is_dir() and os.access(ancestor, os.W_OK)
+    except OSError:
+        return False
+
+
+def _now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _prune_audit_events(now: datetime | None = None) -> None:
+    now = now or _now_utc()
+    cutoff = now - _AUDIT_WINDOW
+    while _audit_write_events and _audit_write_events[0]["timestamp"] < cutoff:
+        _audit_write_events.popleft()
+
+
+def reset_audit_health_state() -> None:
+    """Clear the in-memory health counters. For tests and restarts."""
+    _audit_write_events.clear()
+
+
+def _record_audit_write(success: bool, bytes_written: int = 0) -> None:
+    now = _now_utc()
+    _audit_write_events.append(
+        {"timestamp": now, "success": success, "bytes_written": bytes_written if success else 0}
+    )
+    _prune_audit_events(now)
+
+
+def audit_health_payload() -> dict[str, Any]:
+    """Audit status for the /health endpoint (process-local 24h counters)."""
+    if not audit_enabled():
+        return {"enabled": False}
+    if not audit_path_writable():
+        return {"enabled": False, "writable": False, "log_path": str(audit_log_path())}
+    now = _now_utc()
+    _prune_audit_events(now)
+    successful = [e for e in _audit_write_events if e["success"]]
+    return {
+        "enabled": True,
+        "log_path": str(audit_log_path()),
+        "includes_reads": bool(config.VAULT_AUDIT_LOG_INCLUDE_READS),
+        "last_write_at": successful[-1]["timestamp"].isoformat() if successful else None,
+        "write_errors_count_24h": sum(1 for e in _audit_write_events if not e["success"]),
+        "bytes_written_24h": sum(int(e["bytes_written"]) for e in _audit_write_events),
+    }
+
+
+def _hash_value(value: str | None) -> str | None:
+    if not value:
+        return None
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _sha256_file(path: Path) -> str | None:
+    if not path.is_file():
+        return None
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def snapshot_path(path: Any) -> dict[str, Any]:
+    """Capture (size, checksum) for a vault-relative path; nulls when absent or invalid.
+
+    Routes through resolve_vault_path so a path that escapes the vault is treated as
+    absent rather than read.
+    """
+    empty: dict[str, Any] = {"size": None, "checksum": None}
+    if not isinstance(path, str) or not path:
+        return empty
+    try:
+        resolved = resolve_vault_path(path)
+    except ValueError:
+        return empty
+    if not resolved.is_file():
+        return empty
+    return {"size": resolved.stat().st_size, "checksum": _sha256_file(resolved)}
+
+
+def before_target_path(operation: str, context: dict[str, Any]) -> Any:
+    """The path to snapshot before a mutation runs."""
+    if operation == "vault_move":
+        return context.get("source")
+    return context.get("path") or context.get("source")
+
+
+def infer_target_path(operation: str, context: dict[str, Any], result: dict[str, Any] | None = None) -> Any:
+    """Best-effort target path from the call context and the parsed result payload."""
+    result = result or {}
+    if operation == "vault_move":
+        return result.get("destination") or context.get("destination")
+    if operation == "vault_batch_frontmatter_update":
+        results = result.get("results")
+        if isinstance(results, list):
+            paths = [item.get("path") for item in results if isinstance(item, dict) and item.get("path")]
+            if paths:
+                return paths
+    return result.get("path") or context.get("path") or context.get("source")
+
+
+def build_audit_record(
+    *,
+    operation: str,
+    target_path: Any,
+    before: dict[str, Any] | None = None,
+    after: dict[str, Any] | None = None,
+    operation_status: str = "success",
+    error: str | None = None,
+) -> dict[str, Any]:
+    """Build one normalized audit record from the current request context."""
+    ctx = current_request_context()
+    before = before or {"size": None, "checksum": None}
+    after = after or {"size": None, "checksum": None}
+    return {
+        "timestamp": _now_utc().isoformat(),
+        "token_id_hash": _hash_value(ctx.get("principal")),
+        "client_id": ctx.get("client"),
+        "operation": operation,
+        "target_path": target_path,
+        "size_before": before.get("size"),
+        "size_after": after.get("size"),
+        "checksum_before": before.get("checksum"),
+        "checksum_after": after.get("checksum"),
+        "request_id": ctx.get("request_id") or uuid.uuid4().hex,
+        "operation_status": operation_status,
+        "error": error,
+    }
+
+
+def write_audit_record(record: dict[str, Any]) -> bool:
+    """Append one JSON record. A write failure is logged, counted, and swallowed."""
+    if not audit_enabled():
+        return False
+    try:
+        path = audit_log_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        line = dumps(record, sort_keys=True) + "\n"
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(line)
+        _record_audit_write(True, len(line.encode("utf-8")))
+        return True
+    except Exception as exc:
+        _record_audit_write(False)
+        logger.error("Audit log write failed: %s", exc)
+        return False

--- a/src/obsidian_vault_mcp/audit.py
+++ b/src/obsidian_vault_mcp/audit.py
@@ -5,10 +5,11 @@ file: a UTC timestamp, a SHA-256 hash of the bearer token (never the token itsel
 operation, the target path, and the size + checksum of the target before and after the
 change. Read/search operations are logged too when VAULT_AUDIT_LOG_INCLUDE_READS is on.
 
-Auditing is off unless a log path is configured. A failure to write a record is logged
-and counted but never alters the tool result -- the audit trail must not be able to break
-a write. The log path is validated as writable at startup (see server.main), so a
-misconfigured path fails the server closed rather than silently dropping records.
+Auditing is off unless a log path is configured. At startup the path is validated as
+writable AND rejected if it resolves inside the vault (where the vault tools could rewrite
+it), so a misconfigured path fails the server closed. At runtime the log is best-effort:
+a failure to write a record is logged but never alters the tool result -- the audit trail
+must not be able to break a write.
 """
 
 from __future__ import annotations
@@ -17,8 +18,7 @@ import hashlib
 import logging
 import os
 import uuid
-from collections import deque
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -53,8 +53,8 @@ READ_OPERATIONS = {
     "vault_daily_note_read",
 }
 
-_AUDIT_WINDOW = timedelta(hours=24)
-_audit_write_events: deque[dict[str, Any]] = deque()
+# Mutations whose result reports per-file outcomes; audited one record per file.
+BATCH_OPERATIONS = {"vault_batch_frontmatter_update"}
 
 
 def audit_enabled() -> bool:
@@ -105,47 +105,26 @@ def audit_path_writable(path: Path | None = None) -> bool:
         return False
 
 
+def audit_path_inside_vault() -> bool:
+    """True when the configured audit log resolves inside the vault.
+
+    A same-vault log is just another file the vault tools can reach: resolve_vault_path
+    only blocks traversal and dotfiles, so an authenticated caller could overwrite it via
+    vault_write or relocate it via vault_delete, defeating the append-only integrity
+    premise. Such a path is rejected at startup (see server.main).
+    """
+    if not audit_enabled():
+        return False
+    try:
+        log = audit_log_path().resolve()
+        vault = config.VAULT_PATH.resolve()
+    except OSError:
+        return False
+    return log == vault or vault in log.parents
+
+
 def _now_utc() -> datetime:
     return datetime.now(timezone.utc)
-
-
-def _prune_audit_events(now: datetime | None = None) -> None:
-    now = now or _now_utc()
-    cutoff = now - _AUDIT_WINDOW
-    while _audit_write_events and _audit_write_events[0]["timestamp"] < cutoff:
-        _audit_write_events.popleft()
-
-
-def reset_audit_health_state() -> None:
-    """Clear the in-memory health counters. For tests and restarts."""
-    _audit_write_events.clear()
-
-
-def _record_audit_write(success: bool, bytes_written: int = 0) -> None:
-    now = _now_utc()
-    _audit_write_events.append(
-        {"timestamp": now, "success": success, "bytes_written": bytes_written if success else 0}
-    )
-    _prune_audit_events(now)
-
-
-def audit_health_payload() -> dict[str, Any]:
-    """Audit status for the /health endpoint (process-local 24h counters)."""
-    if not audit_enabled():
-        return {"enabled": False}
-    if not audit_path_writable():
-        return {"enabled": False, "writable": False, "log_path": str(audit_log_path())}
-    now = _now_utc()
-    _prune_audit_events(now)
-    successful = [e for e in _audit_write_events if e["success"]]
-    return {
-        "enabled": True,
-        "log_path": str(audit_log_path()),
-        "includes_reads": bool(config.VAULT_AUDIT_LOG_INCLUDE_READS),
-        "last_write_at": successful[-1]["timestamp"].isoformat() if successful else None,
-        "write_errors_count_24h": sum(1 for e in _audit_write_events if not e["success"]),
-        "bytes_written_24h": sum(int(e["bytes_written"]) for e in _audit_write_events),
-    }
 
 
 def _hash_value(value: str | None) -> str | None:
@@ -233,7 +212,7 @@ def build_audit_record(
 
 
 def write_audit_record(record: dict[str, Any]) -> bool:
-    """Append one JSON record. A write failure is logged, counted, and swallowed."""
+    """Append one JSON record. A write failure is logged and swallowed (best-effort)."""
     if not audit_enabled():
         return False
     try:
@@ -242,9 +221,7 @@ def write_audit_record(record: dict[str, Any]) -> bool:
         line = dumps(record, sort_keys=True) + "\n"
         with path.open("a", encoding="utf-8") as handle:
             handle.write(line)
-        _record_audit_write(True, len(line.encode("utf-8")))
         return True
     except Exception as exc:
-        _record_audit_write(False)
         logger.error("Audit log write failed: %s", exc)
         return False

--- a/src/obsidian_vault_mcp/auth.py
+++ b/src/obsidian_vault_mcp/auth.py
@@ -1,6 +1,7 @@
 """Bearer token authentication middleware for the vault MCP server."""
 
 import hmac
+import uuid
 
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
@@ -8,6 +9,7 @@ from starlette.responses import JSONResponse
 
 from . import config
 from .config import VAULT_MCP_TOKEN
+from .context import reset_request_context, set_request_context
 
 # Paths that don't require bearer auth (OAuth flow + health)
 _AUTH_EXEMPT_PATHS = {
@@ -76,4 +78,14 @@ class BearerAuthMiddleware(BaseHTTPMiddleware):
                 headers={"WWW-Authenticate": _www_authenticate(request, "invalid_token")},
             )
 
-        return await call_next(request)
+        # Thread the authenticated principal (plus a request id and best-effort client
+        # hint) to the tool layer for the audit log. The raw token never leaves this
+        # context; audit.build_audit_record stores only its SHA-256 hash. client_id is a
+        # User-Agent-derived hint -- it becomes a true per-client id if the static bearer
+        # token is ever replaced with per-client tokens.
+        client = request.headers.get("user-agent", "").strip()[:200] or None
+        ctx_token = set_request_context(principal=token, request_id=uuid.uuid4().hex, client=client)
+        try:
+            return await call_next(request)
+        finally:
+            reset_request_context(ctx_token)

--- a/src/obsidian_vault_mcp/config.py
+++ b/src/obsidian_vault_mcp/config.py
@@ -136,6 +136,22 @@ def validate_heartbeat() -> int | None:
         raise ValueError("VAULT_MCP_HEARTBEAT_INTERVAL must be a positive integer")
     return interval
 
+
+# Append-only JSONL audit log of vault mutations. When VAULT_AUDIT_LOG_PATH is set,
+# every mutation appends one JSON record (UTC timestamp, SHA-256 hash of the bearer
+# token, operation, target path, size + checksum before and after). Empty (the default)
+# disables auditing entirely. The raw bearer token is never written -- only its SHA-256
+# hash. The path is validated as writable at startup; an unwritable path fails the
+# server closed (see server.main) rather than dropping records silently.
+VAULT_AUDIT_LOG_PATH = os.environ.get("VAULT_AUDIT_LOG_PATH", "").strip()
+
+# Also record read/search operations (opt-in). Off by default because reads are
+# high-volume and may carry privacy weight; mutations are always logged once the audit
+# log is enabled. Accepts 1/true/yes/on (case-insensitive).
+VAULT_AUDIT_LOG_INCLUDE_READS = os.environ.get(
+    "VAULT_AUDIT_LOG_INCLUDE_READS", ""
+).strip().lower() in {"1", "true", "yes", "on"}
+
 # Safety limits
 MAX_CONTENT_SIZE = 1_000_000  # 1MB max write size
 MAX_BATCH_SIZE = 20           # Max files per batch operation

--- a/src/obsidian_vault_mcp/context.py
+++ b/src/obsidian_vault_mcp/context.py
@@ -1,0 +1,34 @@
+"""Request-scoped context shared by the bearer middleware and the audit log.
+
+The middleware records, per authenticated request, the principal (the bearer token), a
+generated request id, and a best-effort client hint. The audit module reads them when
+building a record. It lives in its own module so auth.py (the writer) and audit.py (the
+reader) share one ContextVar without importing each other.
+"""
+
+from __future__ import annotations
+
+from contextvars import ContextVar, Token
+from typing import Any
+
+# A single context var carrying the per-request audit context. Threading the principal
+# to the tool layer this way -- rather than as a function argument -- keeps every tool
+# signature untouched and works through FastMCP's call path.
+_request_context: ContextVar[dict[str, Any] | None] = ContextVar("request_context", default=None)
+
+
+def set_request_context(principal: str | None, request_id: str | None, client: str | None) -> Token:
+    """Bind the audit context for the current request. Returns a reset token."""
+    return _request_context.set(
+        {"principal": principal, "request_id": request_id, "client": client}
+    )
+
+
+def reset_request_context(token: Token) -> None:
+    """Restore the previous audit context (call in a finally block)."""
+    _request_context.reset(token)
+
+
+def current_request_context() -> dict[str, Any]:
+    """Return the current request's audit context, or an empty dict outside a request."""
+    return _request_context.get() or {}

--- a/src/obsidian_vault_mcp/server.py
+++ b/src/obsidian_vault_mcp/server.py
@@ -30,10 +30,11 @@ from .config import (
 )
 from .frontmatter_index import FrontmatterIndex
 from .audit import (
+    BATCH_OPERATIONS,
     MUTATION_OPERATIONS,
     audit_enabled,
-    audit_health_payload,
     audit_log_path,
+    audit_path_inside_vault,
     audit_path_writable,
     before_target_path,
     build_audit_record,
@@ -149,6 +150,8 @@ from .tools.canvas import (
     vault_canvas_add_edge as _vault_canvas_add_edge,
 )
 from .tools.daily import (
+    _daily_note_path,
+    _today,
     vault_daily_note_path as _vault_daily_note_path,
     vault_daily_note_read as _vault_daily_note_read,
     vault_daily_note_append as _vault_daily_note_append,
@@ -172,17 +175,30 @@ from .models import (
 )
 
 
+def _parse_tool_result(result: str) -> dict:
+    """Parse a tool's JSON result into a dict, or {} when it is not a JSON object."""
+    try:
+        payload = json.loads(result)
+    except (ValueError, TypeError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
 def _run_audited(operation: str, func, **context) -> str:
-    """Run a tool and emit one audit record when auditing covers this operation.
+    """Run a tool and emit audit records when auditing covers this operation.
 
     A straight passthrough when auditing is off (no log path) or the operation is a read
     and read-audit is disabled, so there is no cost on the default path. For mutations the
     target is snapshotted (size + checksum) before and after; reads capture the target as
-    it is read. An audit-write failure is swallowed inside write_audit_record so the trail
-    can never break the tool result.
+    it is read. Batch mutations emit one record per file (see _run_audited_batch). An
+    audit-write failure is swallowed inside write_audit_record so the trail can never break
+    the tool result.
     """
     if not should_audit_operation(operation):
         return func()
+
+    if operation in BATCH_OPERATIONS:
+        return _run_audited_batch(operation, func, context)
 
     is_mutation = operation in MUTATION_OPERATIONS
     before = snapshot_path(before_target_path(operation, context)) if is_mutation else None
@@ -190,45 +206,77 @@ def _run_audited(operation: str, func, **context) -> str:
     try:
         result = func()
     except Exception:
-        record = build_audit_record(
+        write_audit_record(build_audit_record(
             operation=operation,
             target_path=infer_target_path(operation, context),
             before=before,
             operation_status="error",
             error="tool exception",
-        )
-        write_audit_record(record)
+        ))
         raise
 
-    parsed: dict = {}
-    try:
-        payload = json.loads(result)
-        if isinstance(payload, dict):
-            parsed = payload
-    except (ValueError, TypeError):
-        parsed = {}
-
+    parsed = _parse_tool_result(result)
     target_path = infer_target_path(operation, context, parsed)
     status = "error" if "error" in parsed else "success"
     error = parsed.get("error") if status == "error" else None
     if is_mutation:
         record = build_audit_record(
-            operation=operation,
-            target_path=target_path,
-            before=before,
-            after=snapshot_path(target_path),
-            operation_status=status,
-            error=error,
+            operation=operation, target_path=target_path, before=before,
+            after=snapshot_path(target_path), operation_status=status, error=error,
         )
     else:
         record = build_audit_record(
-            operation=operation,
-            target_path=target_path,
-            before=snapshot_path(target_path),
-            operation_status=status,
-            error=error,
+            operation=operation, target_path=target_path,
+            before=snapshot_path(target_path), operation_status=status, error=error,
         )
     write_audit_record(record)
+    return result
+
+
+def _run_audited_batch(operation: str, func, context: dict) -> str:
+    """Audit a batch mutation as one record per file with correct per-file status.
+
+    The batch tools report per-file outcomes inside ``results`` (some files can fail while
+    the call as a whole "succeeds"), so a single top-level record would both hide partial
+    failures and lose per-file snapshots. Each file gets its own before/after snapshot and
+    its own operation_status.
+    """
+    paths = [p for p in (context.get("paths") or []) if isinstance(p, str) and p]
+    before_map = {p: snapshot_path(p) for p in paths}
+
+    try:
+        result = func()
+    except Exception:
+        for p in paths:
+            write_audit_record(build_audit_record(
+                operation=operation, target_path=p, before=before_map.get(p),
+                operation_status="error", error="tool exception",
+            ))
+        raise
+
+    parsed = _parse_tool_result(result)
+    items = parsed.get("results")
+    if not isinstance(items, list) or not items:
+        # A tool-level failure (e.g. validation) before any per-file work ran.
+        write_audit_record(build_audit_record(
+            operation=operation, target_path=paths or None,
+            operation_status="error" if "error" in parsed else "success",
+            error=parsed.get("error"),
+        ))
+        return result
+
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        path = item.get("path")
+        item_error = item.get("error")
+        item_status = "error" if item_error else "success"
+        before = before_map.get(path) if isinstance(path, str) else None
+        after = snapshot_path(path) if (item_status == "success" and isinstance(path, str)) else None
+        write_audit_record(build_audit_record(
+            operation=operation, target_path=path, before=before, after=after,
+            operation_status=item_status, error=item_error,
+        ))
     return result
 
 
@@ -280,6 +328,9 @@ def vault_write(path: str, content: str, create_dirs: bool = True, merge_frontma
 def vault_edit(path: str, edits: list[dict], dry_run: bool = False) -> str:
     """Patch a file with exact text replacements."""
     inp = VaultEditInput(path=path, edits=edits, dry_run=dry_run)
+    if inp.dry_run:
+        # A dry run writes nothing; don't record it as a mutation.
+        return _vault_edit(inp.path, [edit.model_dump() for edit in inp.edits], inp.dry_run)
     return _run_audited(
         "vault_edit",
         lambda: _vault_edit(inp.path, [edit.model_dump() for edit in inp.edits], inp.dry_run),
@@ -316,6 +367,7 @@ def vault_batch_frontmatter_update(updates: list[dict]) -> str:
     return _run_audited(
         "vault_batch_frontmatter_update",
         lambda: _vault_batch_frontmatter_update(inp.updates),
+        paths=[u.get("path") for u in inp.updates if isinstance(u, dict) and u.get("path")],
     )
 
 
@@ -490,6 +542,7 @@ def vault_daily_note_append(content: str) -> str:
     return _run_audited(
         "vault_daily_note_append",
         lambda: _vault_daily_note_append(inp.content),
+        path=_daily_note_path(_today()),
     )
 
 
@@ -534,7 +587,10 @@ def build_app(extensions=()):
     # Health endpoint (bearer-exempt, see auth._AUTH_EXEMPT_PATHS). Surfaces audit status
     # so an operator can confirm the log is enabled and being written.
     async def health(_request):
-        return JSONResponse({"status": "ok", "audit": audit_health_payload()})
+        # Unauthenticated and reachable over the public tunnel, so keep it to liveness:
+        # report only whether auditing is on -- never the log path or write counters,
+        # which would leak the host filesystem layout and a vault-activity side-channel.
+        return JSONResponse({"status": "ok", "audit": {"enabled": audit_enabled()}})
 
     app.routes.insert(0, Route("/health", health, methods=["GET"]))
 
@@ -640,6 +696,14 @@ def serve(extensions=()):
     # is not writable, refuse to start rather than silently dropping mutation records.
     if audit_enabled() and not audit_path_writable():
         logger.error(f"VAULT_AUDIT_LOG_PATH is not writable: {audit_log_path()}")
+        sys.exit(1)
+    # Fail CLOSED on an audit log that resolves inside the vault: the vault tools could
+    # then overwrite or delete it, defeating the append-only integrity premise.
+    if audit_enabled() and audit_path_inside_vault():
+        logger.error(
+            f"VAULT_AUDIT_LOG_PATH resolves inside the vault ({audit_log_path()}); "
+            "the vault tools could rewrite it. Choose a path outside VAULT_PATH."
+        )
         sys.exit(1)
     if audit_enabled():
         logger.info(

--- a/src/obsidian_vault_mcp/server.py
+++ b/src/obsidian_vault_mcp/server.py
@@ -18,6 +18,7 @@ from mcp.server.fastmcp import FastMCP
 from mcp.server.transport_security import TransportSecuritySettings
 
 from .config import (
+    VAULT_AUDIT_LOG_INCLUDE_READS,
     VAULT_MCP_ALLOWED_HOSTS,
     VAULT_MCP_FORWARDED_ALLOW_IPS,
     VAULT_MCP_HEARTBEAT_URL,
@@ -28,6 +29,19 @@ from .config import (
     VAULT_PATH,
 )
 from .frontmatter_index import FrontmatterIndex
+from .audit import (
+    MUTATION_OPERATIONS,
+    audit_enabled,
+    audit_health_payload,
+    audit_log_path,
+    audit_path_writable,
+    before_target_path,
+    build_audit_record,
+    infer_target_path,
+    should_audit_operation,
+    snapshot_path,
+    write_audit_record,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -158,6 +172,66 @@ from .models import (
 )
 
 
+def _run_audited(operation: str, func, **context) -> str:
+    """Run a tool and emit one audit record when auditing covers this operation.
+
+    A straight passthrough when auditing is off (no log path) or the operation is a read
+    and read-audit is disabled, so there is no cost on the default path. For mutations the
+    target is snapshotted (size + checksum) before and after; reads capture the target as
+    it is read. An audit-write failure is swallowed inside write_audit_record so the trail
+    can never break the tool result.
+    """
+    if not should_audit_operation(operation):
+        return func()
+
+    is_mutation = operation in MUTATION_OPERATIONS
+    before = snapshot_path(before_target_path(operation, context)) if is_mutation else None
+
+    try:
+        result = func()
+    except Exception:
+        record = build_audit_record(
+            operation=operation,
+            target_path=infer_target_path(operation, context),
+            before=before,
+            operation_status="error",
+            error="tool exception",
+        )
+        write_audit_record(record)
+        raise
+
+    parsed: dict = {}
+    try:
+        payload = json.loads(result)
+        if isinstance(payload, dict):
+            parsed = payload
+    except (ValueError, TypeError):
+        parsed = {}
+
+    target_path = infer_target_path(operation, context, parsed)
+    status = "error" if "error" in parsed else "success"
+    error = parsed.get("error") if status == "error" else None
+    if is_mutation:
+        record = build_audit_record(
+            operation=operation,
+            target_path=target_path,
+            before=before,
+            after=snapshot_path(target_path),
+            operation_status=status,
+            error=error,
+        )
+    else:
+        record = build_audit_record(
+            operation=operation,
+            target_path=target_path,
+            before=snapshot_path(target_path),
+            operation_status=status,
+            error=error,
+        )
+    write_audit_record(record)
+    return result
+
+
 @mcp.tool(
     name="vault_read",
     description="Read a file from the Obsidian vault, returning content, metadata, and parsed YAML frontmatter.",
@@ -166,7 +240,7 @@ from .models import (
 def vault_read(path: str) -> str:
     """Read a file from the vault."""
     inp = VaultReadInput(path=path)
-    return _vault_read(inp.path)
+    return _run_audited("vault_read", lambda: _vault_read(inp.path), path=inp.path)
 
 
 @mcp.tool(
@@ -177,7 +251,7 @@ def vault_read(path: str) -> str:
 def vault_batch_read(paths: list[str], include_content: bool = True) -> str:
     """Read multiple files at once."""
     inp = VaultBatchReadInput(paths=paths, include_content=include_content)
-    return _vault_batch_read(inp.paths, inp.include_content)
+    return _run_audited("vault_batch_read", lambda: _vault_batch_read(inp.paths, inp.include_content))
 
 
 @mcp.tool(
@@ -188,7 +262,11 @@ def vault_batch_read(paths: list[str], include_content: bool = True) -> str:
 def vault_write(path: str, content: str, create_dirs: bool = True, merge_frontmatter: bool = False) -> str:
     """Write a file to the vault."""
     inp = VaultWriteInput(path=path, content=content, create_dirs=create_dirs, merge_frontmatter=merge_frontmatter)
-    return _vault_write(inp.path, inp.content, inp.create_dirs, inp.merge_frontmatter)
+    return _run_audited(
+        "vault_write",
+        lambda: _vault_write(inp.path, inp.content, inp.create_dirs, inp.merge_frontmatter),
+        path=inp.path,
+    )
 
 
 @mcp.tool(
@@ -202,10 +280,10 @@ def vault_write(path: str, content: str, create_dirs: bool = True, merge_frontma
 def vault_edit(path: str, edits: list[dict], dry_run: bool = False) -> str:
     """Patch a file with exact text replacements."""
     inp = VaultEditInput(path=path, edits=edits, dry_run=dry_run)
-    return _vault_edit(
-        inp.path,
-        [edit.model_dump() for edit in inp.edits],
-        inp.dry_run,
+    return _run_audited(
+        "vault_edit",
+        lambda: _vault_edit(inp.path, [edit.model_dump() for edit in inp.edits], inp.dry_run),
+        path=inp.path,
     )
 
 
@@ -220,7 +298,11 @@ def vault_edit(path: str, edits: list[dict], dry_run: bool = False) -> str:
 def vault_append(path: str, content: str, separator: str = "\n\n", create_dirs: bool = True) -> str:
     """Append content to a file."""
     inp = VaultAppendInput(path=path, content=content, separator=separator, create_dirs=create_dirs)
-    return _vault_append(inp.path, inp.content, inp.separator, inp.create_dirs)
+    return _run_audited(
+        "vault_append",
+        lambda: _vault_append(inp.path, inp.content, inp.separator, inp.create_dirs),
+        path=inp.path,
+    )
 
 
 @mcp.tool(
@@ -231,7 +313,10 @@ def vault_append(path: str, content: str, separator: str = "\n\n", create_dirs: 
 def vault_batch_frontmatter_update(updates: list[dict]) -> str:
     """Batch update frontmatter fields."""
     inp = VaultBatchFrontmatterUpdateInput(updates=updates)
-    return _vault_batch_frontmatter_update(inp.updates)
+    return _run_audited(
+        "vault_batch_frontmatter_update",
+        lambda: _vault_batch_frontmatter_update(inp.updates),
+    )
 
 
 @mcp.tool(
@@ -248,7 +333,10 @@ def vault_search(
 ) -> str:
     """Search vault file contents."""
     inp = VaultSearchInput(query=query, path_prefix=path_prefix, file_pattern=file_pattern, max_results=max_results, context_lines=context_lines)
-    return _vault_search(inp.query, inp.path_prefix, inp.file_pattern, inp.max_results, inp.context_lines)
+    return _run_audited(
+        "vault_search",
+        lambda: _vault_search(inp.query, inp.path_prefix, inp.file_pattern, inp.max_results, inp.context_lines),
+    )
 
 
 @mcp.tool(
@@ -265,7 +353,10 @@ def vault_search_frontmatter(
 ) -> str:
     """Search by frontmatter fields."""
     inp = VaultSearchFrontmatterInput(field=field, value=value, match_type=match_type, path_prefix=path_prefix, max_results=max_results)
-    return _vault_search_frontmatter(inp.field, inp.value, inp.match_type, inp.path_prefix, inp.max_results)
+    return _run_audited(
+        "vault_search_frontmatter",
+        lambda: _vault_search_frontmatter(inp.field, inp.value, inp.match_type, inp.path_prefix, inp.max_results),
+    )
 
 
 @mcp.tool(
@@ -282,7 +373,11 @@ def vault_list(
 ) -> str:
     """List vault directory contents."""
     inp = VaultListInput(path=path, depth=depth, include_files=include_files, include_dirs=include_dirs, pattern=pattern)
-    return _vault_list(inp.path, inp.depth, inp.include_files, inp.include_dirs, inp.pattern)
+    return _run_audited(
+        "vault_list",
+        lambda: _vault_list(inp.path, inp.depth, inp.include_files, inp.include_dirs, inp.pattern),
+        path=inp.path,
+    )
 
 
 @mcp.tool(
@@ -293,7 +388,12 @@ def vault_list(
 def vault_move(source: str, destination: str, create_dirs: bool = True) -> str:
     """Move a file or directory."""
     inp = VaultMoveInput(source=source, destination=destination, create_dirs=create_dirs)
-    return _vault_move(inp.source, inp.destination, inp.create_dirs)
+    return _run_audited(
+        "vault_move",
+        lambda: _vault_move(inp.source, inp.destination, inp.create_dirs),
+        source=inp.source,
+        destination=inp.destination,
+    )
 
 
 @mcp.tool(
@@ -304,7 +404,11 @@ def vault_move(source: str, destination: str, create_dirs: bool = True) -> str:
 def vault_delete(path: str, confirm: bool = False) -> str:
     """Delete a file (move to .trash/)."""
     inp = VaultDeleteInput(path=path, confirm=confirm)
-    return _vault_delete(inp.path, inp.confirm)
+    return _run_audited(
+        "vault_delete",
+        lambda: _vault_delete(inp.path, inp.confirm),
+        path=inp.path,
+    )
 
 
 @mcp.tool(
@@ -315,7 +419,7 @@ def vault_delete(path: str, confirm: bool = False) -> str:
 def vault_canvas_read(path: str) -> str:
     """Read an Obsidian Canvas file."""
     inp = VaultCanvasReadInput(path=path)
-    return _vault_canvas_read(inp.path)
+    return _run_audited("vault_canvas_read", lambda: _vault_canvas_read(inp.path), path=inp.path)
 
 
 @mcp.tool(
@@ -329,7 +433,11 @@ def vault_canvas_read(path: str) -> str:
 def vault_canvas_add_node(path: str, node: dict) -> str:
     """Append a node to a Canvas file."""
     inp = VaultCanvasAddNodeInput(path=path, node=node)
-    return _vault_canvas_add_node(inp.path, inp.node.model_dump(exclude_none=True, mode="json"))
+    return _run_audited(
+        "vault_canvas_add_node",
+        lambda: _vault_canvas_add_node(inp.path, inp.node.model_dump(exclude_none=True, mode="json")),
+        path=inp.path,
+    )
 
 
 @mcp.tool(
@@ -344,7 +452,11 @@ def vault_canvas_add_node(path: str, node: dict) -> str:
 def vault_canvas_add_edge(path: str, edge: dict) -> str:
     """Append an edge to a Canvas file."""
     inp = VaultCanvasAddEdgeInput(path=path, edge=edge)
-    return _vault_canvas_add_edge(inp.path, inp.edge.model_dump(exclude_none=True, mode="json"))
+    return _run_audited(
+        "vault_canvas_add_edge",
+        lambda: _vault_canvas_add_edge(inp.path, inp.edge.model_dump(exclude_none=True, mode="json")),
+        path=inp.path,
+    )
 
 
 @mcp.tool(
@@ -364,7 +476,7 @@ def vault_daily_note_path() -> str:
 )
 def vault_daily_note_read() -> str:
     """Read today's daily note."""
-    return _vault_daily_note_read()
+    return _run_audited("vault_daily_note_read", _vault_daily_note_read)
 
 
 @mcp.tool(
@@ -375,7 +487,10 @@ def vault_daily_note_read() -> str:
 def vault_daily_note_append(content: str) -> str:
     """Append to today's daily note."""
     inp = VaultDailyNoteAppendInput(content=content)
-    return _vault_daily_note_append(inp.content)
+    return _run_audited(
+        "vault_daily_note_append",
+        lambda: _vault_daily_note_append(inp.content),
+    )
 
 
 def build_app(extensions=()):
@@ -391,7 +506,7 @@ def build_app(extensions=()):
     routes are bearer-protected. A route that collides with an auth-exempt path is
     rejected (fail closed) so an extension cannot expose an unauthenticated endpoint.
     """
-    from starlette.responses import Response
+    from starlette.responses import JSONResponse, Response
     from starlette.routing import Route
 
     from .auth import BearerAuthMiddleware
@@ -415,6 +530,13 @@ def build_app(extensions=()):
     # Mount OAuth routes (these are excluded from bearer auth via the middleware)
     for route in oauth_routes:
         app.routes.insert(0, route)
+
+    # Health endpoint (bearer-exempt, see auth._AUTH_EXEMPT_PATHS). Surfaces audit status
+    # so an operator can confirm the log is enabled and being written.
+    async def health(_request):
+        return JSONResponse({"status": "ok", "audit": audit_health_payload()})
+
+    app.routes.insert(0, Route("/health", health, methods=["GET"]))
 
     # Extension routes (e.g. a localhost search endpoint), added before the auth
     # middleware so they are bearer-protected like the MCP transport.
@@ -475,7 +597,6 @@ def build_app(extensions=()):
                     f"extension route {getattr(r, 'path', r)!r} covers auth-exempt "
                     f"{m} {p!r}; it would be served without bearer authentication"
                 )
-
     app.add_middleware(BearerAuthMiddleware)
     return app
 
@@ -514,6 +635,18 @@ def serve(extensions=()):
 
     if not VAULT_MCP_TOKEN:
         logger.warning("VAULT_MCP_TOKEN is not set -- auth will reject all requests")
+
+    # Fail CLOSED on a misconfigured audit log: if auditing is requested but the log path
+    # is not writable, refuse to start rather than silently dropping mutation records.
+    if audit_enabled() and not audit_path_writable():
+        logger.error(f"VAULT_AUDIT_LOG_PATH is not writable: {audit_log_path()}")
+        sys.exit(1)
+    if audit_enabled():
+        logger.info(
+            "Audit log enabled: %s (reads included: %s)",
+            audit_log_path(),
+            VAULT_AUDIT_LOG_INCLUDE_READS,
+        )
 
     # Extension setup: register tools BEFORE the app/tool-schema is built, and let
     # each extension prepare before the frontmatter index starts (e.g. attach a

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,0 +1,176 @@
+"""Tests for the append-only JSONL audit log (VAULT_AUDIT_LOG_PATH).
+
+The vault_dir fixture (conftest) points the server at a temp vault. These tests drive the
+server-level tool functions directly -- the same callables FastMCP registers -- so the
+_run_audited wrapper is exercised end to end. The bearer middleware is not in the loop
+here, so the authenticated principal is bound manually via context.set_request_context.
+"""
+
+import json
+
+import pytest
+
+from obsidian_vault_mcp import audit, config, context, server
+
+PRINCIPAL = "test-bearer-token-abc123"
+EXPECTED_HASH = __import__("hashlib").sha256(PRINCIPAL.encode("utf-8")).hexdigest()
+
+
+@pytest.fixture
+def audit_log(vault_dir, tmp_path, monkeypatch):
+    """Enable auditing to a temp log file with a bound principal; isolate global state."""
+    log_path = tmp_path / "audit" / "mutations.jsonl"
+    monkeypatch.setattr(config, "VAULT_AUDIT_LOG_PATH", str(log_path))
+    monkeypatch.setattr(config, "VAULT_AUDIT_LOG_INCLUDE_READS", False)
+    audit.reset_audit_health_state()
+    token = context.set_request_context(principal=PRINCIPAL, request_id="req-1", client="pytest")
+    yield log_path
+    context.reset_request_context(token)
+    audit.reset_audit_health_state()
+
+
+def _records(log_path):
+    if not log_path.exists():
+        return []
+    return [json.loads(line) for line in log_path.read_text(encoding="utf-8").splitlines() if line]
+
+
+# --- off by default ---
+
+def test_audit_off_by_default(vault_dir, monkeypatch, tmp_path):
+    monkeypatch.setattr(config, "VAULT_AUDIT_LOG_PATH", "")
+    log_path = tmp_path / "should-not-exist.jsonl"
+    result = json.loads(server.vault_write("note.md", "body"))
+    assert result["path"] == "note.md"
+    assert not log_path.exists()
+    assert audit.should_audit_operation("vault_write") is False
+
+
+# --- mutations ---
+
+def test_mutation_writes_record_with_required_fields(audit_log):
+    server.vault_write("audited.md", "hello audit")
+    records = _records(audit_log)
+    assert len(records) == 1
+    rec = records[0]
+    for field in (
+        "timestamp", "token_id_hash", "client_id", "operation", "target_path",
+        "size_before", "size_after", "checksum_before", "checksum_after",
+        "request_id", "operation_status", "error",
+    ):
+        assert field in rec
+    assert rec["operation"] == "vault_write"
+    assert rec["target_path"] == "audited.md"
+    assert rec["operation_status"] == "success"
+    assert rec["size_before"] is None          # new file
+    assert rec["size_after"] == len(b"hello audit")
+    assert rec["checksum_after"] is not None
+
+
+def test_raw_token_never_written_only_hash(audit_log):
+    server.vault_write("audited.md", "secret content")
+    raw = audit_log.read_text(encoding="utf-8")
+    assert PRINCIPAL not in raw
+    assert _records(audit_log)[0]["token_id_hash"] == EXPECTED_HASH
+    assert _records(audit_log)[0]["client_id"] == "pytest"
+
+
+def test_overwrite_captures_before_and_after(audit_log):
+    server.vault_write("note.md", "first version")
+    server.vault_write("note.md", "second, longer version")
+    rec = _records(audit_log)[-1]
+    assert rec["size_before"] == len(b"first version")
+    assert rec["size_after"] == len(b"second, longer version")
+    assert rec["checksum_before"] != rec["checksum_after"]
+
+
+def test_mutation_error_recorded(audit_log):
+    # A path that escapes the vault returns an error payload (a mutation attempt).
+    result = json.loads(server.vault_write("../escape.md", "x"))
+    assert "error" in result
+    rec = _records(audit_log)[-1]
+    assert rec["operation"] == "vault_write"
+    assert rec["operation_status"] == "error"
+    assert rec["error"]
+
+
+def test_move_records_destination(audit_log):
+    server.vault_write("src.md", "movable")
+    server.vault_move("src.md", "dst.md")
+    rec = _records(audit_log)[-1]
+    assert rec["operation"] == "vault_move"
+    assert rec["target_path"] == "dst.md"
+    assert rec["size_after"] == len(b"movable")
+
+
+# --- reads (opt-in) ---
+
+def test_reads_not_logged_by_default(audit_log):
+    server.vault_read("test-note.md")
+    assert _records(audit_log) == []
+    assert audit.should_audit_operation("vault_read") is False
+
+
+def test_reads_logged_when_enabled(audit_log, monkeypatch):
+    monkeypatch.setattr(config, "VAULT_AUDIT_LOG_INCLUDE_READS", True)
+    server.vault_read("test-note.md")
+    rec = _records(audit_log)[-1]
+    assert rec["operation"] == "vault_read"
+    assert rec["target_path"] == "test-note.md"
+    assert rec["checksum_before"] is not None   # captured as read
+
+
+# --- failure isolation ---
+
+def test_audit_write_failure_does_not_break_tool(vault_dir, monkeypatch):
+    # Parent of the log path is an existing FILE, so mkdir/open fails on every write.
+    bad = vault_dir / "test-note.md" / "audit.jsonl"
+    monkeypatch.setattr(config, "VAULT_AUDIT_LOG_PATH", str(bad))
+    audit.reset_audit_health_state()
+    token = context.set_request_context(principal=PRINCIPAL, request_id="r", client="c")
+    try:
+        result = json.loads(server.vault_write("still-works.md", "body"))
+        assert result["created"] is True        # the write itself succeeded
+        health = audit.audit_health_payload()
+        assert health["enabled"] is False        # path not writable
+    finally:
+        context.reset_request_context(token)
+        audit.reset_audit_health_state()
+
+
+# --- health + writability ---
+
+def test_health_payload_reflects_state(audit_log, monkeypatch):
+    enabled = audit.audit_health_payload()
+    assert enabled["enabled"] is True
+    assert enabled["includes_reads"] is False
+    monkeypatch.setattr(config, "VAULT_AUDIT_LOG_PATH", "")
+    assert audit.audit_health_payload() == {"enabled": False}
+
+
+def test_path_writable_checks(vault_dir, tmp_path, monkeypatch):
+    good = tmp_path / "ok.jsonl"
+    monkeypatch.setattr(config, "VAULT_AUDIT_LOG_PATH", str(good))
+    assert audit.audit_path_writable() is True
+    bad = vault_dir / "test-note.md" / "nope.jsonl"   # parent is a file
+    monkeypatch.setattr(config, "VAULT_AUDIT_LOG_PATH", str(bad))
+    assert audit.audit_path_writable() is False
+
+
+# --- snapshot safety ---
+
+def test_snapshot_path_stays_in_vault(vault_dir):
+    assert audit.snapshot_path("../outside.md") == {"size": None, "checksum": None}
+    assert audit.snapshot_path("does-not-exist.md") == {"size": None, "checksum": None}
+    snap = audit.snapshot_path("test-note.md")
+    assert snap["size"] > 0 and snap["checksum"]
+
+
+# --- wiring: tools stay registered (wrapper preserved the schema) ---
+
+@pytest.mark.parametrize("name", [
+    "vault_write", "vault_edit", "vault_append", "vault_move", "vault_delete",
+    "vault_read", "vault_search", "vault_canvas_add_node", "vault_daily_note_append",
+])
+def test_audited_tools_still_registered(vault_dir, name):
+    assert server.mcp._tool_manager.get_tool(name) is not None

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -22,11 +22,9 @@ def audit_log(vault_dir, tmp_path, monkeypatch):
     log_path = tmp_path / "audit" / "mutations.jsonl"
     monkeypatch.setattr(config, "VAULT_AUDIT_LOG_PATH", str(log_path))
     monkeypatch.setattr(config, "VAULT_AUDIT_LOG_INCLUDE_READS", False)
-    audit.reset_audit_health_state()
     token = context.set_request_context(principal=PRINCIPAL, request_id="req-1", client="pytest")
     yield log_path
     context.reset_request_context(token)
-    audit.reset_audit_health_state()
 
 
 def _records(log_path):
@@ -126,27 +124,31 @@ def test_audit_write_failure_does_not_break_tool(vault_dir, monkeypatch):
     # Parent of the log path is an existing FILE, so mkdir/open fails on every write.
     bad = vault_dir / "test-note.md" / "audit.jsonl"
     monkeypatch.setattr(config, "VAULT_AUDIT_LOG_PATH", str(bad))
-    audit.reset_audit_health_state()
+    assert audit.audit_path_writable() is False
     token = context.set_request_context(principal=PRINCIPAL, request_id="r", client="c")
     try:
         result = json.loads(server.vault_write("still-works.md", "body"))
-        assert result["created"] is True        # the write itself succeeded
-        health = audit.audit_health_payload()
-        assert health["enabled"] is False        # path not writable
+        assert result["created"] is True        # the write itself succeeded despite audit failing
     finally:
         context.reset_request_context(token)
-        audit.reset_audit_health_state()
 
 
-# --- health + writability ---
+# --- in-vault audit log rejected (#2 integrity) ---
 
-def test_health_payload_reflects_state(audit_log, monkeypatch):
-    enabled = audit.audit_health_payload()
-    assert enabled["enabled"] is True
-    assert enabled["includes_reads"] is False
-    monkeypatch.setattr(config, "VAULT_AUDIT_LOG_PATH", "")
-    assert audit.audit_health_payload() == {"enabled": False}
+def test_audit_path_inside_vault_detected(vault_dir, monkeypatch):
+    monkeypatch.setattr(config, "VAULT_AUDIT_LOG_PATH", str(vault_dir / "audit.jsonl"))
+    assert audit.audit_path_inside_vault() is True
+    monkeypatch.setattr(config, "VAULT_AUDIT_LOG_PATH", str(vault_dir / "subfolder" / "a.jsonl"))
+    assert audit.audit_path_inside_vault() is True
 
+
+def test_audit_path_outside_vault_ok(vault_dir, tmp_path, monkeypatch):
+    # tmp_path is the vault's parent, so a sibling dir is outside the vault.
+    monkeypatch.setattr(config, "VAULT_AUDIT_LOG_PATH", str(tmp_path / "outside" / "audit.jsonl"))
+    assert audit.audit_path_inside_vault() is False
+
+
+# --- writability ---
 
 def test_path_writable_checks(vault_dir, tmp_path, monkeypatch):
     good = tmp_path / "ok.jsonl"
@@ -174,3 +176,41 @@ def test_snapshot_path_stays_in_vault(vault_dir):
 ])
 def test_audited_tools_still_registered(vault_dir, name):
     assert server.mcp._tool_manager.get_tool(name) is not None
+
+
+# --- batch: one record per file with correct per-file status (#3) ---
+
+def test_batch_emits_one_record_per_file_with_status(audit_log):
+    server.vault_write("a.md", "---\nx: 1\n---\nbody")
+    # a.md exists, missing.md does not -> partial failure within one batch call
+    updates = [
+        {"path": "a.md", "fields": {"status": "done"}},
+        {"path": "missing.md", "fields": {"status": "done"}},
+    ]
+    server.vault_batch_frontmatter_update(updates)
+    recs = [r for r in _records(audit_log) if r["operation"] == "vault_batch_frontmatter_update"]
+    assert len(recs) == 2                      # one record per file, not one for the call
+    by_path = {r["target_path"]: r for r in recs}
+    assert by_path["a.md"]["operation_status"] == "success"
+    assert by_path["a.md"]["checksum_after"] is not None   # real snapshot, not null
+    assert by_path["missing.md"]["operation_status"] == "error"   # partial failure surfaced
+    assert by_path["missing.md"]["error"]
+
+
+# --- dry-run edit is not recorded as a mutation (non-blocking item) ---
+
+def test_dry_run_edit_not_audited(audit_log):
+    server.vault_write("edit.md", "alpha beta")
+    before = len(_records(audit_log))
+    server.vault_edit("edit.md", [{"old_text": "alpha", "new_text": "ALPHA"}], dry_run=True)
+    assert len(_records(audit_log)) == before          # dry run wrote nothing, logged nothing
+    server.vault_edit("edit.md", [{"old_text": "alpha", "new_text": "ALPHA"}])
+    assert len(_records(audit_log)) == before + 1       # the real edit IS audited
+
+
+def test_daily_append_captures_before_snapshot(audit_log, monkeypatch):
+    monkeypatch.setattr(config, "VAULT_DAILY_NOTES_FOLDER", "")
+    server.vault_daily_note_append("first line")
+    server.vault_daily_note_append("second line")
+    recs = [r for r in _records(audit_log) if r["operation"] == "vault_daily_note_append"]
+    assert recs[-1]["size_before"] is not None          # before-snapshot now captured

--- a/tests/test_audit_propagation.py
+++ b/tests/test_audit_propagation.py
@@ -1,0 +1,53 @@
+"""HTTP-level coverage for the load-bearing path the audit log depends on.
+
+test_audit.py binds the request context in-frame; these drive a real request through
+BearerAuthMiddleware so the principal / client_id / request_id propagation -- the one
+thing the whole feature relies on -- is actually exercised (requested by upstream review
+on #56). Also asserts the unauthenticated /health is liveness-only (no audit internals).
+"""
+
+from starlette.applications import Starlette
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from obsidian_vault_mcp import auth as auth_module
+from obsidian_vault_mcp import config, server
+from obsidian_vault_mcp.context import current_request_context
+
+
+def test_principal_propagates_to_sync_handler(monkeypatch):
+    monkeypatch.setattr(auth_module, "VAULT_MCP_TOKEN", "secret-token")
+
+    def sync_probe(request):  # sync on purpose: mirrors how FastMCP runs vault_* tools
+        ctx = current_request_context()
+        return JSONResponse({"principal": ctx.get("principal"), "client": ctx.get("client"),
+                             "request_id": ctx.get("request_id")})
+
+    app = Starlette(routes=[Route("/probe", sync_probe)])
+    app.add_middleware(auth_module.BearerAuthMiddleware)
+    client = TestClient(app)
+
+    r = client.get("/probe", headers={"Authorization": "Bearer secret-token",
+                                      "User-Agent": "probe/1"})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["principal"] == "secret-token"   # null here => token_id_hash null in prod
+    assert body["client"] == "probe/1"
+    assert body["request_id"]
+
+
+def test_context_clean_outside_request():
+    assert current_request_context() == {}
+
+
+def test_health_is_liveness_only(vault_dir, monkeypatch):
+    # Unauthenticated /health must not leak the audit log path or write counters.
+    monkeypatch.setattr(config, "VAULT_AUDIT_LOG_PATH", str(vault_dir.parent / "audit.jsonl"))
+    app = server.build_app()
+    client = TestClient(app)
+    r = client.get("/health")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["status"] == "ok"
+    assert body["audit"] == {"enabled": True}    # only the bool, nothing else


### PR DESCRIPTION
## What it does

Adds the optional append-only JSONL audit log we discussed on #50 -- the token-id-hash
shape you asked for, self-contained, off by default, fails closed. With
`VAULT_AUDIT_LOG_PATH` unset there is zero overhead; set it and every vault mutation
appends one JSON record.

| Env var | Default | Effect |
|---|---|---|
| `VAULT_AUDIT_LOG_PATH` | (none) | Append-only JSONL log of mutations. Empty = auditing off. |
| `VAULT_AUDIT_LOG_INCLUDE_READS` | `false` | Also record read/search ops (opt-in). |

Each record: `timestamp` (UTC), `token_id_hash` (SHA-256 of the bearer token -- the raw
token is never written), `client_id` (best-effort User-Agent hint), `operation`,
`target_path`, `size_before`/`size_after`, `checksum_before`/`checksum_after` (SHA-256),
`request_id`, `operation_status`, `error`.

`GET /health` (bearer-exempt) now returns an `audit` block: enabled, log path, includes_reads,
last write time, and 24h write-error / byte counts.

## Example

```jsonl
{"checksum_after":"9f86d0…","checksum_before":null,"client_id":"claude","error":null,"operation":"vault_write","operation_status":"success","request_id":"a1b2…","size_after":42,"size_before":null,"target_path":"notes/today.md","timestamp":"2026-06-14T18:30:00+00:00","token_id_hash":"5e88…"}
```

## How it fits the bar

- **No new attack surface that runs anything.** This is the audit half only -- it records,
  it never executes. (The post-write/exec hook from the same internal work is deliberately
  *not* here, per your call on #44.)
- **Principal threading is one ContextVar.** The bearer middleware records the principal
  (plus a request id + UA hint) in `context.py`; the tool layer reads it. The raw token
  stays in that context -- only its SHA-256 hash is ever persisted. No secrets in the log.
- **Fail-closed config.** `VAULT_AUDIT_LOG_PATH` is validated as writable at startup; an
  unwritable path aborts the server rather than silently dropping records. Off by default.
- **Audit can't break a write.** A record-write failure is logged and counted, never
  propagated to the tool result.
- **Paths via `resolve_vault_path`.** Snapshots resolve through the same guard, so a path
  escaping the vault is treated as absent, not read.
- **No new dependencies.** Wraps the existing tools through one `_run_audited` helper; tool
  schemas are unchanged.

The auth + server + health touch is the single self-contained change you said was fine here
("the plumbing is the feature"). It has been running on my own instance for ~a month.

## Tests

`tests/test_audit.py` (21 cases): record shape + all required fields, token hashed (raw
token asserted absent from the log), before/after size+checksum on overwrite and move, read
opt-in (off by default / on when enabled), error `operation_status`, audit-write failure
isolation (tool still succeeds), startup writability (file-parent rejected, mkdir-intermediates
allowed), path-traversal snapshot safety, and that every wrapped tool stays registered.

Full suite green on Linux: **220 passed, 1 skipped**. (`test_oauth.py` uses `os.fchmod`, so
the suite is validated on Linux, not Windows.)

## PR checklist

- [x] One self-contained change, rebased on main (not stacked on another PR)
- [x] Full test suite passes locally (`pytest`)
- [x] New/abuse inputs covered by tests; the tool wiring is tested, not just helpers
- [x] Auth: any new route/mount validated against the exempt set; fails closed
- [x] Paths go through resolve_vault_path; resolved path re-validated
- [x] No shell=True on request input; subprocess env scrubbed of secrets (n/a -- no subprocess)
- [x] Outbound requests don't follow redirects to private ranges; response size capped (n/a -- no outbound)
- [x] No secrets/tokens/capability URLs in logs
- [x] New config validated at startup, fails closed, off by default if risky
- [x] Bridge/optional deps fail soft when absent; heavy deps are optional extras (n/a -- no new deps)
- [x] Writes go through the atomic write path (n/a -- the log is append-only JSONL, not a vault write)
- [x] README updated for new env vars / tools / dependencies
