### PR TITLE
feat: vault analytics — hygiene summary + findings (read-only) [#50]

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ Found a vulnerability? Please report it privately rather than opening a public i
 | `vault_daily_note_path` | Resolve today's daily-note path from the configured folder/format |
 | `vault_daily_note_read` | Read today's daily note; returns an error (does not create it) when missing |
 | `vault_daily_note_append` | Append to today's daily note, creating it from the template when missing |
+| `vault_analytics_summary` | Compact vault-hygiene summary: counts and examples of missing frontmatter, broken wikilinks, near-duplicate tag variants, and non-UTF-8 files |
+| `vault_analytics_findings` | Detailed findings for one analytics category (`frontmatter_missing`, `required_frontmatter_missing`, `broken_wikilinks`, `suspicious_tag_variants`, `encoding_issues`, `oversized_files`) |
 
 ## Prerequisites
 

--- a/src/obsidian_vault_mcp/models.py
+++ b/src/obsidian_vault_mcp/models.py
@@ -446,3 +446,60 @@ class VaultDailyNoteAppendInput(BaseModel):
         description="Content to append to today's daily note (the note is created from the template if missing)",
         max_length=MAX_CONTENT_SIZE,
     )
+
+
+class VaultAnalyticsSummaryInput(BaseModel):
+    """Build a compact analytics summary for a vault path."""
+
+    model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
+
+    path_prefix: str | None = Field(
+        default=None,
+        description="Optional folder prefix to restrict the analysis",
+        max_length=500,
+    )
+    required_frontmatter: list[str] | None = Field(
+        default=None,
+        description="Optional required frontmatter fields to validate",
+        max_length=20,
+    )
+    max_examples: int = Field(
+        default=3,
+        ge=1,
+        le=20,
+        description="Maximum example findings to include per category",
+    )
+
+
+class VaultAnalyticsFindingsInput(BaseModel):
+    """Return detailed findings for one analytics category."""
+
+    model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
+
+    category: Literal[
+        "frontmatter_missing",
+        "required_frontmatter_missing",
+        "broken_wikilinks",
+        "suspicious_tag_variants",
+        "encoding_issues",
+        "oversized_files",
+    ] = Field(
+        ...,
+        description="Analytics finding category to return",
+    )
+    path_prefix: str | None = Field(
+        default=None,
+        description="Optional folder prefix to restrict the analysis",
+        max_length=500,
+    )
+    required_frontmatter: list[str] | None = Field(
+        default=None,
+        description="Optional required frontmatter fields to validate",
+        max_length=20,
+    )
+    max_results: int = Field(
+        default=50,
+        ge=1,
+        le=200,
+        description="Maximum number of findings to return",
+    )

--- a/src/obsidian_vault_mcp/server.py
+++ b/src/obsidian_vault_mcp/server.py
@@ -157,6 +157,10 @@ from .tools.daily import (
     vault_daily_note_read as _vault_daily_note_read,
     vault_daily_note_append as _vault_daily_note_append,
 )
+from .tools.analytics import (
+    vault_analytics_summary as _vault_analytics_summary,
+    vault_analytics_findings as _vault_analytics_findings,
+)
 from .models import (
     VaultReadInput,
     VaultWriteInput,
@@ -174,6 +178,8 @@ from .models import (
     VaultCanvasAddNodeInput,
     VaultCanvasAddEdgeInput,
     VaultDailyNoteAppendInput,
+    VaultAnalyticsSummaryInput,
+    VaultAnalyticsFindingsInput,
 )
 
 
@@ -556,6 +562,58 @@ def vault_daily_note_append(content: str) -> str:
         "vault_daily_note_append",
         lambda: _vault_daily_note_append(inp.content),
         path=_daily_note_path(_today()),
+    )
+
+
+@mcp.tool(
+    name="vault_analytics_summary",
+    description=(
+        "Return a compact analytics summary for vault hygiene, including frontmatter, link, tag, and encoding "
+        "findings. Read-only; scoped to an optional folder prefix."
+    ),
+    annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True, "openWorldHint": False},
+)
+def vault_analytics_summary(
+    path_prefix: str | None = None,
+    required_frontmatter: list[str] | None = None,
+    max_examples: int = 3,
+) -> str:
+    """Return a compact analytics summary for vault hygiene."""
+    inp = VaultAnalyticsSummaryInput(
+        path_prefix=path_prefix,
+        required_frontmatter=required_frontmatter,
+        max_examples=max_examples,
+    )
+    return _vault_analytics_summary(inp.path_prefix or "", inp.required_frontmatter, inp.max_examples)
+
+
+@mcp.tool(
+    name="vault_analytics_findings",
+    description=(
+        "Return detailed findings for one vault analytics category: frontmatter_missing, "
+        "required_frontmatter_missing, broken_wikilinks, suspicious_tag_variants, encoding_issues, "
+        "or oversized_files. Read-only."
+    ),
+    annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True, "openWorldHint": False},
+)
+def vault_analytics_findings(
+    category: str,
+    path_prefix: str | None = None,
+    required_frontmatter: list[str] | None = None,
+    max_results: int = 50,
+) -> str:
+    """Return detailed findings for one analytics category."""
+    inp = VaultAnalyticsFindingsInput(
+        category=category,
+        path_prefix=path_prefix,
+        required_frontmatter=required_frontmatter,
+        max_results=max_results,
+    )
+    return _vault_analytics_findings(
+        inp.category,
+        inp.path_prefix or "",
+        inp.required_frontmatter,
+        inp.max_results,
     )
 
 

