### PR TITLE
feat: signed direct binary upload (vault_request_upload_url + POST /upload/{id})

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Found a vulnerability? Please report it privately rather than opening a public i
 | `vault_batch_read` | Read multiple files in one call; handles missing files gracefully |
 | `vault_write` | Write a file with optional frontmatter merging; creates parent dirs |
 | `vault_write_binary` | Write an allowed binary file (image/PDF) to the vault from base64 content; enforces a media-type allowlist (declared type/extension, not byte-sniffed) and size cap, writes atomically |
+| `vault_request_upload_url` | Return a short-lived, HMAC-signed URL for a direct binary upload; the client then `POST`s the bytes to `/upload/{id}` (server fetches nothing). For files larger than `vault_write_binary`'s base64 path. Same allowlist + size cap |
 | `vault_edit` | Patch a file with ordered exact text replacements (token-efficient partial edits); supports dry-run diff previews |
 | `vault_append` | Append content to the end of a file without resending the existing body; creates the file when missing |
 | `vault_batch_frontmatter_update` | Update YAML frontmatter fields on multiple files without touching body content |

--- a/src/obsidian_vault_mcp/auth.py
+++ b/src/obsidian_vault_mcp/auth.py
@@ -29,6 +29,12 @@ _AUTH_EXEMPT_METHOD_PATHS = (
     {("GET", "/"), ("HEAD", "/")} if config.VAULT_MCP_PATH != "/" else set()
 )
 
