### PR TITLE
feat: write-listener seam — register_write_listener + public fire_write (#58)

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ you need) and run the server with `serve([YourExtension()])` from your own entry
 ```python
 from obsidian_vault_mcp.server import serve
 from obsidian_vault_mcp.extensions import Extension
+from obsidian_vault_mcp.write_events import register_write_listener
 
 
 class MyExtension(Extension):
@@ -290,6 +291,8 @@ class MyExtension(Extension):
     def before_indexes_start(self, frontmatter_index):
         # e.g. attach a change listener so no change is missed once the index starts
         frontmatter_index.add_change_listener(self._on_change)
+        # ...or react to a mutation as an operation (see write-event seam below)
+        register_write_listener(self._on_write)  # _on_write(operation, paths)
 
     def after_indexes_start(self, frontmatter_index):
         # e.g. start a periodic reconcile loop now that the index is live
@@ -326,7 +329,16 @@ Two things worth knowing:
   accidents; it is **not** a boundary against a hostile extension (which, running
   in-process, could bypass it anyway — see the trust model above).
 - **The stock server is unaffected.** With no extensions, `serve()` behaves exactly like
-  the previous `main()`; `FrontmatterIndex` change listeners are a no-op with none registered.
+  the previous `main()`; `FrontmatterIndex` change listeners and write listeners are a no-op
+  with none registered.
+- **Write listeners see mutations as operations.** Where `add_change_listener` is watcher-driven
+  (`(abs_path, exists)`, `.md` only, can't tell a tool write from an external edit),
+  `write_events.register_write_listener(cb)` fires `cb(operation, paths)` once per successful
+  mutation from the core write tools — `operation` is `"created"`/`"updated"`/`"moved"`/`"deleted"`,
+  a move passes `[source, destination]`, a batch passes only the paths it wrote. The publish
+  side, `fire_write(operation, paths)`, is public so an extension that writes on its own path
+  can join the same stream. Use it for a provenance-aware commit, an audit log, or a webhook;
+  a listener's exception is logged and swallowed.
 
 ## VPS Setup With Cloudflare Origin TLS + Caddy Reverse Proxy
 

--- a/src/obsidian_vault_mcp/extensions.py
+++ b/src/obsidian_vault_mcp/extensions.py
@@ -14,6 +14,11 @@ A custom deployment provides its own console entry point, e.g.:
 
 Override only the hooks you need; the rest stay no-ops.
 
+To react to vault mutations *as operations* (a provenance-aware commit, an audit
+log, a webhook), subscribe from `before_indexes_start` via the write-event seam in
+`write_events` (`register_write_listener` / `fire_write`) -- the write-side mirror of
+`FrontmatterIndex.add_change_listener`.
+
 TRUST MODEL
 -----------
 Extensions are FULLY-TRUSTED, in-process code that the operator chooses to load.

--- a/src/obsidian_vault_mcp/tools/manage.py
+++ b/src/obsidian_vault_mcp/tools/manage.py
@@ -4,6 +4,7 @@ import logging
 
 from ..serialization import dumps
 from ..vault import list_directory, move_path, delete_path
+from ..write_events import fire_write
 
 logger = logging.getLogger(__name__)
 
@@ -38,6 +39,8 @@ def vault_move(source: str, destination: str, create_dirs: bool = True) -> str:
     """Move a file or directory within the vault."""
     try:
         moved = move_path(source, destination, create_dirs=create_dirs)
+        if moved:
+            fire_write("moved", [source, destination])
         return dumps({"source": source, "destination": destination, "moved": moved})
     except ValueError as e:
         return dumps({"error": str(e), "source": source, "destination": destination})
@@ -56,6 +59,8 @@ def vault_delete(path: str, confirm: bool = False) -> str:
 
     try:
         deleted = delete_path(path)
+        if deleted:
+            fire_write("deleted", [path])
         return dumps({"path": path, "deleted": deleted})
     except ValueError as e:
         return dumps({"error": str(e), "path": path})

--- a/src/obsidian_vault_mcp/tools/write.py
+++ b/src/obsidian_vault_mcp/tools/write.py
@@ -7,6 +7,7 @@ import frontmatter
 
 from ..serialization import dumps
 from ..vault import resolve_vault_path, read_file, write_file_atomic
+from ..write_events import fire_write
 
 logger = logging.getLogger(__name__)
 
@@ -34,6 +35,7 @@ def vault_write(path: str, content: str, create_dirs: bool = True, merge_frontma
 
         is_new, size = write_file_atomic(path, content, create_dirs=create_dirs)
 
+        fire_write("created" if is_new else "updated", [path])
         return dumps({"path": path, "created": is_new, "size": size})
     except ValueError as e:
         return dumps({"error": str(e), "path": path})
@@ -119,6 +121,7 @@ def vault_edit(path: str, edits: list[dict], dry_run: bool = False) -> str:
         changed = content != original_content
         if changed:
             write_file_atomic(path, content, create_dirs=False)
+            fire_write("updated", [path])
 
         return dumps({
             "path": path,
@@ -188,6 +191,7 @@ def vault_append(
         changed = new_content != existing_content
         if changed:
             _, size = write_file_atomic(path, new_content, create_dirs=create_dirs)
+            fire_write("created" if created else "updated", [path])
         else:
             size = len(existing_content.encode("utf-8"))
 
@@ -244,5 +248,10 @@ def vault_batch_frontmatter_update(updates: list[dict]) -> str:
             results.append({"path": file_path, "updated": False, "error": str(e)})
         except Exception as e:
             results.append({"path": file_path, "updated": False, "error": str(e)})
+
+    # One event per batch, carrying only the paths actually written.
+    written = [r["path"] for r in results if r.get("updated")]
+    if written:
+        fire_write("updated", written)
 
     return dumps({"results": results})

--- a/src/obsidian_vault_mcp/write_events.py
+++ b/src/obsidian_vault_mcp/write_events.py
@@ -1,0 +1,51 @@
+"""In-process write-event seam: the write-side mirror of
+``FrontmatterIndex.add_change_listener``.
+
+Lets an extension react to a vault mutation *as an operation* -- a provenance-aware
+git commit, an audit log, a webhook -- which the watcher-driven change-listener
+can't express (it only reports ``(abs_path, exists)`` for ``.md`` files). Core stays
+a no-op callback list: with zero listeners ``fire_write`` does nothing, side effects
+live entirely downstream in the (fully-trusted) extension, and a listener's exception
+is logged and swallowed so it can't break a write or starve the other listeners.
+
+The publish side is public on purpose -- called by the core mutation tools AND by an
+extension after its own write (e.g. attachment bytes on a path no core tool touches),
+so one stream carries both::
+
+    from obsidian_vault_mcp.write_events import register_write_listener, fire_write
+
+    register_write_listener(lambda op, paths: ...)   # subscribe
+    fire_write("created", ["attachments/img.png"])    # publish (from an extension)
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Registered at startup (before serving), fired during request handling.
+_write_listeners: list = []
+
+
+def register_write_listener(callback) -> None:
+    """Register a ``callback(operation: str, paths: list[str])`` for vault mutations.
+
+    Invoked once per successful mutation operation, after the write lands. ``operation``
+    is one of "created", "updated", "moved", "deleted"; ``paths`` are vault-relative
+    (a move passes ``[source, destination]``; a batch passes only the paths it wrote).
+    With no listeners registered this seam is a true no-op on the stock server.
+    Exceptions raised by a listener are logged and swallowed, never propagated.
+    """
+    _write_listeners.append(callback)
+
+
+def fire_write(operation: str, paths: list[str]) -> None:
+    """Notify every write listener of a mutation; a no-op with none registered.
+
+    Called by the core mutation tools at their success path, and public so an
+    extension can publish its own writes to the same stream.
+    """
+    for listener in _write_listeners:
+        try:
+            listener(operation, paths)
+        except Exception:
+            logger.warning("Write listener error for %s %s", operation, paths)

--- a/tests/test_write_events.py
+++ b/tests/test_write_events.py
@@ -1,0 +1,56 @@
+"""Tests for the write-event seam (register_write_listener + fire_write).
+
+The write-side mirror of FrontmatterIndex.add_change_listener: a process-global
+registry that is a true no-op with zero listeners, carries (operation, paths) per
+operation, and logs-and-swallows a listener's exceptions so one bad subscriber
+can never break a write or starve the others.
+"""
+
+import pytest
+
+from obsidian_vault_mcp import write_events
+
+
+@pytest.fixture(autouse=True)
+def _clear_listeners():
+    """Each test starts with an empty registry (it is process-global)."""
+    write_events._write_listeners.clear()
+    yield
+    write_events._write_listeners.clear()
+
+
+def test_fire_with_no_listeners_is_a_noop():
+    """Zero listeners => byte-identical stock server: fire must not raise."""
+    write_events.fire_write("created", ["a.md"])  # must not raise
+
+
+def test_registered_listener_receives_operation_and_paths():
+    seen = []
+    write_events.register_write_listener(lambda op, paths: seen.append((op, paths)))
+
+    write_events.fire_write("created", ["note.md"])
+
+    assert seen == [("created", ["note.md"])]
+
+
+def test_all_listeners_fire_in_registration_order():
+    order = []
+    write_events.register_write_listener(lambda op, paths: order.append("first"))
+    write_events.register_write_listener(lambda op, paths: order.append("second"))
+
+    write_events.fire_write("updated", ["x.md"])
+
+    assert order == ["first", "second"]
+
+
+def test_listener_exception_is_swallowed_and_others_still_fire(caplog):
+    survived = []
+    write_events.register_write_listener(
+        lambda op, paths: (_ for _ in ()).throw(RuntimeError("boom"))
+    )
+    write_events.register_write_listener(lambda op, paths: survived.append(paths))
+
+    # Must not propagate despite the throwing listener.
+    write_events.fire_write("deleted", ["gone.md"])
+
+    assert survived == [["gone.md"]]

--- a/tests/test_write_listener_integration.py
+++ b/tests/test_write_listener_integration.py
@@ -1,0 +1,149 @@
+"""The six core mutation tools fire write events at their success path.
+
+Semantics under test (from #58): created-vs-updated distinguished; vault_move is a
+single "moved" with both paths; a batch fires once with only the successfully-written
+paths; vault_edit does not fire on a dry-run or a no-change edit; delete fires only on
+a confirmed success; a failed/aborted write never fires.
+"""
+
+import json
+
+import pytest
+
+from obsidian_vault_mcp import write_events
+from obsidian_vault_mcp.tools.write import (
+    vault_append,
+    vault_batch_frontmatter_update,
+    vault_edit,
+    vault_write,
+)
+from obsidian_vault_mcp.tools.manage import vault_delete, vault_move
+
+
+@pytest.fixture
+def events():
+    """Capture (operation, paths) events and isolate the process-global registry."""
+    write_events._write_listeners.clear()
+    captured = []
+    write_events.register_write_listener(lambda op, paths: captured.append((op, paths)))
+    yield captured
+    write_events._write_listeners.clear()
+
+
+# --- vault_write ---
+
+def test_vault_write_new_file_fires_created(vault_dir, events):
+    vault_write("fresh.md", "hello")
+    assert events == [("created", ["fresh.md"])]
+
+
+def test_vault_write_existing_file_fires_updated(vault_dir, events):
+    vault_write("test-note.md", "changed body")
+    assert events == [("updated", ["test-note.md"])]
+
+
+def test_vault_write_invalid_path_does_not_fire(vault_dir, events):
+    result = json.loads(vault_write("../escape.md", "x"))
+    assert "error" in result
+    assert events == []
+
+
+# --- vault_edit ---
+
+def test_vault_edit_applied_change_fires_updated(vault_dir, events):
+    vault_edit("test-note.md", [{"old_text": "test note", "new_text": "edited note"}])
+    assert events == [("updated", ["test-note.md"])]
+
+
+def test_vault_edit_dry_run_does_not_fire(vault_dir, events):
+    vault_edit(
+        "test-note.md",
+        [{"old_text": "test note", "new_text": "edited note"}],
+        dry_run=True,
+    )
+    assert events == []
+
+
+def test_vault_edit_no_change_does_not_fire(vault_dir, events):
+    """old_text == new_text leaves the file untouched, so nothing is written."""
+    result = json.loads(vault_edit(
+        "test-note.md", [{"old_text": "test note", "new_text": "test note"}]
+    ))
+    assert result["changed"] is False
+    assert events == []
+
+
+def test_vault_edit_failed_match_does_not_fire(vault_dir, events):
+    json.loads(vault_edit(
+        "test-note.md", [{"old_text": "nope-not-present", "new_text": "x"}]
+    ))
+    assert events == []
+
+
+# --- vault_append ---
+
+def test_vault_append_existing_fires_updated(vault_dir, events):
+    vault_append("no-frontmatter.md", "more text")
+    assert events == [("updated", ["no-frontmatter.md"])]
+
+
+def test_vault_append_new_file_fires_created(vault_dir, events):
+    vault_append("new/appended.md", "brand new")
+    assert events == [("created", ["new/appended.md"])]
+
+
+def test_vault_append_no_change_does_not_fire(vault_dir, events):
+    """Appending empty content to an existing file writes nothing."""
+    result = json.loads(vault_append("no-frontmatter.md", ""))
+    assert result["changed"] is False
+    assert events == []
+
+
+# --- vault_batch_frontmatter_update ---
+
+def test_batch_fires_once_with_only_successful_paths(vault_dir, events):
+    vault_batch_frontmatter_update([
+        {"path": "test-note.md", "fields": {"reviewed": True}},
+        {"path": "does-not-exist.md", "fields": {"reviewed": True}},
+        {"path": "subfolder/nested-note.md", "fields": {"reviewed": True}},
+    ])
+    assert events == [
+        ("updated", ["test-note.md", "subfolder/nested-note.md"]),
+    ]
+
+
+def test_batch_all_failed_does_not_fire(vault_dir, events):
+    vault_batch_frontmatter_update([
+        {"path": "missing-a.md", "fields": {"x": 1}},
+        {"path": "missing-b.md", "fields": {"x": 1}},
+    ])
+    assert events == []
+
+
+# --- vault_move ---
+
+def test_vault_move_fires_one_moved_with_both_paths(vault_dir, events):
+    vault_move("test-note.md", "moved-note.md")
+    assert events == [("moved", ["test-note.md", "moved-note.md"])]
+
+
+def test_vault_move_failure_does_not_fire(vault_dir, events):
+    json.loads(vault_move("does-not-exist.md", "anywhere.md"))
+    assert events == []
+
+
+# --- vault_delete ---
+
+def test_vault_delete_confirmed_fires_deleted(vault_dir, events):
+    vault_delete("test-note.md", confirm=True)
+    assert events == [("deleted", ["test-note.md"])]
+
+
+def test_vault_delete_without_confirm_does_not_fire(vault_dir, events):
+    vault_delete("test-note.md", confirm=False)
+    assert events == []
+
+
+def test_vault_delete_missing_file_does_not_fire(vault_dir, events):
+    json.loads(vault_delete("not-here.md", confirm=True))
+    assert events == []


### PR DESCRIPTION
Implements #58 — the write-side analogue of `FrontmatterIndex.add_change_listener` (#57).

## Why

The extension seam (#57) lets you observe *indexed content* via `add_change_listener`, but that's watcher-driven: it collapses create/update/move/delete into `(abs_path, exists)`, can't distinguish a tool write from an external edit (Sync, `git pull`), fires per-path not per-operation, and is `.md`-only. An extension that needs a vault mutation *as an operation* — a provenance-aware git commit, an audit log, a webhook — has nothing to subscribe to. `register_tools` only *adds* tools; it can't observe `vault_write`/`vault_append`/`vault_edit`/`vault_batch_frontmatter_update`/`vault_move`/`vault_delete`.

This is the redesign of the declined #44: instead of a `shell=True` hook in core, core gains only a no-op callback list and **all side effects move downstream** into the (already fully-trusted) extension.

## What

New `write_events.py`:
- `register_write_listener(cb)` — subscribe; `cb(operation, paths)`.
- `fire_write(operation, paths)` — **public** publish side, so an extension that writes on its own path (e.g. attachment bytes that never pass through a core tool) can join the same stream.

Wired at the success path of the six core mutation tools. Semantics:
- created-vs-updated distinguished;
- `vault_move` fires one `"moved"` with `[source, destination]`;
- a batch fires **once** with only the successfully-written paths;
- no fire on a dry-run or no-change `vault_edit`, a no-change `vault_append`, or any error;
- `vault_delete` fires only on a confirmed success.

Zero listeners ⇒ byte-identical no-op; a listener's exception is logged and swallowed so it can't break the write or starve the other listeners.

Design discussion (public publish side, and keeping the principal/before-state out of this seam) is in #58 — thanks @mleitnercom for shaping it from the audit-extension side.

## Tests

21 new tests (`test_write_events.py` + `test_write_listener_integration.py`) exercising the tools, not just the helper, with the negative cases (dry-run, no-change, error, unconfirmed delete). No CI on this repo — green local run is the gate:

```
287 passed, 1 skipped
```

## Checklist

- [x] One self-contained change, rebased on main (not stacked on another PR)
- [x] Full test suite passes locally (`pytest`)
- [x] New/abuse inputs covered by tests; the tool wiring is tested, not just helpers
- [x] Auth: no new route/mount
- [x] Paths: no new path handling (rides the existing tools' resolved paths)
- [x] No `shell=True`; no subprocess at all (the point — side effects stay downstream)
- [x] Outbound requests: none
- [x] No secrets/tokens/capability URLs in logs (logs only operation + vault-relative paths, mirroring the change-listener log)
- [x] No new config; zero-listener no-op is the off-by-default
- [x] No new dependencies
- [x] Writes still go through the atomic path (fire is *after* the existing write)
- [x] README updated (extension-seam section)