--- a/src/obsidian_vault_mcp/tools/analytics.py
+++ b/src/obsidian_vault_mcp/tools/analytics.py
@@ -1,0 +1,432 @@
+"""Vault analytics tools for hygiene and structural diagnostics.
+
+Read-only, pure-filesystem diagnostics over the markdown in a vault: missing or
+incomplete frontmatter, broken ``[[wikilinks]]``, near-duplicate tag variants,
+and files that are not valid UTF-8. No plugin, no network, no subprocess, no new
+config. Every walk is rooted at ``resolve_vault_path`` (or the vault root) so the
+same traversal/dotfile guard every other tool uses applies here too, and the
+standard ``EXCLUDED_DIRS`` (``.obsidian``, ``.trash``, ...) are skipped.
+"""
+
+import logging
+import posixpath
+import re
+from collections import Counter, defaultdict
+from pathlib import Path
+
+import frontmatter
+
+from .. import config
+from ..serialization import dumps
+from ..vault import resolve_vault_path
+
+logger = logging.getLogger(__name__)
+
+WIKILINK_RE = re.compile(r"\[\[([^\]]+)\]\]")
+
+# Per-file read cap for analysis, aligned with the 1 MB write cap. A file over this is read
+# only up to the cap (so top-of-file frontmatter still parses) and separately surfaced as an
+# "oversized_files" finding -- one giant note can't spike memory on a tunnel-reachable server.
+_MAX_ANALYZE_BYTES = config.MAX_CONTENT_SIZE
+
+
+def _vault_root() -> Path:
+    return config.VAULT_PATH.resolve()
+
+
+def _iter_vault_files(path_prefix: str = "", pattern: str = "*") -> list[Path]:
+    """Walk the vault (or a sub-prefix) yielding non-excluded, real files.
+
+    ``resolve_vault_path`` enforces the traversal/dotfile/null-byte guard; an
+    empty prefix walks the whole vault from its root.
+    """
+    root = resolve_vault_path(path_prefix) if path_prefix else _vault_root()
+    if not root.is_dir():
+        raise NotADirectoryError(f"Not a directory: {path_prefix}")
+
+    files: list[Path] = []
+    for path in root.rglob(pattern):
+        if any(part in config.EXCLUDED_DIRS for part in path.parts):
+            continue
+        if path.is_symlink() or not path.is_file():
+            continue
+        files.append(path)
+    return files
+
+
+def _relative_to_vault_root(path: Path) -> str:
+    return str(path.relative_to(_vault_root())).replace("\\", "/")
+
+
+def _scan_encoding_issues(path_prefix: str = "", max_results: int = 100) -> list[dict]:
+    """Return markdown files under the prefix that are not valid UTF-8."""
+    issues: list[dict] = []
+    for path in _iter_vault_files(path_prefix, "*.md"):
+        try:
+            path.read_text(encoding="utf-8")
+        except UnicodeDecodeError as e:
+            issues.append(
+                {
+                    "path": _relative_to_vault_root(path),
+                    "position": e.start,
+                    "reason": e.reason,
+                }
+            )
+            if len(issues) >= max_results:
+                break
+    return issues
+
+
+def _load_posts(path_prefix: str = "") -> tuple[list[dict], dict[str, list[str]], dict[str, str]]:
+    vault_root = _vault_root()
+    files = _iter_vault_files(path_prefix, "*.md")
+    vault_files = _iter_vault_files(path_prefix, "*")
+    posts: list[dict] = []
+    basename_index: dict[str, list[str]] = defaultdict(list)
+    path_index: dict[str, str] = {}
+
+    for path in vault_files:
+        rel = str(path.relative_to(vault_root)).replace("\\", "/")
+        basename_index[path.stem.lower()].append(rel)
+        path_index[rel.lower()] = rel
+        path_index[path.with_suffix("").relative_to(vault_root).as_posix().lower()] = rel
+
+    for path in files:
+        rel = str(path.relative_to(vault_root)).replace("\\", "/")
+        # Cap the per-file read so one pathological note can't spike memory; an oversized
+        # file is read only up to the cap (top-of-file frontmatter still parses).
+        try:
+            oversized = path.stat().st_size > _MAX_ANALYZE_BYTES
+        except OSError:
+            oversized = False
+        try:
+            if oversized:
+                with path.open("r", encoding="utf-8", errors="ignore") as handle:
+                    raw = handle.read(_MAX_ANALYZE_BYTES)
+            else:
+                raw = path.read_text(encoding="utf-8")
+            post = frontmatter.loads(raw)
+            metadata = dict(post.metadata)
+            body = post.content
+        except UnicodeDecodeError:
+            metadata = {}
+            body = ""
+        except Exception:
+            with path.open("r", encoding="utf-8", errors="ignore") as handle:
+                body = handle.read(_MAX_ANALYZE_BYTES)
+            metadata = {}
+        posts.append(
+            {
+                "path": rel,
+                "body": body,
+                "frontmatter": metadata,
+            }
+        )
+
+    return posts, basename_index, path_index
+
+
+def _oversized_files(path_prefix: str = "", max_results: int = 100) -> list[dict]:
+    """Markdown files larger than the analysis cap.
+
+    Surfaced as a finding so a file that ``_load_posts`` only read up to the cap is visible
+    rather than silently under-analysed.
+    """
+    vault_root = _vault_root()
+    findings: list[dict] = []
+    for path in _iter_vault_files(path_prefix, "*.md"):
+        try:
+            size = path.stat().st_size
+        except OSError:
+            continue
+        if size > _MAX_ANALYZE_BYTES:
+            rel = str(path.relative_to(vault_root)).replace("\\", "/")
+            findings.append({"path": rel, "size_bytes": size, "limit_bytes": _MAX_ANALYZE_BYTES})
+            if len(findings) >= max_results:
+                break
+    return findings
+
+
+def _extract_tags(frontmatter_data: dict) -> list[str]:
+    tags = frontmatter_data.get("tags", [])
+    if isinstance(tags, str):
+        return [tags]
+    if isinstance(tags, list):
+        return [str(tag) for tag in tags]
+    return []
+
+
+def _split_wikilink_target(target: str) -> str:
+    clean = target.split("|", 1)[0].split("#", 1)[0].strip()
+    return clean.replace("\\", "/")
+
+
+def _normalize_relative_candidate(source_path: str, candidate: str) -> str | None:
+    if not candidate:
+        return ""
+
+    if candidate.startswith("/"):
+        normalized = posixpath.normpath(candidate.lstrip("/"))
+    elif candidate.startswith("./") or candidate.startswith("../"):
+        source_parent = posixpath.dirname(source_path)
+        normalized = posixpath.normpath(posixpath.join(source_parent, candidate))
+    else:
+        normalized = posixpath.normpath(candidate)
+
+    if normalized in ("", ".") or normalized.startswith("../"):
+        return None
+    return normalized
+
+
+def _candidate_lookup_key(relative_candidate: str) -> str:
+    if Path(relative_candidate).suffix:
+        return relative_candidate.lower()
+    return f"{relative_candidate}.md".lower()
+
+
+def _classify_wikilink_target(
+    source_path: str,
+    target: str,
+    basename_index: dict[str, list[str]],
+    path_index: dict[str, str],
+) -> dict:
+    clean = _split_wikilink_target(target)
+    if not clean:
+        return {"status": "ok_exact", "target": target}
+
+    relative_candidate = _normalize_relative_candidate(source_path, clean)
+    if relative_candidate is not None:
+        exact_match = path_index.get(_candidate_lookup_key(relative_candidate))
+        if exact_match:
+            return {
+                "status": "ok_exact",
+                "target": target,
+                "resolved_candidate": exact_match,
+            }
+
+    basename_matches = basename_index.get(Path(clean).stem.lower(), [])
+    if "/" not in clean and "." not in Path(clean).name:
+        if len(basename_matches) == 1:
+            result = {
+                "status": "ok_basename",
+                "target": target,
+                "match_count": 1,
+                "resolved_candidate": basename_matches[0],
+            }
+            return result
+        if len(basename_matches) > 1:
+            return {
+                "status": "ambiguous_basename",
+                "target": target,
+                "match_count": len(basename_matches),
+                "candidates": basename_matches[:5],
+            }
+        return {"status": "missing_target", "target": target}
+
+    if len(basename_matches) == 1:
+        result = {
+            "status": "repairable_path_mismatch",
+            "target": target,
+            "match_count": 1,
+            "resolved_candidate": basename_matches[0],
+        }
+        if relative_candidate is not None:
+            result["requested_candidate"] = relative_candidate
+        return result
+    if len(basename_matches) > 1:
+        result = {
+            "status": "ambiguous_path_mismatch",
+            "target": target,
+            "match_count": len(basename_matches),
+            "candidates": basename_matches[:5],
+        }
+        if relative_candidate is not None:
+            result["requested_candidate"] = relative_candidate
+        return result
+
+    result = {"status": "missing_target", "target": target}
+    if relative_candidate is not None:
+        result["requested_candidate"] = relative_candidate
+    return result
+
+
+def _iter_wikilink_matches(text: str) -> list[dict]:
+    matches: list[dict] = []
+    for match in WIKILINK_RE.finditer(text):
+        start = match.start()
+        line = text.count("\n", 0, start) + 1
+        line_start = text.rfind("\n", 0, start)
+        column = start + 1 if line_start == -1 else start - line_start
+        matches.append(
+            {
+                "target": match.group(1),
+                "line": line,
+                "column": column,
+            }
+        )
+    return matches
+
+
+def _frontmatter_missing(posts: list[dict]) -> list[dict]:
+    return [{"path": post["path"]} for post in posts if not post["frontmatter"]]
+
+
+def _required_frontmatter_missing(posts: list[dict], required_fields: list[str]) -> list[dict]:
+    if not required_fields:
+        return []
+    findings = []
+    for post in posts:
+        missing = [field for field in required_fields if field not in post["frontmatter"]]
+        if missing:
+            findings.append({"path": post["path"], "missing_fields": missing})
+    return findings
+
+
+def _broken_wikilinks(
+    posts: list[dict],
+    basename_index: dict[str, list[str]],
+    path_index: dict[str, str],
+) -> list[dict]:
+    findings = []
+    for post in posts:
+        for match in _iter_wikilink_matches(post["body"]):
+            classification = _classify_wikilink_target(post["path"], match["target"], basename_index, path_index)
+            if not classification["status"].startswith("ok_"):
+                findings.append(
+                    {
+                        "path": post["path"],
+                        "line": match["line"],
+                        "column": match["column"],
+                        **classification,
+                    }
+                )
+    return findings
+
+
+def _broken_wikilink_breakdown(findings: list[dict]) -> dict[str, int]:
+    counts = Counter(item["status"] for item in findings)
+    return {
+        "total": len(findings),
+        "repairable": counts.get("repairable_path_mismatch", 0),
+        "missing_target": counts.get("missing_target", 0),
+        "ambiguous": counts.get("ambiguous_basename", 0) + counts.get("ambiguous_path_mismatch", 0),
+    }
+
+
+def _suspicious_tag_variants(posts: list[dict]) -> list[dict]:
+    raw_by_normalized: dict[str, set[str]] = defaultdict(set)
+    usage_count: Counter[str] = Counter()
+    for post in posts:
+        for tag in _extract_tags(post["frontmatter"]):
+            normalized = tag.strip().lower()
+            if not normalized:
+                continue
+            raw_by_normalized[normalized].add(tag)
+            usage_count[normalized] += 1
+
+    findings = []
+    for normalized, variants in raw_by_normalized.items():
+        if len(variants) > 1:
+            findings.append(
+                {
+                    "normalized_tag": normalized,
+                    "variants": sorted(variants),
+                    "usage_count": usage_count[normalized],
+                }
+            )
+    return sorted(findings, key=lambda item: (-item["usage_count"], item["normalized_tag"]))
+
+
+def vault_analytics_summary(
+    path_prefix: str = "",
+    required_frontmatter: list[str] | None = None,
+    max_examples: int = 3,
+) -> str:
+    """Return a compact analytics summary for vault hygiene."""
+    try:
+        posts, basename_index, path_index = _load_posts(path_prefix)
+        encoding_issues = _scan_encoding_issues(path_prefix, max_results=1000)
+        oversized = _oversized_files(path_prefix, max_results=1000)
+        frontmatter_missing = _frontmatter_missing(posts)
+        required_missing = _required_frontmatter_missing(posts, required_frontmatter or [])
+        broken_wikilinks = _broken_wikilinks(posts, basename_index, path_index)
+        broken_wikilink_breakdown = _broken_wikilink_breakdown(broken_wikilinks)
+        suspicious_tags = _suspicious_tag_variants(posts)
+
+        summary = {
+            "path_prefix": path_prefix,
+            "file_count": len(posts),
+            "findings": {
+                "frontmatter_missing": len(frontmatter_missing),
+                "required_frontmatter_missing": len(required_missing),
+                "broken_wikilinks": broken_wikilink_breakdown["total"],
+                "broken_wikilinks_repairable": broken_wikilink_breakdown["repairable"],
+                "broken_wikilinks_missing_target": broken_wikilink_breakdown["missing_target"],
+                "broken_wikilinks_ambiguous": broken_wikilink_breakdown["ambiguous"],
+                "suspicious_tag_variants": len(suspicious_tags),
+                "encoding_issues": len(encoding_issues),
+                "oversized_files": len(oversized),
+            },
+            "examples": {
+                "frontmatter_missing": frontmatter_missing[:max_examples],
+                "required_frontmatter_missing": required_missing[:max_examples],
+                "broken_wikilinks": broken_wikilinks[:max_examples],
+                "suspicious_tag_variants": suspicious_tags[:max_examples],
+                "encoding_issues": encoding_issues[:max_examples],
+                "oversized_files": oversized[:max_examples],
+            },
+        }
+        return dumps(summary)
+    except ValueError as e:
+        return dumps({"error": str(e), "path_prefix": path_prefix})
+    except Exception as e:
+        logger.error(f"vault_analytics_summary error for {path_prefix!r}: {e}")
+        return dumps({"error": str(e), "path_prefix": path_prefix})
+
+
+def vault_analytics_findings(
+    category: str,
+    path_prefix: str = "",
+    required_frontmatter: list[str] | None = None,
+    max_results: int = 50,
+) -> str:
+    """Return detailed findings for one analytics category."""
+    try:
+        posts, basename_index, path_index = _load_posts(path_prefix)
+        required_frontmatter = required_frontmatter or []
+        category_map = {
+            "frontmatter_missing": lambda: _frontmatter_missing(posts),
+            "required_frontmatter_missing": lambda: _required_frontmatter_missing(posts, required_frontmatter),
+            "broken_wikilinks": lambda: _broken_wikilinks(posts, basename_index, path_index),
+            "suspicious_tag_variants": lambda: _suspicious_tag_variants(posts),
+            "encoding_issues": lambda: _scan_encoding_issues(path_prefix, max_results=max_results),
+            "oversized_files": lambda: _oversized_files(path_prefix, max_results=max_results),
+        }
+        if category not in category_map:
+            return dumps(
+                {
+                    "error": (
+                        "Unsupported category. Use one of: frontmatter_missing, "
+                        "required_frontmatter_missing, broken_wikilinks, "
+                        "suspicious_tag_variants, encoding_issues, oversized_files"
+                    ),
+                    "category": category,
+                }
+            )
+
+        findings = category_map[category]()
+        return dumps(
+            {
+                "category": category,
+                "path_prefix": path_prefix,
+                "required_frontmatter": required_frontmatter,
+                "count": len(findings),
+                "results": findings[:max_results],
+                "truncated": len(findings) > max_results,
+            }
+        )
+    except ValueError as e:
+        return dumps({"error": str(e), "category": category, "path_prefix": path_prefix})
+    except Exception as e:
+        logger.error(f"vault_analytics_findings error for {category!r}/{path_prefix!r}: {e}")
+        return dumps({"error": str(e), "category": category, "path_prefix": path_prefix})

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -1,0 +1,232 @@
+"""Tests for the vault analytics tools (summary / findings).
+
+Covers the happy path over a small temp vault (missing frontmatter, broken
+wikilinks, tag variants, encoding issues), wikilink classification edge cases,
+the server wiring seam, and an abuse case (a path_prefix that escapes the vault
+must produce a clean error, not a traceback).
+"""
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from obsidian_vault_mcp import server
+from obsidian_vault_mcp.models import VaultAnalyticsFindingsInput
+from obsidian_vault_mcp.tools.analytics import (
+    vault_analytics_findings,
+    vault_analytics_summary,
+)
+
+
+# --- summary happy path ----------------------------------------------------
+
+
+def test_summary_reports_hygiene_findings(vault_dir):
+    """vault_analytics_summary returns compact counts and examples."""
+    (vault_dir / "missing-frontmatter.md").write_text("plain text\n", encoding="utf-8")
+    (vault_dir / "broken-link.md").write_text("[[Missing Target]]\n", encoding="utf-8")
+    result = json.loads(vault_analytics_summary(required_frontmatter=["status", "type"]))
+
+    assert "error" not in result
+    assert result["file_count"] >= 4
+    assert result["findings"]["frontmatter_missing"] >= 2
+    assert result["findings"]["broken_wikilinks"] >= 1
+    # required-frontmatter validation flags the plain-text notes
+    assert result["findings"]["required_frontmatter_missing"] >= 2
+
+
+def test_oversized_file_is_capped_and_flagged(vault_dir, monkeypatch):
+    """A file over the analyze cap is surfaced as an oversized_files finding (and the
+    walk reads it only up to the cap rather than spiking memory)."""
+    import obsidian_vault_mcp.tools.analytics as analytics
+    monkeypatch.setattr(analytics, "_MAX_ANALYZE_BYTES", 100)
+    (vault_dir / "huge.md").write_text(
+        "---\nstatus: active\ntype: note\n---\n" + ("x" * 5000), encoding="utf-8"
+    )
+
+    summary = json.loads(vault_analytics_summary())
+    assert summary["findings"]["oversized_files"] >= 1
+
+    findings = json.loads(vault_analytics_findings("oversized_files"))
+    assert findings["count"] >= 1
+    hit = next(f for f in findings["results"] if f["path"] == "huge.md")
+    assert hit["size_bytes"] > 100 and hit["limit_bytes"] == 100
+
+
+def test_oversized_files_category_reachable_through_model(vault_dir):
+    """oversized_files must be reachable through the MCP endpoint, not just the helper.
+
+    Jim's catch on #59: the category was in the category_map + README but missing from the
+    Literal in VaultAnalyticsFindingsInput, so the model rejected it before the logic ran.
+    This drives it through the model (and the server wrapper that validates with it)."""
+    assert VaultAnalyticsFindingsInput(category="oversized_files").category == "oversized_files"
+
+    result = json.loads(server.vault_analytics_findings("oversized_files"))
+    assert result.get("category") == "oversized_files"
+    assert "error" not in result
+
+    with pytest.raises(ValidationError):
+        VaultAnalyticsFindingsInput(category="not_a_category")
+
+
+def test_summary_flags_suspicious_tag_variants(vault_dir):
+    """Tags that normalize to the same value but differ in case/whitespace are flagged."""
+    (vault_dir / "a.md").write_text("---\ntags: [Project]\n---\nbody\n", encoding="utf-8")
+    (vault_dir / "b.md").write_text("---\ntags: [project]\n---\nbody\n", encoding="utf-8")
+
+    summary = json.loads(vault_analytics_summary())
+    findings = json.loads(vault_analytics_findings("suspicious_tag_variants"))
+
+    assert summary["findings"]["suspicious_tag_variants"] >= 1
+    variant = next(f for f in findings["results"] if f["normalized_tag"] == "project")
+    assert variant["variants"] == ["Project", "project"]
+    assert variant["usage_count"] == 2
+
+
+def test_summary_counts_encoding_issues(vault_dir):
+    """Markdown files that are not valid UTF-8 are surfaced as encoding issues."""
+    # cp1252 'ä' (0xE4) is not a valid standalone UTF-8 byte
+    (vault_dir / "bad-encoding.md").write_bytes(b"caf\xe4 latte\n")
+
+    summary = json.loads(vault_analytics_summary())
+    findings = json.loads(vault_analytics_findings("encoding_issues"))
+
+    assert summary["findings"]["encoding_issues"] >= 1
+    assert any(item["path"] == "bad-encoding.md" for item in findings["results"])
+
+
+# --- findings happy path ---------------------------------------------------
+
+
+def test_findings_returns_broken_wikilinks(vault_dir):
+    """vault_analytics_findings returns detailed category results."""
+    (vault_dir / "broken-link.md").write_text("[[Missing Target]]\n", encoding="utf-8")
+    result = json.loads(vault_analytics_findings("broken_wikilinks"))
+
+    assert "error" not in result
+    assert result["category"] == "broken_wikilinks"
+    assert any(item["target"] == "Missing Target" for item in result["results"])
+
+
+def test_findings_rejects_unknown_category_at_model(vault_dir):
+    """An unsupported category is rejected by the input model."""
+    with pytest.raises(ValidationError):
+        VaultAnalyticsFindingsInput(category="not_a_category")
+
+
+# --- wikilink classification edge cases ------------------------------------
+
+
+def test_source_relative_wikilink_not_flagged(vault_dir):
+    """Source-relative wikilinks should not be flagged when the target exists."""
+    (vault_dir / "target-note.md").write_text("target\n", encoding="utf-8")
+    source_dir = vault_dir / "reports"
+    source_dir.mkdir()
+    (source_dir / "report.md").write_text("[[../target-note]]\n", encoding="utf-8")
+
+    result = json.loads(vault_analytics_summary())
+
+    assert "error" not in result
+    assert result["findings"]["broken_wikilinks"] == 0
+
+
+def test_classifies_repairable_and_missing_wikilinks(vault_dir):
+    """Repairable path mismatches are distinguished from truly missing targets."""
+    target_dir = vault_dir / "projects"
+    target_dir.mkdir()
+    (target_dir / "actual-target.md").write_text("exists\n", encoding="utf-8")
+    (vault_dir / "repairable-link.md").write_text("[[wrong/actual-target]]\n", encoding="utf-8")
+    (vault_dir / "missing-link.md").write_text("[[Missing Target]]\n", encoding="utf-8")
+
+    summary = json.loads(vault_analytics_summary())
+    findings = json.loads(vault_analytics_findings("broken_wikilinks", max_results=10))
+
+    assert summary["findings"]["broken_wikilinks"] == 2
+    assert summary["findings"]["broken_wikilinks_repairable"] == 1
+    assert summary["findings"]["broken_wikilinks_missing_target"] == 1
+
+    repairable = next(i for i in findings["results"] if i["target"] == "wrong/actual-target")
+    missing = next(i for i in findings["results"] if i["target"] == "Missing Target")
+    assert repairable["status"] == "repairable_path_mismatch"
+    assert repairable["resolved_candidate"] == "projects/actual-target.md"
+    assert missing["status"] == "missing_target"
+
+
+def test_flags_ambiguous_wikilinks(vault_dir):
+    """Ambiguous basename matches are surfaced explicitly with line/column."""
+    (vault_dir / "team").mkdir()
+    (vault_dir / "archive").mkdir()
+    (vault_dir / "team" / "roadmap.md").write_text("team\n", encoding="utf-8")
+    (vault_dir / "archive" / "roadmap.md").write_text("archive\n", encoding="utf-8")
+    (vault_dir / "ambiguous-link.md").write_text("[[roadmap]]\n", encoding="utf-8")
+
+    summary = json.loads(vault_analytics_summary())
+    findings = json.loads(vault_analytics_findings("broken_wikilinks"))
+
+    assert summary["findings"]["broken_wikilinks"] == 1
+    assert summary["findings"]["broken_wikilinks_ambiguous"] == 1
+    finding = findings["results"][0]
+    assert finding["status"] == "ambiguous_basename"
+    assert finding["line"] == 1
+    assert finding["column"] == 1
+
+
+def test_ignores_wikilinks_in_frontmatter(vault_dir):
+    """Links embedded in frontmatter metadata do not count as broken body wikilinks."""
+    (vault_dir / "meta-link.md").write_text(
+        "---\nrelated: \"[[Missing Target]]\"\n---\n\nBody without wikilinks.\n",
+        encoding="utf-8",
+    )
+
+    summary = json.loads(vault_analytics_summary())
+    assert summary["findings"]["broken_wikilinks"] == 0
+
+
+def test_excluded_dirs_are_skipped(vault_dir):
+    """Files under .obsidian / .trash are not analyzed."""
+    trash = vault_dir / ".trash"
+    trash.mkdir()
+    (trash / "deleted.md").write_text("[[Missing Target]]\n", encoding="utf-8")
+
+    summary = json.loads(vault_analytics_summary())
+    assert summary["findings"]["broken_wikilinks"] == 0
+
+
+# --- abuse / edge ----------------------------------------------------------
+
+
+def test_path_prefix_traversal_returns_clean_error(vault_dir):
+    """A path_prefix escaping the vault yields a clean error payload, not a traceback."""
+    summary = json.loads(vault_analytics_summary(path_prefix=".."))
+    assert "error" in summary
+    assert summary["path_prefix"] == ".."
+
+    findings = json.loads(vault_analytics_findings("broken_wikilinks", path_prefix="../escape"))
+    assert "error" in findings
+    assert findings["category"] == "broken_wikilinks"
+
+
+def test_path_prefix_dotfile_returns_clean_error(vault_dir):
+    """A dotfile/hidden-dir prefix is rejected by resolve_vault_path with a clean error."""
+    summary = json.loads(vault_analytics_summary(path_prefix=".obsidian"))
+    assert "error" in summary
+
+
+# --- server wiring (the @mcp.tool seam, not just the helper) ---------------
+
+
+def test_analytics_tools_registered_and_wired(vault_dir):
+    """Tools are registered on the FastMCP server and the wrappers reach the helpers."""
+    for name in ("vault_analytics_summary", "vault_analytics_findings"):
+        assert server.mcp._tool_manager.get_tool(name) is not None
+
+    (vault_dir / "broken-link.md").write_text("[[Missing Target]]\n", encoding="utf-8")
+
+    summary = json.loads(server.vault_analytics_summary(required_frontmatter=["status"]))
+    assert "error" not in summary
+    assert summary["findings"]["broken_wikilinks"] >= 1
+
+    findings = json.loads(server.vault_analytics_findings("broken_wikilinks"))
+    assert findings["category"] == "broken_wikilinks"
+    assert any(item["target"] == "Missing Target" for item in findings["results"])


