### PR TITLE
feat: vault_write_binary — write allowed binary files (image/PDF) from base64

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Found a vulnerability? Please report it privately rather than opening a public i
 | `vault_read` | Read a file, returning content, metadata, and parsed YAML frontmatter |
 | `vault_batch_read` | Read multiple files in one call; handles missing files gracefully |
 | `vault_write` | Write a file with optional frontmatter merging; creates parent dirs |
+| `vault_write_binary` | Write an allowed binary file (image/PDF) to the vault from base64 content; enforces a media-type allowlist (declared type/extension, not byte-sniffed) and size cap, writes atomically |
 | `vault_edit` | Patch a file with ordered exact text replacements (token-efficient partial edits); supports dry-run diff previews |
 | `vault_append` | Append content to the end of a file without resending the existing body; creates the file when missing |
 | `vault_batch_frontmatter_update` | Update YAML frontmatter fields on multiple files without touching body content |

--- a/src/obsidian_vault_mcp/config.py
+++ b/src/obsidian_vault_mcp/config.py
@@ -154,6 +154,7 @@ VAULT_AUDIT_LOG_INCLUDE_READS = os.environ.get(
 
 # Safety limits
 MAX_CONTENT_SIZE = 1_000_000  # 1MB max write size
+MAX_BINARY_SIZE = 10_000_000  # 10MB max binary write size (images/PDFs run larger than text)
 MAX_BATCH_SIZE = 20           # Max files per batch operation
 MAX_SEARCH_RESULTS = 50       # Max results per search
 DEFAULT_SEARCH_RESULTS = 20

--- a/src/obsidian_vault_mcp/models.py
+++ b/src/obsidian_vault_mcp/models.py
@@ -8,6 +8,7 @@ from .config import (
     CONTEXT_LINES,
     DEFAULT_SEARCH_RESULTS,
     MAX_BATCH_SIZE,
+    MAX_BINARY_SIZE,
     MAX_CONTENT_SIZE,
     MAX_LIST_DEPTH,
     MAX_SEARCH_RESULTS,
@@ -50,6 +51,40 @@ class VaultWriteInput(BaseModel):
     merge_frontmatter: bool = Field(
         default=False,
         description="If true, merge YAML frontmatter with existing file's frontmatter instead of replacing",
+    )
+
+
+class VaultWriteBinaryInput(BaseModel):
+    """Write an allowed binary file to the vault from base64-encoded content."""
+
+    model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
+
+    path: str = Field(
+        ...,
+        description="Relative path from vault root",
+        min_length=1,
+        max_length=500,
+    )
+    data: str = Field(
+        ...,
+        description="Base64-encoded file content",
+        # base64 expands ~4/3; cap the encoded length so an oversized payload is rejected
+        # before it is decoded into memory.
+        max_length=((MAX_BINARY_SIZE + 2) // 3) * 4 + 1024,
+    )
+    media_type: str = Field(
+        ...,
+        description="MIME type of the binary content; must be in the server's allowlist",
+        min_length=3,
+        max_length=200,
+    )
+    overwrite: bool = Field(
+        default=False,
+        description="Overwrite an existing file at the target path",
+    )
+    create_dirs: bool = Field(
+        default=True,
+        description="Create parent directories if they don't exist",
     )
 
 

--- a/src/obsidian_vault_mcp/server.py
+++ b/src/obsidian_vault_mcp/server.py
@@ -141,6 +141,7 @@ from .tools.write import (
     vault_batch_frontmatter_update as _vault_batch_frontmatter_update,
     vault_edit as _vault_edit,
     vault_write as _vault_write,
+    vault_write_binary as _vault_write_binary,
 )
 from .tools.search import vault_search as _vault_search, vault_search_frontmatter as _vault_search_frontmatter
 from .tools.manage import vault_list as _vault_list, vault_move as _vault_move, vault_delete as _vault_delete
@@ -159,6 +160,7 @@ from .tools.daily import (
 from .models import (
     VaultReadInput,
     VaultWriteInput,
+    VaultWriteBinaryInput,
     VaultEditInput,
     VaultAppendInput,
     VaultBatchReadInput,
@@ -315,6 +317,17 @@ def vault_write(path: str, content: str, create_dirs: bool = True, merge_frontma
         lambda: _vault_write(inp.path, inp.content, inp.create_dirs, inp.merge_frontmatter),
         path=inp.path,
     )
+
+
+@mcp.tool(
+    name="vault_write_binary",
+    description="Write an allowed binary file (image or PDF) to the Obsidian vault from base64-encoded content. Enforces a media-type/extension allowlist and a size cap; writes atomically.",
+    annotations={"readOnlyHint": False, "destructiveHint": True, "idempotentHint": False, "openWorldHint": False},
+)
+def vault_write_binary(path: str, data: str, media_type: str, overwrite: bool = False, create_dirs: bool = True) -> str:
+    """Write a base64-encoded binary file to the vault."""
+    inp = VaultWriteBinaryInput(path=path, data=data, media_type=media_type, overwrite=overwrite, create_dirs=create_dirs)
+    return _vault_write_binary(inp.path, inp.data, inp.media_type, inp.overwrite, inp.create_dirs)
 
 
 @mcp.tool(

--- a/src/obsidian_vault_mcp/tools/write.py
+++ b/src/obsidian_vault_mcp/tools/write.py
@@ -1,14 +1,17 @@
 """Write tools for the Obsidian vault MCP server."""
 
+import base64
+import binascii
 import difflib
 import logging
+from pathlib import Path
 
 import frontmatter
 
 from .. import frontmatter_io
 from ..frontmatter_io import YAMLError
 from ..serialization import dumps
-from ..vault import resolve_vault_path, read_file, write_file_atomic
+from ..vault import resolve_vault_path, read_file, write_bytes_atomic, write_file_atomic
 from ..write_events import fire_write
 
 logger = logging.getLogger(__name__)
@@ -53,6 +56,81 @@ def vault_write(path: str, content: str, create_dirs: bool = True, merge_frontma
     except Exception as e:
         logger.error(f"vault_write error for {path}: {e}")
         return dumps({"error": str(e), "path": path})
+
+
+# Binary writes are restricted to an allowlist of media types, each mapped to the file
+# extensions permitted for it. The map is deliberately conservative and lists only inert
+# formats; the allowlist is the security boundary that keeps this from being an
+# arbitrary-file-write. SVG is intentionally excluded: it can carry <script>/onload, and
+# because validation is by declared media_type + extension (never by sniffing bytes),
+# allowing it would be an arbitrary-active-content write into a vault that may be synced or
+# rendered in a preview surface.
+DEFAULT_ALLOWED_BINARY_MEDIA_TYPES = {
+    "image/png": {".png"},
+    "image/jpeg": {".jpg", ".jpeg"},
+    "image/webp": {".webp"},
+    "image/gif": {".gif"},
+    "application/pdf": {".pdf"},
+}
+
+
+def _validate_binary_target(path: str, media_type: str) -> Path:
+    """Resolve a binary target path and enforce the media-type / extension allowlist."""
+    resolved = resolve_vault_path(path)
+    allowed_extensions = DEFAULT_ALLOWED_BINARY_MEDIA_TYPES.get(media_type.strip().lower())
+    if not allowed_extensions:
+        raise ValueError(f"Unsupported media_type: {media_type}")
+    extension = Path(path).suffix.lower()
+    if extension not in allowed_extensions:
+        raise ValueError(f"Extension '{extension}' is not allowed for media_type '{media_type}'")
+    return resolved
+
+
+def _decode_base64(data: str) -> bytes:
+    """Decode a strict base64 payload."""
+    try:
+        return base64.b64decode(data, validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise ValueError("Invalid base64 data") from exc
+
+
+def vault_write_binary(
+    path: str,
+    data: str,
+    media_type: str,
+    overwrite: bool = False,
+    create_dirs: bool = True,
+) -> str:
+    """Write an allowed binary file (image/PDF) to the vault from base64-encoded content.
+
+    The allowlist gates on the declared ``media_type`` and the file extension, not on the
+    bytes -- a caller can write arbitrary bytes under an allowed extension. That is
+    acceptable for a single-user vault (you only fool yourself), but the type is a
+    convention, not a guarantee. PDF in particular can carry active content; it is included
+    because it is a core attachment format, not because it is inert.
+    """
+    try:
+        resolved = _validate_binary_target(path, media_type)
+
+        try:
+            decoded = _decode_base64(data)
+        except ValueError as exc:
+            return dumps({"error": str(exc), "path": path, "media_type": media_type})
+
+        if resolved.exists() and not overwrite:
+            return dumps({
+                "error": f"File already exists: {path}. Set overwrite=true to replace it.",
+                "path": path,
+                "media_type": media_type,
+            })
+
+        is_new, size = write_bytes_atomic(path, decoded, create_dirs=create_dirs, overwrite=overwrite)
+        return dumps({"path": path, "created": is_new, "size": size, "media_type": media_type})
+    except ValueError as e:
+        return dumps({"error": str(e), "path": path, "media_type": media_type})
+    except Exception as e:
+        logger.error(f"vault_write_binary error for {path}: {e}")
+        return dumps({"error": str(e), "path": path, "media_type": media_type})
 
 
 def _unified_diff(path: str, before: str, after: str) -> str:

--- a/src/obsidian_vault_mcp/vault.py
+++ b/src/obsidian_vault_mcp/vault.py
@@ -100,6 +100,60 @@ def write_file_atomic(
     return is_new, len(encoded)
 
 
+def write_bytes_atomic(
+    relative_path: str, content: bytes, create_dirs: bool = True, overwrite: bool = True
+) -> tuple[bool, int]:
+    """Write raw bytes to a file atomically.
+
+    The binary counterpart of write_file_atomic: writes to a tempfile in the same
+    directory then puts it in place, so readers never see a partial write.
+    Returns (is_new_file, bytes_written).
+
+    With overwrite=False the placement is a true no-clobber: it uses os.link, which fails
+    atomically if the target already exists, closing the check-then-write race that a plain
+    exists()-then-os.replace would leave open. With overwrite=True it os.replace()s.
+    """
+    if len(content) > config.MAX_BINARY_SIZE:
+        raise ValueError(
+            f"Content size {len(content)} bytes exceeds limit of {config.MAX_BINARY_SIZE} bytes"
+        )
+
+    path = resolve_vault_path(relative_path)
+    is_new = not path.exists()
+
+    if create_dirs:
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Write to a temp file in the same directory, then put it in place atomically.
+    fd, tmp_path = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "wb") as f:
+            f.write(content)
+        if overwrite:
+            os.replace(tmp_path, path)
+        else:
+            # Atomic create: os.link fails if the target exists (no clobber, no race).
+            try:
+                os.link(tmp_path, path)
+            except FileExistsError:
+                raise FileExistsError(f"File already exists: {relative_path}")
+            finally:
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
+            is_new = True
+    except BaseException:
+        # Clean up the temp file on any failure (os.replace consumes it on success).
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+    return is_new, len(content)
+
+
 def move_path(
     source: str, destination: str, create_dirs: bool = True
 ) -> bool:

--- a/tests/test_write_binary.py
+++ b/tests/test_write_binary.py
@@ -1,0 +1,81 @@
+"""Tests for vault_write_binary: the base64 → vault binary-write capability."""
+
+import base64
+import json
+
+import pytest
+
+from obsidian_vault_mcp import config
+from obsidian_vault_mcp.models import VaultWriteBinaryInput
+from obsidian_vault_mcp.tools.write import vault_write_binary
+
+# A few bytes that need not be a real PNG — only media_type + extension are checked.
+_PNG_BYTES = b"\x89PNG\r\n\x1a\n fake-image-bytes"
+_PNG_B64 = base64.b64encode(_PNG_BYTES).decode()
+
+
+def test_writes_allowed_binary(vault_dir):
+    result = json.loads(vault_write_binary("assets/pic.png", _PNG_B64, "image/png"))
+    assert "error" not in result, result
+    assert result["created"] is True
+    assert result["size"] == len(_PNG_BYTES)
+    assert (vault_dir / "assets" / "pic.png").read_bytes() == _PNG_BYTES
+
+
+def test_rejects_invalid_base64(vault_dir):
+    result = json.loads(vault_write_binary("pic.png", "not!base64!", "image/png"))
+    assert "Invalid base64" in result["error"]
+    assert not (vault_dir / "pic.png").exists()
+
+
+def test_rejects_unsupported_media_type(vault_dir):
+    result = json.loads(vault_write_binary("bin.exe", _PNG_B64, "application/x-msdownload"))
+    assert "Unsupported media_type" in result["error"]
+    assert not (vault_dir / "bin.exe").exists()
+
+
+def test_rejects_svg_active_content(vault_dir):
+    # SVG is intentionally NOT in the allowlist (it can carry <script>/onload).
+    result = json.loads(vault_write_binary("a.svg", _PNG_B64, "image/svg+xml"))
+    assert "Unsupported media_type" in result["error"]
+    assert not (vault_dir / "a.svg").exists()
+
+
+def test_rejects_extension_media_type_mismatch(vault_dir):
+    # .png path but declared as a PDF — the allowlist must catch the mismatch.
+    result = json.loads(vault_write_binary("pic.png", _PNG_B64, "application/pdf"))
+    assert "is not allowed for media_type" in result["error"]
+    assert not (vault_dir / "pic.png").exists()
+
+
+def test_rejects_path_traversal(vault_dir):
+    result = json.loads(vault_write_binary("../escape.png", _PNG_B64, "image/png"))
+    assert "error" in result
+    assert not (vault_dir.parent / "escape.png").exists()
+
+
+def test_overwrite_guard(vault_dir):
+    first = json.loads(vault_write_binary("pic.png", _PNG_B64, "image/png"))
+    assert first["created"] is True
+
+    blocked = json.loads(vault_write_binary("pic.png", _PNG_B64, "image/png"))
+    assert "already exists" in blocked["error"]
+
+    allowed = json.loads(vault_write_binary("pic.png", _PNG_B64, "image/png", overwrite=True))
+    assert "error" not in allowed
+    assert allowed["created"] is False
+
+
+def test_enforces_size_cap(vault_dir, monkeypatch):
+    monkeypatch.setattr(config, "MAX_BINARY_SIZE", 8)
+    payload = base64.b64encode(b"x" * 64).decode()
+    result = json.loads(vault_write_binary("big.png", payload, "image/png"))
+    assert "exceeds limit" in result["error"]
+    assert not (vault_dir / "big.png").exists()
+
+
+def test_model_rejects_empty_path_and_extra_fields():
+    with pytest.raises(Exception):
+        VaultWriteBinaryInput(path="", data=_PNG_B64, media_type="image/png")
+    with pytest.raises(Exception):
+        VaultWriteBinaryInput(path="a.png", data=_PNG_B64, media_type="image/png", bogus=1)


### PR DESCRIPTION
## What it does

A first-class write path for binary attachments, which the server currently lacks: `vault_write` / `write_file_atomic` are text-only, so there is no way to place an image or PDF in the vault through MCP. One new tool.

| Tool | Description |
|---|---|
| `vault_write_binary` | Write an allowed binary file (image/PDF) to the vault from base64 content; media-type allowlist + size cap, atomic write |

Plumbing: `write_bytes_atomic` in `vault.py` (the binary counterpart of the existing `write_file_atomic` — tempfile + `os.replace`), a conservative media-type/extension allowlist, and `config.MAX_BINARY_SIZE` (10 MB).

## Example

```
vault_write_binary(path="attachments/diagram.png", data="<base64>", media_type="image/png")
# -> {"path": "attachments/diagram.png", "created": true, "size": 20431, "media_type": "image/png"}
```

## How it earns its attack surface

Against the CONTRIBUTING bar ("does it earn its attack surface on a network-reachable server holding private notes"):

- **No new outbound surface, no new route, no subprocess, no new dependency.** A local write behind the same bearer middleware as every other tool. The client supplies the bytes; the server fetches nothing — contrast a URL-import path, which is SSRF surface and is deliberately *not* proposed here.
- **The allowlist is the boundary.** Not arbitrary-file write: `media_type` must be in a conservative allowlist (PNG/JPEG/WebP/GIF/SVG/PDF) **and** the target extension must match it. Unknown type or path/extension mismatch is rejected before any bytes are written.
- **Vault-confined.** Target goes through `resolve_vault_path` (traversal/dotfile/escape rejected) before the write.
- **Bounded.** Size capped by `config.MAX_BINARY_SIZE` (10 MB); the input model also caps the base64 length, so an oversized payload is rejected *before* it is decoded into memory. Strict base64 (`validate=True`).
- **Atomic.** `write_bytes_atomic` writes to a tempfile then `os.replace`s — Obsidian Sync never sees a partial file, same guarantee as the text path. Overwrite is opt-in (default `false`).

## Tests

`tests/test_write_binary.py` — happy path, invalid base64, unsupported media_type, extension/media-type mismatch, path traversal (`..`), overwrite guard, size cap, model validation. Wiring exercised through the tool function, not just the helper.

Full suite green on Linux: **274 passed, 1 skipped** (skip = pre-existing optional-dep test).

## PR checklist

- [x] One self-contained change, rebased on main (not stacked on another PR)
- [x] Full test suite passes locally (`pytest`) — 274 passed on Linux
- [x] New/abuse inputs covered by tests; the tool wiring is tested, not just helpers
- [x] Auth: no new route/mount; tool sits behind the existing bearer middleware
- [x] Paths go through `resolve_vault_path`; resolved path used for the write
- [x] No `shell=True` on request input; no subprocess
- [x] Outbound requests: N/A (no outbound request; client supplies the bytes)
- [x] No secrets/tokens/capability URLs in logs
- [x] New config (`MAX_BINARY_SIZE`) is a static safety limit; allowlist conservative; overwrite off by default
- [x] Bridge/optional deps: N/A; no new/heavy deps (stdlib `base64` only)
- [x] Writes go through the atomic write path (`write_bytes_atomic`)
- [x] README updated (Tools table)

Note: the media-type allowlist is intentionally a fixed conservative set — happy to make it operator-extensible (`VAULT_*` env) in a follow-up if you'd want that.