+# Path PREFIXES exempt from bearer auth. The signed direct-upload endpoint
+# POST /upload/{id} carries its OWN authorization: an HMAC signature in the URL that
+# commit_direct_upload verifies (exact-expiry + single-use + constant-time compared). It is
+# therefore bearer-exempt by design. Kept narrow and explicit so it can't widen by accident.
+_AUTH_EXEMPT_PATH_PREFIXES = ("/upload/",)
+
 
 def _www_authenticate(request: Request, error: str) -> str:
     """RFC 9728 challenge header pointing clients at the protected-resource metadata.
@@ -53,6 +59,9 @@ class BearerAuthMiddleware(BaseHTTPMiddleware):
             return await call_next(request)
 
         if (request.method, request.url.path) in _AUTH_EXEMPT_METHOD_PATHS:
+            return await call_next(request)
+
+        if any(request.url.path.startswith(p) for p in _AUTH_EXEMPT_PATH_PREFIXES):
             return await call_next(request)
 
         if not VAULT_MCP_TOKEN:

--- a/src/obsidian_vault_mcp/config.py
+++ b/src/obsidian_vault_mcp/config.py
@@ -155,6 +155,25 @@ VAULT_AUDIT_LOG_INCLUDE_READS = os.environ.get(
 # Safety limits
 MAX_CONTENT_SIZE = 1_000_000  # 1MB max write size
 MAX_BINARY_SIZE = 10_000_000  # 10MB max binary write size (images/PDFs run larger than text)
+
+# Signed direct binary upload. The POST /upload/{id} route is bearer-exempt because the HMAC
+# signature in the URL IS the authorization: single-use, short-lived, constant-time compared.
+# VAULT_UPLOAD_URL_SECRET is the HMAC key; it falls back to VAULT_MCP_TOKEN when unset. The
+# staging dir holds only per-upload metadata.json, OUTSIDE the vault so vault tools can't reach
+# it; the uploaded bytes are written into the vault atomically on commit.
+VAULT_UPLOAD_URL_SECRET = os.environ.get("VAULT_UPLOAD_URL_SECRET", "").strip()
+try:
+    VAULT_UPLOAD_URL_TTL_SECONDS = int(os.environ.get("VAULT_UPLOAD_URL_TTL_SECONDS", "900"))
+except ValueError:
+    VAULT_UPLOAD_URL_TTL_SECONDS = 900
+try:
+    VAULT_UPLOAD_URL_MAX_TTL_SECONDS = int(os.environ.get("VAULT_UPLOAD_URL_MAX_TTL_SECONDS", "3600"))
+except ValueError:
+    VAULT_UPLOAD_URL_MAX_TTL_SECONDS = 3600
+UPLOAD_STAGING_DIR = Path(os.environ.get(
+    "VAULT_UPLOAD_STAGING_DIR",
+    Path.home() / ".local" / "share" / "vault-mcp" / "uploads",
+))
 MAX_BATCH_SIZE = 20           # Max files per batch operation
 MAX_SEARCH_RESULTS = 50       # Max results per search
 DEFAULT_SEARCH_RESULTS = 20

--- a/src/obsidian_vault_mcp/models.py
+++ b/src/obsidian_vault_mcp/models.py
@@ -88,6 +88,34 @@ class VaultWriteBinaryInput(BaseModel):
     )
 
 
+class VaultRequestUploadUrlInput(BaseModel):
+    """Request a short-lived signed URL for a direct binary upload."""
+
+    model_config = ConfigDict(str_strip_whitespace=True, extra="forbid")
+
+    path: str = Field(..., description="Relative path from vault root", min_length=1, max_length=500)
+    media_type: str = Field(
+        ...,
+        description="MIME type of the binary content; must be in the server's allowlist",
+        min_length=3,
+        max_length=200,
+    )
+    max_size_bytes: int = Field(
+        ...,
+        ge=1,
+        le=MAX_BINARY_SIZE,
+        description="Maximum byte size the signed URL will accept",
+    )
+    overwrite: bool = Field(default=False, description="Overwrite an existing file at the target path")
+    create_dirs: bool = Field(default=True, description="Create parent directories if they don't exist")
+    expected_sha256: str | None = Field(
+        default=None, description="Optional SHA-256 hex digest the uploaded bytes must match"
+    )
+    ttl_seconds: int | None = Field(
+        default=None, ge=1, description="Requested URL lifetime in seconds (clamped to the server max)"
+    )
+
+
 class VaultEditOperationInput(BaseModel):
     """Replace one exact text fragment inside a vault file."""
 

--- a/src/obsidian_vault_mcp/server.py
+++ b/src/obsidian_vault_mcp/server.py
@@ -157,10 +157,15 @@ from .tools.daily import (
     vault_daily_note_read as _vault_daily_note_read,
     vault_daily_note_append as _vault_daily_note_append,
 )
+from .tools.upload import (
+    vault_request_upload_url as _vault_request_upload_url,
+    commit_direct_upload,
+)
 from .models import (
     VaultReadInput,
     VaultWriteInput,
     VaultWriteBinaryInput,
+    VaultRequestUploadUrlInput,
     VaultEditInput,
     VaultAppendInput,
     VaultBatchReadInput,
@@ -328,6 +333,36 @@ def vault_write_binary(path: str, data: str, media_type: str, overwrite: bool = 
     """Write a base64-encoded binary file to the vault."""
     inp = VaultWriteBinaryInput(path=path, data=data, media_type=media_type, overwrite=overwrite, create_dirs=create_dirs)
     return _vault_write_binary(inp.path, inp.data, inp.media_type, inp.overwrite, inp.create_dirs)
+
+
+@mcp.tool(
+    name="vault_request_upload_url",
+    description="Create a short-lived, HMAC-signed URL for a direct binary upload (image/PDF). The client then POSTs the bytes to the returned URL; the server fetches nothing. Use for files too large for vault_write_binary's base64 path. Enforces the media-type allowlist and a size cap.",
+    annotations={"readOnlyHint": False, "destructiveHint": False, "idempotentHint": False, "openWorldHint": False},
+)
+def vault_request_upload_url(
+    path: str,
+    media_type: str,
+    max_size_bytes: int,
+    overwrite: bool = False,
+    create_dirs: bool = True,
+    expected_sha256: str | None = None,
+    ttl_seconds: int | None = None,
+) -> str:
+    """Return a short-lived signed direct-upload URL."""
+    inp = VaultRequestUploadUrlInput(
+        path=path,
+        media_type=media_type,
+        max_size_bytes=max_size_bytes,
+        overwrite=overwrite,
+        create_dirs=create_dirs,
+        expected_sha256=expected_sha256,
+        ttl_seconds=ttl_seconds,
+    )
+    return _vault_request_upload_url(
+        inp.path, inp.media_type, inp.max_size_bytes, inp.overwrite,
+        inp.create_dirs, inp.expected_sha256, inp.ttl_seconds,
+    )
 
 
 @mcp.tool(
@@ -607,6 +642,51 @@ def build_app(extensions=()):
 
     app.routes.insert(0, Route("/health", health, methods=["GET"]))
 
+    # Signed direct binary upload (bearer-exempt, see auth._AUTH_EXEMPT_PATH_PREFIXES): the
+    # HMAC signature in the URL IS the authorization. commit_direct_upload re-validates
+    # everything server-side (exact expiry, single-use, constant-time signature, size caps,
+    # media-type, target allowlist) before any byte is written.
+    async def direct_upload(request):
+        upload_id = request.path_params["upload_id"]
+        content_length = request.headers.get("content-length")
+        if content_length:
+            try:
+                if int(content_length) > config.MAX_BINARY_SIZE:
+                    return JSONResponse(
+                        {"error": f"Uploaded content exceeds server limit of {config.MAX_BINARY_SIZE} bytes", "upload_id": upload_id},
+                        status_code=413,
+                    )
+            except ValueError:
+                return JSONResponse({"error": "Invalid Content-Length", "upload_id": upload_id}, status_code=400)
+
+        content_type = request.headers.get("content-type", "")
+        if content_type.split(";", 1)[0].strip().lower() == "multipart/form-data":
+            try:
+                form = await request.form()
+            except Exception as exc:
+                logger.warning("Direct upload multipart parse failed for %s: %s", upload_id, exc)
+                return JSONResponse({"error": "Could not parse multipart upload; send field 'file' or use --data-binary", "upload_id": upload_id}, status_code=400)
+            uploaded = form.get("file")
+            if uploaded is None:
+                return JSONResponse({"error": "Multipart upload must include a 'file' field", "upload_id": upload_id}, status_code=400)
+            content_type = getattr(uploaded, "content_type", "") or content_type
+            body = await uploaded.read()
+        else:
+            body = await request.body()
+
+        result, status_code = commit_direct_upload(
+            upload_id=upload_id,
+            content=body,
+            content_type=content_type,
+            expires=request.query_params.get("expires", ""),
+            signature=request.query_params.get("signature", ""),
+        )
+        if "error" in result:
+            logger.warning("Direct upload rejected: %s (%s)", upload_id, result["error"])
+        return JSONResponse(result, status_code=status_code)
+
+    app.routes.insert(0, Route("/upload/{upload_id}", direct_upload, methods=["POST"]))
+
     # Extension routes (e.g. a localhost search endpoint), added before the auth
     # middleware so they are bearer-protected like the MCP transport.
     #
@@ -620,7 +700,7 @@ def build_app(extensions=()):
     # mutates an existing route in place, opens a raw socket, etc.
     from starlette.routing import Match, Mount, WebSocketRoute
 
-    from .auth import _AUTH_EXEMPT_METHOD_PATHS, _AUTH_EXEMPT_PATHS
+    from .auth import _AUTH_EXEMPT_METHOD_PATHS, _AUTH_EXEMPT_PATHS, _AUTH_EXEMPT_PATH_PREFIXES
 
     extensions = tuple(extensions)
     before_ids = {id(r) for r in app.routes}
@@ -665,6 +745,14 @@ def build_app(extensions=()):
                 raise ValueError(
                     f"extension route {getattr(r, 'path', r)!r} covers auth-exempt "
                     f"{m} {p!r}; it would be served without bearer authentication"
+                )
+        # Method-AGNOSTIC exempt PREFIXES (e.g. /upload/): any route covering a path under
+        # the prefix would be served unauthenticated. Probe with a representative sub-path.
+        for prefix in _AUTH_EXEMPT_PATH_PREFIXES:
+            if _covers(r, "POST", prefix + "probe") is not Match.NONE:
+                raise ValueError(
+                    f"extension route {getattr(r, 'path', r)!r} covers auth-exempt prefix "
+                    f"{prefix!r}; it would be served without bearer authentication"
                 )
     app.add_middleware(BearerAuthMiddleware)
     return app

--- a/src/obsidian_vault_mcp/tools/upload.py
+++ b/src/obsidian_vault_mcp/tools/upload.py
@@ -1,0 +1,291 @@
+"""Signed direct binary upload: request a short-lived HMAC-signed URL, then POST the bytes
+straight to it.
+
+The client uploads the bytes (the server fetches nothing -- no SSRF surface), which avoids
+the base64 / MCP-argument-size limits of ``vault_write_binary`` for large files. Two parts:
+
+- ``vault_request_upload_url(...)`` -- an MCP tool that validates the target against the same
+  binary allowlist and returns a short-lived signed URL plus an ``upload_id``.
+- ``commit_direct_upload(...)`` -- called by the ``POST /upload/{id}`` route (wired in
+  ``server.py``). That route is bearer-exempt because the HMAC signature in the URL IS the
+  authorization: it is single-use, short-lived, and constant-time compared.
+
+The staging directory lives OUTSIDE the vault (so the vault tools cannot touch it) and holds
+only a per-upload ``metadata.json``; the uploaded bytes are written into the vault via
+``write_bytes_atomic`` only after every check passes.
+"""
+
+import hashlib
+import hmac
+import json
+import logging
+import shutil
+import time
+import uuid
+from pathlib import Path
+from urllib.parse import urlencode
+
+from .. import config
+from ..serialization import dumps
+from ..vault import write_bytes_atomic
+from .write import _validate_binary_target
+
+logger = logging.getLogger(__name__)
+
+DIRECT_UPLOAD_TYPE = "direct"
+_STALE_CLEANUP_SECONDS = 24 * 60 * 60
+_UPLOAD_ID_ALPHABET = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-"
+
+
+def _upload_root() -> Path:
+    root = config.UPLOAD_STAGING_DIR
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def _upload_paths(upload_id: str) -> tuple[Path, Path]:
+    if not upload_id or any(ch not in _UPLOAD_ID_ALPHABET for ch in upload_id):
+        raise ValueError("Invalid upload_id")
+    upload_dir = _upload_root() / upload_id
+    return upload_dir, upload_dir / "metadata.json"
+
+
+def _upload_secret() -> str:
+    secret = config.VAULT_UPLOAD_URL_SECRET or config.VAULT_MCP_TOKEN
+    if not secret:
+        raise ValueError(
+            "VAULT_UPLOAD_URL_SECRET or VAULT_MCP_TOKEN must be configured for direct uploads"
+        )
+    return secret
+
+
+def _canonical(metadata: dict, expires_at: int) -> str:
+    """The stable string the upload URL signs over."""
+    return "\n".join(
+        [
+            metadata["upload_id"],
+            metadata["path"],
+            metadata["media_type"],
+            str(metadata["max_size_bytes"]),
+            str(expires_at),
+            metadata.get("expected_sha256") or "",
+        ]
+    )
+
+
+def _signature(metadata: dict, expires_at: int) -> str:
+    payload = _canonical(metadata, expires_at).encode("utf-8")
+    return hmac.new(_upload_secret().encode("utf-8"), payload, hashlib.sha256).hexdigest()
+
+
+def _sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def _validate_sha256_hex(value: str) -> str:
+    normalized = value.strip().lower()
+    if len(normalized) != 64 or any(ch not in "0123456789abcdef" for ch in normalized):
+        raise ValueError("expected_sha256 must be a 64-character hex SHA-256 digest")
+    return normalized
+
+
+def _write_json_atomic(path: Path, payload: dict) -> None:
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    tmp_path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    tmp_path.replace(path)
+
+
+def _cleanup_stale_uploads() -> None:
+    cutoff = time.time() - _STALE_CLEANUP_SECONDS
+    try:
+        entries = list(_upload_root().iterdir())
+    except OSError:
+        return
+    for entry in entries:
+        if not entry.is_dir():
+            continue
+        try:
+            if entry.stat().st_mtime < cutoff:
+                shutil.rmtree(entry)
+        except OSError:
+            logger.warning("Could not remove stale upload staging dir: %s", entry)
+
+
+def _load_upload(upload_id: str) -> tuple[dict, Path]:
+    upload_dir, metadata_path = _upload_paths(upload_id)
+    if not upload_dir.exists() or not metadata_path.exists():
+        raise ValueError(f"Unknown upload_id: {upload_id}")
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    return metadata, metadata_path
+
+
+def vault_request_upload_url(
+    path: str,
+    media_type: str,
+    max_size_bytes: int,
+    overwrite: bool = False,
+    create_dirs: bool = True,
+    expected_sha256: str | None = None,
+    ttl_seconds: int | None = None,
+) -> str:
+    """Create a short-lived signed HTTP URL for a direct binary upload."""
+    try:
+        _cleanup_stale_uploads()
+        resolved = _validate_binary_target(path, media_type)
+        if max_size_bytes <= 0:
+            return dumps({"error": "max_size_bytes must be greater than 0", "path": path})
+        if max_size_bytes > config.MAX_BINARY_SIZE:
+            return dumps(
+                {
+                    "error": f"max_size_bytes {max_size_bytes} exceeds limit of {config.MAX_BINARY_SIZE} bytes",
+                    "path": path,
+                    "media_type": media_type,
+                }
+            )
+        if resolved.exists() and not overwrite:
+            return dumps(
+                {
+                    "error": f"File already exists: {path}. Set overwrite=true to replace it.",
+                    "path": path,
+                    "media_type": media_type,
+                }
+            )
+
+        normalized_sha256 = _validate_sha256_hex(expected_sha256) if expected_sha256 else None
+        requested_ttl = ttl_seconds if ttl_seconds is not None else config.VAULT_UPLOAD_URL_TTL_SECONDS
+        max_ttl = max(1, config.VAULT_UPLOAD_URL_MAX_TTL_SECONDS)
+        effective_ttl = max(1, min(requested_ttl, max_ttl))
+        now = int(time.time())
+        expires_at = now + effective_ttl
+        upload_id = str(uuid.uuid4())
+        upload_dir, metadata_path = _upload_paths(upload_id)
+        upload_dir.mkdir(parents=True, exist_ok=False)
+        metadata = {
+            "type": DIRECT_UPLOAD_TYPE,
+            "upload_id": upload_id,
+            "path": path,
+            "media_type": media_type.strip().lower(),
+            "max_size_bytes": max_size_bytes,
+            "overwrite": overwrite,
+            "create_dirs": create_dirs,
+            "expected_sha256": normalized_sha256,
+            "created_at": now,
+            "expires_at": expires_at,
+            "completed_at": None,
+        }
+        _write_json_atomic(metadata_path, metadata)
+        signature = _signature(metadata, expires_at)
+        base_url = config.VAULT_MCP_PUBLIC_URL or f"http://127.0.0.1:{config.VAULT_MCP_PORT}"
+        upload_url = f"{base_url}/upload/{upload_id}?{urlencode({'expires': str(expires_at), 'signature': signature})}"
+        return dumps(
+            {
+                "upload_id": upload_id,
+                "upload_url": upload_url,
+                "expires_at": expires_at,
+                "expires_in_seconds": effective_ttl,
+                "path": path,
+                "media_type": media_type,
+                "max_size_bytes": max_size_bytes,
+                "method": "POST",
+                "curl": f'curl -X POST -H "Content-Type: {media_type}" --data-binary @/path/to/file "{upload_url}"',
+            }
+        )
+    except ValueError as e:
+        return dumps({"error": str(e), "path": path, "media_type": media_type})
+    except Exception as e:  # noqa: BLE001
+        logger.error("vault_request_upload_url error for %s: %s", path, e)
+        return dumps({"error": str(e), "path": path, "media_type": media_type})
+
+
+def commit_direct_upload(
+    upload_id: str,
+    content: bytes,
+    content_type: str,
+    expires: str,
+    signature: str,
+) -> tuple[dict, int]:
+    """Validate and commit a signed direct HTTP upload. Returns (result, http_status)."""
+    try:
+        metadata, metadata_path = _load_upload(upload_id)
+        if metadata.get("type") != DIRECT_UPLOAD_TYPE:
+            return {"error": "Upload id is not a direct upload session", "upload_id": upload_id}, 400
+
+        try:
+            expires_at = int(expires)
+        except (TypeError, ValueError):
+            return {"error": "Invalid expires parameter", "upload_id": upload_id}, 400
+        if expires_at != int(metadata["expires_at"]):
+            return {"error": "Upload expiry mismatch", "upload_id": upload_id}, 403
+        if time.time() > expires_at:
+            return {"error": "Upload URL has expired", "upload_id": upload_id}, 410
+        expected_signature = _signature(metadata, expires_at)
+        if not signature or not hmac.compare_digest(signature, expected_signature):
+            return {"error": "Invalid upload signature", "upload_id": upload_id}, 403
+        if metadata.get("completed_at"):
+            return {"error": "Upload URL has already been used", "upload_id": upload_id}, 409
+
+        media_type = metadata["media_type"]
+        normalized_content_type = (content_type or "").split(";", 1)[0].strip().lower()
+        if normalized_content_type != media_type:
+            return {
+                "error": f"Content-Type '{normalized_content_type}' does not match requested media_type '{media_type}'",
+                "upload_id": upload_id,
+                "media_type": media_type,
+            }, 415
+        if not content:
+            return {"error": "Upload body is empty", "upload_id": upload_id}, 400
+        if len(content) > metadata["max_size_bytes"]:
+            return {
+                "error": f"Uploaded content exceeds max_size_bytes of {metadata['max_size_bytes']} bytes",
+                "upload_id": upload_id,
+                "size": len(content),
+            }, 413
+        if len(content) > config.MAX_BINARY_SIZE:
+            return {
+                "error": f"Uploaded content exceeds server limit of {config.MAX_BINARY_SIZE} bytes",
+                "upload_id": upload_id,
+                "size": len(content),
+            }, 413
+
+        actual_sha256 = _sha256_bytes(content)
+        expected_sha256 = metadata.get("expected_sha256")
+        if expected_sha256 and actual_sha256 != expected_sha256:
+            return {
+                "error": "Upload checksum mismatch",
+                "upload_id": upload_id,
+                "expected_sha256": expected_sha256,
+                "actual_sha256": actual_sha256,
+            }, 422
+
+        # Re-validate the target at commit time (allowlist + vault confinement).
+        resolved = _validate_binary_target(metadata["path"], media_type)
+        if resolved.exists() and not metadata["overwrite"]:
+            return {
+                "error": f"File already exists: {metadata['path']}. Set overwrite=true to replace it.",
+                "upload_id": upload_id,
+                "path": metadata["path"],
+            }, 409
+
+        is_new, size = write_bytes_atomic(
+            metadata["path"],
+            content,
+            create_dirs=metadata["create_dirs"],
+            overwrite=metadata["overwrite"],
+        )
+        metadata["completed_at"] = int(time.time())
+        metadata["size"] = size
+        metadata["sha256"] = actual_sha256
+        _write_json_atomic(metadata_path, metadata)
+        return {
+            "upload_id": upload_id,
+            "path": metadata["path"],
+            "created": is_new,
+            "size": size,
+            "media_type": media_type,
+            "sha256": actual_sha256,
+        }, 201 if is_new else 200
+    except ValueError as e:
+        return {"error": str(e), "upload_id": upload_id}, 400
+    except Exception as e:  # noqa: BLE001
+        logger.error("direct upload commit error for %s: %s", upload_id, e)
+        return {"error": str(e), "upload_id": upload_id}, 500

--- a/tests/test_signed_upload.py
+++ b/tests/test_signed_upload.py
@@ -1,0 +1,168 @@
+"""Tests for the signed direct-upload logic (request + commit).
+
+Exercises the logic layer directly (the thin POST /upload/{id} route is a separate concern):
+request a signed URL, then drive commit_direct_upload with the signature/expiry from it,
+including the abuse cases (bad signature, expired, replay, oversize, media-type, checksum).
+"""
+
+import json
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from obsidian_vault_mcp import config
+from obsidian_vault_mcp.tools import upload as upload_mod
+from obsidian_vault_mcp.tools.upload import commit_direct_upload, vault_request_upload_url
+
+
+@pytest.fixture(autouse=True)
+def _upload_env(vault_dir, tmp_path, monkeypatch):
+    monkeypatch.setattr(config, "UPLOAD_STAGING_DIR", tmp_path / "uploads")
+    monkeypatch.setattr(config, "VAULT_UPLOAD_URL_SECRET", "test-secret")
+    return vault_dir
+
+
+def _request(path, media_type, max_size, **kw):
+    return json.loads(vault_request_upload_url(path, media_type, max_size, **kw))
+
+
+def _sig_expires(req):
+    q = parse_qs(urlparse(req["upload_url"]).query)
+    return q["signature"][0], q["expires"][0]
+
+
+def test_request_and_commit_happy_path(vault_dir):
+    req = _request("assets/x.png", "image/png", 1000)
+    assert "error" not in req, req
+    sig, expires = _sig_expires(req)
+    result, code = commit_direct_upload(req["upload_id"], b"PNGBYTES", "image/png", expires, sig)
+    assert "error" not in result, result
+    assert code == 201 and result["created"] is True
+    assert (vault_dir / "assets" / "x.png").read_bytes() == b"PNGBYTES"
+
+
+def test_bad_signature_rejected(vault_dir):
+    req = _request("x.png", "image/png", 1000)
+    _sig, expires = _sig_expires(req)
+    result, code = commit_direct_upload(req["upload_id"], b"data", "image/png", expires, "deadbeef")
+    assert code == 403 and "signature" in result["error"]
+    assert not (vault_dir / "x.png").exists()
+
+
+def test_expired_rejected(vault_dir, monkeypatch):
+    req = _request("x.png", "image/png", 1000, ttl_seconds=2)
+    sig, expires = _sig_expires(req)
+    monkeypatch.setattr(upload_mod.time, "time", lambda: int(expires) + 10)
+    result, code = commit_direct_upload(req["upload_id"], b"data", "image/png", expires, sig)
+    assert code == 410 and "expired" in result["error"].lower()
+
+
+def test_single_use_replay_rejected(vault_dir):
+    req = _request("x.png", "image/png", 1000)
+    sig, expires = _sig_expires(req)
+    first, code1 = commit_direct_upload(req["upload_id"], b"data", "image/png", expires, sig)
+    assert code1 in (200, 201) and "error" not in first
+    second, code2 = commit_direct_upload(req["upload_id"], b"data", "image/png", expires, sig)
+    assert code2 == 409 and "already been used" in second["error"]
+
+
+def test_oversize_rejected(vault_dir):
+    req = _request("x.png", "image/png", 8)  # max_size_bytes = 8
+    sig, expires = _sig_expires(req)
+    result, code = commit_direct_upload(req["upload_id"], b"x" * 64, "image/png", expires, sig)
+    assert code == 413 and "exceeds" in result["error"]
+    assert not (vault_dir / "x.png").exists()
+
+
+def test_media_type_mismatch_rejected(vault_dir):
+    req = _request("x.png", "image/png", 1000)
+    sig, expires = _sig_expires(req)
+    result, code = commit_direct_upload(req["upload_id"], b"data", "application/pdf", expires, sig)
+    assert code == 415 and "does not match" in result["error"]
+
+
+def test_checksum_mismatch_rejected(vault_dir):
+    import hashlib
+    wanted = hashlib.sha256(b"the-right-bytes").hexdigest()
+    req = _request("x.png", "image/png", 1000, expected_sha256=wanted)
+    sig, expires = _sig_expires(req)
+    result, code = commit_direct_upload(req["upload_id"], b"the-wrong-bytes", "image/png", expires, sig)
+    assert code == 422 and "checksum" in result["error"]
+
+
+def test_request_rejects_svg(vault_dir):
+    req = _request("x.svg", "image/svg+xml", 1000)
+    assert "Unsupported media_type" in req["error"]
+
+
+def test_request_rejects_oversize_max(vault_dir):
+    req = _request("x.png", "image/png", config.MAX_BINARY_SIZE + 1)
+    assert "exceeds limit" in req["error"]
+
+
+def test_unknown_upload_id_rejected(vault_dir):
+    result, code = commit_direct_upload("not-a-real-id", b"data", "image/png", "0", "x")
+    assert code == 400 and "Unknown upload_id" in result["error"]
+
+
+# --- wiring: the route is registered and bearer-exempt ---
+
+def test_upload_route_registered_and_app_builds(monkeypatch):
+    monkeypatch.setattr(config, "VAULT_MCP_TOKEN", "secret-token")
+    from obsidian_vault_mcp.server import build_app
+    app = build_app()
+    paths = {getattr(r, "path", None) for r in app.routes}
+    assert "/upload/{upload_id}" in paths
+
+
+def test_upload_path_is_bearer_exempt_end_to_end(vault_dir, monkeypatch):
+    from starlette.applications import Starlette
+    from starlette.responses import JSONResponse, PlainTextResponse
+    from starlette.routing import Route
+    from starlette.testclient import TestClient
+
+    from obsidian_vault_mcp import auth as auth_module
+
+    monkeypatch.setattr(auth_module, "VAULT_MCP_TOKEN", "secret-token")
+
+    async def up(request):
+        body = await request.body()
+        result, code = commit_direct_upload(
+            request.path_params["upload_id"],
+            body,
+            request.headers.get("content-type", ""),
+            request.query_params.get("expires", ""),
+            request.query_params.get("signature", ""),
+        )
+        return JSONResponse(result, status_code=code)
+
+    async def root(request):
+        return PlainTextResponse("ok")
+
+    app = Starlette(routes=[Route("/upload/{upload_id}", up, methods=["POST"]), Route("/", root)])
+    app.add_middleware(auth_module.BearerAuthMiddleware)
+    client = TestClient(app)
+
+    # Control: a normal route still demands the bearer token.
+    assert client.get("/").status_code == 401
+
+    # POST /upload/{id} WITHOUT a bearer token must reach commit (HMAC is the auth).
+    req = json.loads(vault_request_upload_url("up.png", "image/png", 1000))
+    sig, expires = _sig_expires(req)
+    r = client.post(
+        f"/upload/{req['upload_id']}?expires={expires}&signature={sig}",
+        content=b"PNGBYTES",
+        headers={"content-type": "image/png"},
+    )
+    assert r.status_code == 201, r.text
+    assert (vault_dir / "up.png").read_bytes() == b"PNGBYTES"
+
+    # A bad signature is rejected (403) -- reached the handler, never a 401.
+    req2 = json.loads(vault_request_upload_url("up2.png", "image/png", 1000))
+    _sig2, expires2 = _sig_expires(req2)
+    bad = client.post(
+        f"/upload/{req2['upload_id']}?expires={expires2}&signature=deadbeef",
+        content=b"x",
+        headers={"content-type": "image/png"},
+    )
+    assert bad.status_code == 403


### PR DESCRIPTION
## What it does

A client-pushes-the-bytes path for binary files too large for `vault_write_binary`'s base64 argument: the client requests a short-lived HMAC-signed URL, then `POST`s the bytes straight to `/upload/{id}`. The server fetches nothing (no SSRF surface). Builds on `write_bytes_atomic` from #61.

| Tool | Description |
|---|---|
| `vault_request_upload_url` | Return a short-lived HMAC-signed upload URL; the client then `POST`s the bytes to `/upload/{id}` |

## Example

```
vault_request_upload_url(path="attachments/scan.pdf", media_type="application/pdf", max_size_bytes=4000000)
# -> { upload_url, upload_id, expires_at, curl, ... }
# then: curl -X POST -H "Content-Type: application/pdf" --data-binary @scan.pdf "<upload_url>"
```

## How it fits the bar

- **`POST /upload/{id}` is bearer-exempt because the HMAC signature in the URL IS the authorization.** Before any byte is written, `commit_direct_upload` verifies server-side: exact `expires` match against the stored metadata, not-expired, constant-time HMAC (`hmac.compare_digest`), single-use (`completed_at`), `Content-Type` matches the requested `media_type`, both size caps (per-URL `max_size_bytes` and the server `MAX_BINARY_SIZE`), the optional `expected_sha256`, and the target against the binary allowlist + `resolve_vault_path`.
- **Auth surface is narrow and explicit.** `auth.py` gains a single `/upload/` exempt *prefix* (it previously had only exact paths); `build_app`'s footgun guard now also rejects any extension route that would land under `/upload/`. No other path changes. Every check fails closed.
- **No outbound request, no subprocess, no new dependency.** The client supplies the bytes; the server only writes them via the existing atomic path. (Contrast a URL-import path, which is SSRF surface and deliberately not here.)
- **Secret + staging.** `VAULT_UPLOAD_URL_SECRET` is the HMAC key (falls back to `VAULT_MCP_TOKEN`). Staging holds only per-upload `metadata.json`, OUTSIDE the vault, with stale entries swept. The signed URL is a capability URL and is never logged (only `upload_id` + the rejection reason).
- **Write goes through the atomic path** (`write_bytes_atomic`: tempfile + `os.replace`, or `os.link` no-clobber when `overwrite=false`).

## Tests

`tests/test_signed_upload.py` (12) — happy path; bad signature; expired; single-use replay; oversize; media-type mismatch; checksum mismatch; SVG rejected; oversize-max; unknown id; plus wiring: the route is registered in `build_app`, and `POST /upload/{id}` is bearer-exempt end-to-end via TestClient (a normal route still `401`s; `/upload/` reaches the handler; a bad signature is `403`, never `401`).

Full suite green on Linux: **369 passed, 1 skipped**.

## PR checklist

- [x] One self-contained change, rebased on main (prepared on top of #61, rebased onto main now that #61 has landed)
- [x] Full test suite passes locally (`pytest`) — 369 passed on Linux
- [x] New/abuse inputs covered by tests; the route + auth-exempt wiring is tested, not just the helper
- [x] Auth: the one new route is validated against the exempt set — it is *intentionally* bearer-exempt (HMAC is the auth), the exemption is a narrow `/upload/` prefix, and `build_app` fails closed if an extension route would cover it
- [x] Paths go through `resolve_vault_path` (via `_validate_binary_target`) at request AND commit time
- [x] No `shell=True` on request input; no subprocess
- [x] Outbound requests: none (the client uploads; the server fetches nothing)
- [x] No secrets/tokens/capability URLs in logs (only `upload_id` + the rejection reason)
- [x] New config validated/fails closed, off by default if risky — HMAC secret falls back to `VAULT_MCP_TOKEN`; URLs are short-lived + single-use
- [x] Bridge/optional deps: N/A; no new dependencies (stdlib `hmac`/`hashlib`)
- [x] Writes go through the atomic write path (`write_bytes_atomic`)
- [x] README updated (Tools table)

Builds on #61 (now merged).