### PR DESCRIPTION
## What it does

Adds two read-only, pure-filesystem vault analytics tools (the "hygiene findings" you marked welcome on #50):

- `vault_analytics_summary` — compact vault-hygiene summary: counts plus a few examples of missing frontmatter, missing required fields, broken `[[wikilinks]]` (classified repairable path-mismatch / missing-target / ambiguous), near-duplicate tag variants, and markdown files that are not valid UTF-8.
- `vault_analytics_findings` — the detailed list for a single category.

Both take an optional `path_prefix`, walk from `resolve_vault_path` (vault root when empty), skip `EXCLUDED_DIRS` and symlinks, and serialize through `serialization.dumps`.

## How it fits the bar

- **Read-only, no new surface:** no plugin, no network, no subprocess, no new config, and no new dependency (reuses the existing `python-frontmatter`). `readOnlyHint` annotations.
- **Paths through `resolve_vault_path`** (traversal/dotfile/null-byte guard); a bad `path_prefix` returns the standard `{"error", "path_prefix"}` payload, never a stack trace.
- **No fork infrastructure** — plain `@mcp.tool` wrappers registered exactly like the Canvas/Daily tools; no rate-limit, no audit wrapper.

## Tests

`tests/test_analytics.py` (13 tests): summary/findings happy paths over a temp vault (missing frontmatter, broken wikilinks, tag variants, non-UTF-8 files), wikilink classification edge cases (source-relative, repairable, missing, ambiguous, links-in-frontmatter, excluded dirs), abuse cases (`path_prefix` of `..`, `../escape`, and a dotfile dir all return clean errors), and the `@mcp.tool` wiring seam. Full suite green on Linux: **279 passed, 1 skipped** (`test_oauth.py` uses `os.fchmod`, so the suite is validated on Linux).

## PR checklist

- [x] One self-contained change, rebased on main (not stacked on another PR)
- [x] Full test suite passes locally (`pytest`)
- [x] New/abuse inputs covered by tests; the tool wiring is tested, not just helpers
- [x] Auth: any new route/mount validated against the exempt set; fails closed (n/a — no routes)
- [x] Paths go through resolve_vault_path; resolved path re-validated
- [x] No shell=True on request input; subprocess env scrubbed of secrets (n/a — no subprocess)
- [x] Outbound requests don't follow redirects to private ranges; response size capped (n/a — no outbound)
- [x] No secrets/tokens/capability URLs in logs
- [x] New config validated at startup, fails closed, off by default if risky (n/a — no new config)
- [x] Bridge/optional deps fail soft when absent; heavy deps are optional extras (n/a — no new deps)
- [x] Writes go through the atomic write path (n/a — read-only)
- [x] README updated for new env vars / tools / dependencies
