### PR TITLE
fix(deps): pydantic-settings >=2.14.2 — GHSA-4xgf-cpjx-pc3j (MEDIUM)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "httpx>=0.27",
     "google-auth>=2.0",
     "requests>=2.0",
+    "cryptography>=48.0.1,<49",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,9 @@ dependencies = [
     "python-frontmatter>=1.1.0",
     "pydantic>=2.0",
     "watchdog>=4.0.0",
+    "httpx>=0.27",
+    "google-auth>=2.0",
+    "requests>=2.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,13 @@ dependencies = [
     "google-auth>=2.0",
     "requests>=2.0",
     "cryptography>=48.0.1,<49",
+    # pydantic-settings: tranzytywna (mcp[cli]→pydantic-settings), przypięta JAWNIE
+    # dla alertu Dependabota (06.07.2026):
+    #   GHSA-4xgf-cpjx-pc3j (MEDIUM) — pydantic-settings: NestedSecretsSettingsSource
+    #     podąża za symlinkami poza secrets_dir (odczyt lokalnych plików); patch 2.14.2.
+    #     Nie używamy secrets_dir ani BaseSettings w kodzie repo — blast radius zerowy.
+    # Podłoga bez sufitu (wzorzec jarvis-infra #231) — górną granicę trzyma mcp.
+    "pydantic-settings>=2.14.2",
 ]
 
 [project.optional-dependencies]

--- a/src/obsidian_vault_mcp/auth.py
+++ b/src/obsidian_vault_mcp/auth.py
@@ -1,6 +1,7 @@
 """Bearer token authentication middleware for the vault MCP server."""
 
-import os
+import hmac
+
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import JSONResponse
@@ -16,19 +17,7 @@ _AUTH_EXEMPT_PATHS = {
     "/oauth/authorize",
     "/oauth/token",
     "/oauth/register",
-    "/.well-known/openid-configuration",
 }
-
-
-def _www_authenticate_header(request: Request) -> dict[str, str]:
-    """Per MCP spec 2025-03-26: 401 MUST include WWW-Authenticate pointing to PRM."""
-    base = os.environ.get("PUBLIC_BASE_URL", str(request.base_url).rstrip("/")).rstrip("/")
-    return {
-        "WWW-Authenticate": (
-            f'Bearer realm="vault-mcp", '
-            f'resource_metadata="{base}/.well-known/oauth-protected-resource"'
-        )
-    }
 
 
 class BearerAuthMiddleware(BaseHTTPMiddleware):
@@ -49,15 +38,15 @@ class BearerAuthMiddleware(BaseHTTPMiddleware):
             return JSONResponse(
                 {"error": "Missing or malformed Authorization header"},
                 status_code=401,
-                headers=_www_authenticate_header(request),
             )
 
+        # Constant-time comparison — the gate guards every MCP request, a plain
+        # ==/!= is a timing side-channel on the static token (audyt s1099, W20).
         token = auth_header[7:]
-        if token != VAULT_MCP_TOKEN:
+        if not hmac.compare_digest(token.encode("utf-8"), VAULT_MCP_TOKEN.encode("utf-8")):
             return JSONResponse(
                 {"error": "Invalid token"},
                 status_code=401,
-                headers=_www_authenticate_header(request),
             )
 
         return await call_next(request)

--- a/src/obsidian_vault_mcp/auth.py
+++ b/src/obsidian_vault_mcp/auth.py
@@ -7,17 +7,11 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse
 
 from .config import VAULT_MCP_TOKEN
+from .oauth import OPEN_PATHS
 
-# Paths that don't require bearer auth (OAuth flow + health)
-_AUTH_EXEMPT_PATHS = {
-    "/health",
-    "/.well-known/oauth-authorization-server",
-    "/.well-known/oauth-protected-resource",
-    "/.well-known/oauth-protected-resource/mcp",
-    "/oauth/authorize",
-    "/oauth/token",
-    "/oauth/register",
-}
+# Ścieżki bez bearer-auth: /health + cały pre-auth flow OAuth (wyprowadzony z bramy =
+# single source, obejmuje /oauth/google/callback dodany w s1286).
+_AUTH_EXEMPT_PATHS = {"/health"} | OPEN_PATHS
 
 
 class BearerAuthMiddleware(BaseHTTPMiddleware):

--- a/src/obsidian_vault_mcp/auth.py
+++ b/src/obsidian_vault_mcp/auth.py
@@ -1,5 +1,6 @@
 """Bearer token authentication middleware for the vault MCP server."""
 
+import os
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import JSONResponse
@@ -10,10 +11,24 @@ from .config import VAULT_MCP_TOKEN
 _AUTH_EXEMPT_PATHS = {
     "/health",
     "/.well-known/oauth-authorization-server",
+    "/.well-known/oauth-protected-resource",
+    "/.well-known/oauth-protected-resource/mcp",
     "/oauth/authorize",
     "/oauth/token",
     "/oauth/register",
+    "/.well-known/openid-configuration",
 }
+
+
+def _www_authenticate_header(request: Request) -> dict[str, str]:
+    """Per MCP spec 2025-03-26: 401 MUST include WWW-Authenticate pointing to PRM."""
+    base = os.environ.get("PUBLIC_BASE_URL", str(request.base_url).rstrip("/")).rstrip("/")
+    return {
+        "WWW-Authenticate": (
+            f'Bearer realm="vault-mcp", '
+            f'resource_metadata="{base}/.well-known/oauth-protected-resource"'
+        )
+    }
 
 
 class BearerAuthMiddleware(BaseHTTPMiddleware):
@@ -34,6 +49,7 @@ class BearerAuthMiddleware(BaseHTTPMiddleware):
             return JSONResponse(
                 {"error": "Missing or malformed Authorization header"},
                 status_code=401,
+                headers=_www_authenticate_header(request),
             )
 
         token = auth_header[7:]
@@ -41,6 +57,7 @@ class BearerAuthMiddleware(BaseHTTPMiddleware):
             return JSONResponse(
                 {"error": "Invalid token"},
                 status_code=401,
+                headers=_www_authenticate_header(request),
             )
 
         return await call_next(request)

--- a/src/obsidian_vault_mcp/config.py
+++ b/src/obsidian_vault_mcp/config.py
@@ -5,18 +5,36 @@ from pathlib import Path
 VAULT_PATH = Path(os.environ.get("VAULT_PATH", os.path.expanduser("~/Obsidian/MyVault")))
 VAULT_MCP_TOKEN = os.environ.get("VAULT_MCP_TOKEN", "")
 VAULT_MCP_PORT = int(os.environ.get("VAULT_MCP_PORT", "8420"))
+# Bind loopback domyślnie (audyt s1099, secure-coding §5) — dostęp przez Funnel/Caddy.
+VAULT_MCP_HOST = os.environ.get("VAULT_MCP_HOST", "127.0.0.1")
+# Zaufany publiczny URL bazowy dla metadanych OAuth (audyt s1099, N69) — zamiast
+# nagłówka Host żądania (anti-spoofing). Pusty → fallback do request.base_url (dev).
+VAULT_MCP_BASE_URL = os.environ.get("VAULT_MCP_BASE_URL", "").rstrip("/")
 
-# OAuth 2.0 client credentials (for Claude app integration)
-VAULT_OAUTH_CLIENT_ID = os.environ.get("VAULT_OAUTH_CLIENT_ID", "vault-mcp-client")
-VAULT_OAUTH_CLIENT_SECRET = os.environ.get("VAULT_OAUTH_CLIENT_SECRET", "")
+# Dozwolone nagłówki Host (ochrona DNS-rebinding biblioteki MCP, audyt s1099). Allowlista:
+# loopback + nazwy hostów reverse-proxy które realnie kierują ruch na tę usługę. Caddy
+# zachowuje oryginalny Host (vault.grzegorzgolas.com), Funnel przekazuje nazwę tailnet —
+# OBA muszą tu być, inaczej żądania dostają HTTP 421. Konfigurowalne env (przecinki);
+# dopisanie własnej domeny NIE osłabia ochrony (to wciąż allowlista, nie wildcard).
+VAULT_MCP_ALLOWED_HOSTS = [
+    h.strip()
+    for h in os.environ.get(
+        "VAULT_MCP_ALLOWED_HOSTS",
+        "127.0.0.1:*,localhost:*,[::1]:*,vps-2557.tail301a28.ts.net,vault.grzegorzgolas.com",
+    ).split(",")
+    if h.strip()
+]
+
+# (usunięto VAULT_OAUTH_CLIENT_ID/SECRET — martwe, audyt s1099 N71: /oauth/register to
+#  public client PKCE, client_credentials wyłączone, sekret nigdy nie był używany.)
 
 # Safety limits
 MAX_CONTENT_SIZE = 1_000_000  # 1MB max write size
-MAX_BATCH_SIZE = 20           # Max files per batch operation
-MAX_SEARCH_RESULTS = 50       # Max results per search
+MAX_BATCH_SIZE = 20  # Max files per batch operation
+MAX_SEARCH_RESULTS = 50  # Max results per search
 DEFAULT_SEARCH_RESULTS = 20
-MAX_LIST_DEPTH = 5            # Max directory recursion depth
-CONTEXT_LINES = 2             # Default lines of context in search results
+MAX_LIST_DEPTH = 5  # Max directory recursion depth
+CONTEXT_LINES = 2  # Default lines of context in search results
 
 # Directories to never expose or modify
 EXCLUDED_DIRS = {".obsidian", ".trash", ".git", ".DS_Store"}
@@ -24,6 +42,7 @@ EXCLUDED_DIRS = {".obsidian", ".trash", ".git", ".DS_Store"}
 # Frontmatter index refresh interval (seconds)
 FRONTMATTER_INDEX_DEBOUNCE = 5.0
 
-# Rate limiting (requests per minute) -- track in-memory, enforce per-token
-RATE_LIMIT_READ = 100
-RATE_LIMIT_WRITE = 30
+# Rate limiting publicznych endpointów OAuth (audyt s1099, S77/S81) — per-IP w oknie
+# czasu, in-memory. Per-token limit nieosiągalny (jeden statyczny token), więc
+# ograniczamy najbardziej narażoną powierzchnię: publiczne wejścia OAuth na Funnelu.
+RATE_LIMIT_OAUTH_PER_MIN = int(os.environ.get("VAULT_MCP_OAUTH_RATELIMIT", "20"))

--- a/src/obsidian_vault_mcp/config.py
+++ b/src/obsidian_vault_mcp/config.py
@@ -28,6 +28,23 @@ VAULT_MCP_ALLOWED_HOSTS = [
 # (usunięto VAULT_OAUTH_CLIENT_ID/SECRET — martwe, audyt s1099 N71: /oauth/register to
 #  public client PKCE, client_credentials wyłączone, sekret nigdy nie był używany.)
 
+# ── Brama tożsamości Google (s1286, domknięcie K1) ────────────────────────────
+# /oauth/authorize deleguje uwierzytelnienie do logowania Google; kod MCP wydawany
+# tylko gdy zweryfikowany e-mail ∈ VAULT_MCP_ALLOWED_EMAILS. FAIL-CLOSED bez tej
+# konfiguracji (authorize → 503, NIGDY auto-approve). Wspólny mechanizm dla
+# wszystkich MCP — kanon GOLDEN-PATTERNS Wzorzec 9. Sekret klienta = macOS Keychain
+# → EnvironmentFile na VPS (Hard Rule #14). Jeden klient OAuth, adres powrotny per
+# usługa: VAULT_MCP_GOOGLE_OAUTH_REDIRECT_URI = .../oauth/google/callback.
+VAULT_MCP_GOOGLE_OAUTH_CLIENT_ID = os.environ.get("VAULT_MCP_GOOGLE_OAUTH_CLIENT_ID", "")
+VAULT_MCP_GOOGLE_OAUTH_SECRET = os.environ.get("VAULT_MCP_GOOGLE_OAUTH_SECRET", "")
+VAULT_MCP_GOOGLE_OAUTH_REDIRECT_URI = os.environ.get("VAULT_MCP_GOOGLE_OAUTH_REDIRECT_URI", "")
+VAULT_MCP_ALLOWED_EMAILS = [
+    e.strip().lower() for e in os.environ.get("VAULT_MCP_ALLOWED_EMAILS", "").split(",") if e.strip()
+]
+# Tylko dev: auto-approve bez bramy (NIGDY produkcja). Self-audit s1286 złapał fail-open
+# jako blocker — domyślnie wyłączone, brama fail-closed.
+VAULT_MCP_OAUTH_DEV_INSECURE = os.environ.get("VAULT_MCP_OAUTH_DEV_INSECURE", "") == "1"
+
 # Safety limits
 MAX_CONTENT_SIZE = 1_000_000  # 1MB max write size
 MAX_BATCH_SIZE = 20  # Max files per batch operation

--- a/src/obsidian_vault_mcp/frontmatter_index.py
+++ b/src/obsidian_vault_mcp/frontmatter_index.py
@@ -39,9 +39,7 @@ class FrontmatterIndex:
                 count += 1
 
         elapsed = time.monotonic() - t0
-        logger.info(
-            "Frontmatter index built: %d files in %.2f seconds", count, elapsed
-        )
+        logger.info("Frontmatter index built: %d files in %.2f seconds", count, elapsed)
 
         self._observer = Observer()
         handler = _VaultEventHandler(self)
@@ -118,9 +116,7 @@ class FrontmatterIndex:
             self._pending_paths.add(abs_path)
             if self._debounce_timer is not None:
                 self._debounce_timer.cancel()
-            self._debounce_timer = threading.Timer(
-                config.FRONTMATTER_INDEX_DEBOUNCE, self._flush_pending
-            )
+            self._debounce_timer = threading.Timer(config.FRONTMATTER_INDEX_DEBOUNCE, self._flush_pending)
             self._debounce_timer.start()
 
     def _flush_pending(self) -> None:

--- a/src/obsidian_vault_mcp/git_ops.py
+++ b/src/obsidian_vault_mcp/git_ops.py
@@ -15,12 +15,13 @@ responses are never blocked by a commit failure. Worst case: a write succeeds
 but commit fails → untracked file → manual cleanup needed (same as before the
 patch, but now we at least log it).
 """
+
 from __future__ import annotations
 
 import logging
 import subprocess
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Iterable
 
 from . import config
 
@@ -67,24 +68,18 @@ def commit_vault_change(
     vault_path = Path(config.VAULT_PATH).resolve()
     path_list = [p for p in paths if p]
     if not path_list:
-        logger.warning(
-            f"commit_vault_change called with no paths (operation={operation})"
-        )
+        logger.warning(f"commit_vault_change called with no paths (operation={operation})")
         return True
 
     # git add --all handles new files, modifications, and deletions uniformly
-    add_code, _, add_err = _run_git(
-        ["add", "--all", "--"] + path_list, vault_path
-    )
+    add_code, _, add_err = _run_git(["add", "--all", "--"] + path_list, vault_path)
     if add_code != 0:
         logger.error(f"git add failed for {path_list}: {add_err}")
         return False
 
     # Check if there's anything to commit
     # exit 0 = no staged changes, exit 1 = has staged changes, other = error
-    diff_code, _, _ = _run_git(
-        ["diff", "--cached", "--quiet"], vault_path
-    )
+    diff_code, _, _ = _run_git(["diff", "--cached", "--quiet"], vault_path)
     if diff_code == 0:
         logger.debug(f"no changes to commit for {path_list} ({operation})")
         return True
@@ -99,9 +94,7 @@ def commit_vault_change(
     if extra_msg:
         message += f"\n\n{extra_msg}"
 
-    commit_code, commit_out, commit_err = _run_git(
-        ["commit", "-m", message], vault_path
-    )
+    commit_code, commit_out, commit_err = _run_git(["commit", "-m", message], vault_path)
     if commit_code != 0:
         # Defensive: catch "nothing to commit" even though check above covers it
         combined = (commit_err + commit_out).lower()

--- a/src/obsidian_vault_mcp/git_ops.py
+++ b/src/obsidian_vault_mcp/git_ops.py
@@ -1,0 +1,114 @@
+"""Git operations for MCP vault writes — auto-commit to keep tracking consistent.
+
+Context (PDCA-014): MCP vault_write/move/delete previously left files in the
+working tree without git tracking. vault-sync-vps.timer then aborted on
+"untracked files would be overwritten" during pull from GitHub, diverging VPS
+state from Mac for hours.
+
+Mac-side hook (~/.claude/hooks/block_mcp_vault_write_from_desktop.py) blocks
+MCP writes from Claude Code CLI. But Chat / iPhone / Claude Desktop GUI reach
+the MCP server directly and can't be blocked client-side — so the VPS must
+auto-commit to keep tracking in sync regardless of caller.
+
+This module is fail-open: any git error is logged but never raises; MCP tool
+responses are never blocked by a commit failure. Worst case: a write succeeds
+but commit fails → untracked file → manual cleanup needed (same as before the
+patch, but now we at least log it).
+"""
+from __future__ import annotations
+
+import logging
+import subprocess
+from pathlib import Path
+from typing import Iterable
+
+from . import config
+
+logger = logging.getLogger(__name__)
+
+GIT_TIMEOUT = 10  # seconds per git command
+
+
+def _run_git(args: list[str], cwd: Path) -> tuple[int, str, str]:
+    """Run git command, return (returncode, stdout, stderr). Never raises."""
+    try:
+        result = subprocess.run(
+            ["git"] + args,
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            timeout=GIT_TIMEOUT,
+        )
+        return result.returncode, result.stdout.strip(), result.stderr.strip()
+    except subprocess.TimeoutExpired:
+        logger.error(f"git {args[0]} timed out after {GIT_TIMEOUT}s")
+        return -1, "", "timeout"
+    except Exception as e:
+        logger.error(f"git {args[0]} failed: {e}")
+        return -1, "", str(e)
+
+
+def commit_vault_change(
+    paths: Iterable[str],
+    operation: str,
+    extra_msg: str | None = None,
+) -> bool:
+    """Stage paths and create a commit. Fail-open (logs errors, never raises).
+
+    Args:
+        paths: relative vault paths (as passed to vault_write etc.)
+        operation: short label ("write", "move", "delete", "batch_frontmatter")
+        extra_msg: optional extra context for commit message body
+
+    Returns:
+        True if commit created, or if nothing to commit (both are OK).
+        False on git error (state may be inconsistent — see logs).
+    """
+    vault_path = Path(config.VAULT_PATH).resolve()
+    path_list = [p for p in paths if p]
+    if not path_list:
+        logger.warning(
+            f"commit_vault_change called with no paths (operation={operation})"
+        )
+        return True
+
+    # git add --all handles new files, modifications, and deletions uniformly
+    add_code, _, add_err = _run_git(
+        ["add", "--all", "--"] + path_list, vault_path
+    )
+    if add_code != 0:
+        logger.error(f"git add failed for {path_list}: {add_err}")
+        return False
+
+    # Check if there's anything to commit
+    # exit 0 = no staged changes, exit 1 = has staged changes, other = error
+    diff_code, _, _ = _run_git(
+        ["diff", "--cached", "--quiet"], vault_path
+    )
+    if diff_code == 0:
+        logger.debug(f"no changes to commit for {path_list} ({operation})")
+        return True
+    elif diff_code != 1:
+        logger.warning(f"git diff --cached unexpected exit {diff_code}")
+
+    # Build commit message
+    file_summary = ", ".join(path_list[:3])
+    if len(path_list) > 3:
+        file_summary += f" (+{len(path_list) - 3} more)"
+    message = f"mcp: {operation}: {file_summary}"
+    if extra_msg:
+        message += f"\n\n{extra_msg}"
+
+    commit_code, commit_out, commit_err = _run_git(
+        ["commit", "-m", message], vault_path
+    )
+    if commit_code != 0:
+        # Defensive: catch "nothing to commit" even though check above covers it
+        combined = (commit_err + commit_out).lower()
+        if "nothing to commit" in combined:
+            return True
+        logger.error(f"git commit failed ({operation}): {commit_err or commit_out}")
+        return False
+
+    logger.info(f"MCP auto-commit: {operation} {file_summary}")
+    return True

--- a/src/obsidian_vault_mcp/mcp_oauth.py
+++ b/src/obsidian_vault_mcp/mcp_oauth.py
@@ -1,0 +1,461 @@
+# ⚠️ WENDOROWANE z workos_shared/mcp_oauth.py (jedno źródło logiki) — NIE edytuj tutaj.
+# vault-mcp jest forkiem samodzielnym (obsidian-web-mcp, nie importuje workos_shared),
+# więc trzyma wierną kopię. Przy zmianie bramy: edytuj workos_shared, potem zsynchronizuj
+# (cp). Kanon: GOLDEN-PATTERNS Wzorzec 9. Wierność (AST) sprawdzana w tests/test_oauth_gate.
+"""Reużywalny OAuth 2.0 (authorization code + PKCE) z bramą tożsamości Google dla
+connectorów MCP (claude.ai). JEDEN mechanizm logowania dla wszystkich serwerów MCP.
+
+Owner-only: tylko e-maile z `allowed_emails` przechodzą logowanie Google → dostają
+master-token usługi. FAIL-CLOSED bez konfiguracji bramy (odmowa, nie auto-approve).
+
+Kanon: GOLDEN-PATTERNS Wzorzec 9. Decision Memory `2026-06-15 — Brama tożsamości Google
+dla MCP`. Wzór sprawdzony end-to-end: jarvis_rag (s1286).
+
+Dlaczego nie alternatywy (z incydentu s1286):
+- auto-approve = każdy znający URL wyciąga master-token (czyta kod z własnego 302;
+  redirect-allowlist+PKCE NIE chronią przed self-driven exfiltracją).
+- formularz hasła operatora = claude.ai NIE domyka interaktywnego pośrednika.
+- statyczny Bearer w nagłówku = działa w Claude Code, ale web/desktop wymusza OAuth.
+
+Użycie:
+    gate = McpOAuthGate(
+        service_name="jarvis-rag",
+        master_token=RAG_TOKEN,
+        public_base="https://vps-2557.tail301a28.ts.net/rag",  # issuer / metadata base
+        resource_path="/mcp",
+        google_client_id=..., google_client_secret=..., google_redirect_uri=...,
+        allowed_emails={"gg@example.com"},
+        dev_insecure=False,
+    )
+    # mount gate.routes do aplikacji Starlette; dodaj gate.open_paths do wyjątku bearer-auth
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import logging
+import secrets
+import time
+from collections.abc import Iterable
+from urllib.parse import parse_qsl, urlencode
+
+import httpx
+from google.auth.transport import requests as google_requests
+from google.oauth2 import id_token as google_id_token
+from starlette.requests import Request
+from starlette.responses import JSONResponse, RedirectResponse
+from starlette.routing import Route
+
+_GOOGLE_AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth"
+_GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token"  # noqa: S105 (URL, nie sekret)
+
+_AUTHORIZE_FIELDS = (
+    "response_type",
+    "client_id",
+    "redirect_uri",
+    "state",
+    "code_challenge",
+    "code_challenge_method",
+)
+
+_CODE_TTL_S = 300
+_PENDING_TTL_S = 600
+_MAX_PENDING_LOGINS = 256  # twardy cap (anti-DoS) — publiczny /oauth/authorize
+
+
+async def _read_urlencoded(request: Request) -> dict[str, str]:
+    """Parsuj application/x-www-form-urlencoded BEZ python-multipart.
+
+    Endpointy OAuth (token, authorize POST) używają wyłącznie urlencoded (RFC 6749).
+    `request.form()` Starlette wymaga python-multipart — niepotrzebna zależność dla
+    reużywalnej biblioteki. Parsujemy surowe ciało (last-wins, jak form.get)."""
+    body = await request.body()
+    return dict(parse_qsl(body.decode("utf-8")))
+
+
+class McpOAuthGate:
+    """OAuth authorization-code + PKCE z bramą tożsamości Google dla jednego serwera MCP.
+
+    Każda instancja trzyma własny config + stan (kody, pending-loginy). Dostarcza trasy
+    Starlette (`routes`) i ścieżki zwolnione z bearer-auth (`open_paths`).
+    """
+
+    def __init__(
+        self,
+        *,
+        service_name: str,
+        master_token: str,
+        public_base: str,
+        resource_path: str = "/mcp",
+        redirect_allowlist: Iterable[str] = ("https://claude.ai/api/mcp/auth_callback",),
+        google_client_id: str = "",
+        google_client_secret: str = "",
+        google_redirect_uri: str = "",
+        allowed_emails: Iterable[str] = (),
+        dev_insecure: bool = False,
+    ):
+        self.service_name = service_name
+        self._master_token = master_token
+        self.public_base = public_base.rstrip("/")
+        self.resource_path = resource_path
+        self.redirect_allowlist = frozenset(u.strip() for u in redirect_allowlist if u.strip())
+        self.google_client_id = google_client_id
+        self._google_client_secret = google_client_secret
+        self.google_redirect_uri = google_redirect_uri
+        self.allowed_emails = frozenset(e.strip().lower() for e in allowed_emails if e.strip())
+        self.dev_insecure = dev_insecure
+        self.log = logging.getLogger(f"{service_name}.mcp_oauth")
+
+        self._auth_codes: dict[str, dict] = {}
+        self._pending_logins: dict[str, dict] = {}
+
+    # ── publiczne wejścia ────────────────────────────────────────────────────
+
+    @property
+    def identity_gate_enabled(self) -> bool:
+        """Brama aktywna tylko gdy W PEŁNI skonfigurowana (4 elementy)."""
+        return bool(
+            self.google_client_id and self._google_client_secret and self.google_redirect_uri and self.allowed_emails
+        )
+
+    @property
+    def open_paths(self) -> set[str]:
+        """Ścieżki zwolnione z bearer-auth (pre-auth dla flow OAuth + odkrywania)."""
+        return {
+            "/.well-known/oauth-authorization-server",
+            "/.well-known/oauth-protected-resource",
+            f"/.well-known/oauth-protected-resource{self.resource_path}",
+            "/oauth/authorize",
+            "/oauth/google/callback",
+            "/oauth/token",
+            "/oauth/register",
+        }
+
+    @property
+    def routes(self) -> list[Route]:
+        return [
+            Route(
+                "/.well-known/oauth-authorization-server",
+                self.metadata,
+                methods=["GET"],
+            ),
+            Route(
+                "/.well-known/oauth-protected-resource",
+                self.protected_resource,
+                methods=["GET"],
+            ),
+            Route(
+                f"/.well-known/oauth-protected-resource{self.resource_path}",
+                self.protected_resource,
+                methods=["GET"],
+            ),
+            Route("/oauth/authorize", self.authorize, methods=["GET", "POST"]),
+            Route("/oauth/google/callback", self.google_callback, methods=["GET"]),
+            Route("/oauth/token", self.token, methods=["POST"]),
+            Route("/oauth/register", self.register, methods=["POST"]),
+        ]
+
+    # ── helpery ──────────────────────────────────────────────────────────────
+
+    def _base(self, request: Request) -> str:
+        """Zaufany publiczny URL bazowy (anti Host-spoofing); fallback do request (dev)."""
+        return self.public_base or str(request.base_url).rstrip("/")
+
+    def _cleanup_codes(self) -> None:
+        now = time.time()
+        for k in [k for k, v in self._auth_codes.items() if v["expires_at"] < now]:
+            del self._auth_codes[k]
+
+    def _cleanup_pending(self) -> None:
+        now = time.time()
+        for k in [k for k, v in self._pending_logins.items() if v["expires_at"] < now]:
+            del self._pending_logins[k]
+        if len(self._pending_logins) > _MAX_PENDING_LOGINS:
+            excess = len(self._pending_logins) - _MAX_PENDING_LOGINS
+            for k, _ in sorted(self._pending_logins.items(), key=lambda kv: kv[1]["expires_at"])[:excess]:
+                del self._pending_logins[k]
+
+    def _validate_authorize(self, params: dict) -> JSONResponse | None:
+        if params.get("response_type") != "code":
+            return JSONResponse({"error": "unsupported_response_type"}, status_code=400)
+        redirect_uri = params.get("redirect_uri", "")
+        if not redirect_uri:
+            return JSONResponse(
+                {
+                    "error": "invalid_request",
+                    "error_description": "redirect_uri required",
+                },
+                status_code=400,
+            )
+        if redirect_uri not in self.redirect_allowlist:
+            self.log.warning("authorize odrzucony: redirect_uri spoza allowlisty")
+            return JSONResponse(
+                {
+                    "error": "invalid_request",
+                    "error_description": "redirect_uri not allowed",
+                },
+                status_code=400,
+            )
+        if not params.get("code_challenge"):
+            return JSONResponse(
+                {
+                    "error": "invalid_request",
+                    "error_description": "code_challenge required (PKCE)",
+                },
+                status_code=400,
+            )
+        if params.get("code_challenge_method", "S256") != "S256":
+            return JSONResponse(
+                {
+                    "error": "invalid_request",
+                    "error_description": "code_challenge_method must be S256",
+                },
+                status_code=400,
+            )
+        return None
+
+    def _issue_code_and_redirect(self, params: dict):
+        # Re-check allowlisty tuż przed wydaniem (anti open-redirect regres).
+        if params.get("redirect_uri") not in self.redirect_allowlist:
+            self.log.warning("issue_code odmówił: redirect_uri spoza allowlisty")
+            return JSONResponse(
+                {
+                    "error": "invalid_request",
+                    "error_description": "redirect_uri not allowed",
+                },
+                status_code=400,
+            )
+        self._cleanup_codes()
+        code = secrets.token_urlsafe(32)
+        self._auth_codes[code] = {
+            "client_id": params.get("client_id", ""),
+            "redirect_uri": params["redirect_uri"],
+            "code_challenge": params["code_challenge"],
+            "code_challenge_method": params.get("code_challenge_method", "S256"),
+            "expires_at": time.time() + _CODE_TTL_S,
+        }
+        self.log.info("kod autoryzacji wydany, redirect → %s...", params["redirect_uri"][:50])
+        query = {"code": code}
+        if params.get("state"):
+            query["state"] = params["state"]
+        redirect_uri = params["redirect_uri"]
+        sep = "&" if "?" in redirect_uri else "?"
+        return RedirectResponse(url=f"{redirect_uri}{sep}{urlencode(query)}", status_code=302)
+
+    async def _verify_google_identity(self, code: str) -> str | None:
+        """Wymień kod Google na zweryfikowany e-mail (None gdy niepowodzenie). Fail-closed."""
+        try:
+            async with httpx.AsyncClient(timeout=10) as client:
+                resp = await client.post(
+                    _GOOGLE_TOKEN_URL,
+                    data={
+                        "code": code,
+                        "client_id": self.google_client_id,
+                        "client_secret": self._google_client_secret,
+                        "redirect_uri": self.google_redirect_uri,
+                        "grant_type": "authorization_code",
+                    },
+                )
+        except httpx.HTTPError as exc:
+            self.log.warning("Google token exchange transport error: %s", type(exc).__name__)
+            return None
+        if resp.status_code != 200:
+            self.log.warning("Google token exchange rejected: HTTP %s", resp.status_code)
+            return None
+        id_tok = resp.json().get("id_token", "")
+        if not id_tok:
+            return None
+        try:
+            claims = google_id_token.verify_oauth2_token(id_tok, google_requests.Request(), self.google_client_id)
+        except Exception as exc:  # noqa: BLE001 — weryfikacja podpisu MUSI fail-closed na każdy błąd
+            self.log.warning("Google id_token verification failed: %s", type(exc).__name__)
+            return None
+        if not claims.get("email_verified"):
+            return None
+        return claims.get("email")
+
+    # ── trasy ────────────────────────────────────────────────────────────────
+
+    async def metadata(self, request: Request) -> JSONResponse:
+        """RFC 8414 OAuth authorization server metadata."""
+        base = self._base(request)
+        return JSONResponse(
+            {
+                "issuer": base,
+                "authorization_endpoint": f"{base}/oauth/authorize",
+                "token_endpoint": f"{base}/oauth/token",
+                "registration_endpoint": f"{base}/oauth/register",
+                "grant_types_supported": ["authorization_code"],
+                "response_types_supported": ["code"],
+                "code_challenge_methods_supported": ["S256"],
+                "token_endpoint_auth_methods_supported": ["none"],
+            }
+        )
+
+    async def protected_resource(self, request: Request) -> JSONResponse:
+        """RFC 9728 — obsługuje wariant goły I z sufiksem zasobu (claude.ai pyta o ten drugi)."""
+        base = self._base(request)
+        resource = f"{base}{self.resource_path}" if request.url.path.endswith(self.resource_path) else base
+        return JSONResponse({"resource": resource, "authorization_servers": [base]})
+
+    async def authorize(self, request: Request):
+        """Brama tożsamości: waliduj → przekieruj do Google (lub fail-closed/dev)."""
+        if request.method == "POST":
+            form = await _read_urlencoded(request)
+            params = {f: form.get(f, "") for f in _AUTHORIZE_FIELDS}
+        else:
+            params = {f: request.query_params.get(f, "") for f in _AUTHORIZE_FIELDS}
+        if not params.get("code_challenge_method"):
+            params["code_challenge_method"] = "S256"
+        err = self._validate_authorize(params)
+        if err:
+            return err
+
+        if not self.identity_gate_enabled:
+            if self.dev_insecure:
+                self.log.warning("DEV_INSECURE — auto-approve (TYLKO dev, nigdy produkcja)")
+                return self._issue_code_and_redirect(params)
+            self.log.error("Brama tożsamości nieskonfigurowana — authorize ODMÓWIONY (fail-closed)")
+            return JSONResponse(
+                {
+                    "error": "server_error",
+                    "error_description": "OAuth identity gate not configured",
+                },
+                status_code=503,
+            )
+
+        self._cleanup_pending()
+        login_state = secrets.token_urlsafe(32)
+        self._pending_logins[login_state] = {
+            **params,
+            "expires_at": time.time() + _PENDING_TTL_S,
+        }
+        google_url = (
+            _GOOGLE_AUTH_URL
+            + "?"
+            + urlencode(
+                {
+                    "client_id": self.google_client_id,
+                    "redirect_uri": self.google_redirect_uri,
+                    "response_type": "code",
+                    "scope": "openid email",
+                    "state": login_state,
+                    "access_type": "online",
+                    "prompt": "select_account",
+                }
+            )
+        )
+        return RedirectResponse(google_url, status_code=302)
+
+    async def google_callback(self, request: Request):
+        """Powrót z Google: weryfikuj tożsamość, sprawdź allowlistę, wznów OAuth."""
+        login_state = request.query_params.get("state", "")
+        code = request.query_params.get("code", "")
+        self._cleanup_pending()
+        pending = self._pending_logins.pop(login_state, None)
+        if not pending or not code:
+            return JSONResponse(
+                {
+                    "error": "invalid_request",
+                    "error_description": "Nieznany lub wygasły stan logowania.",
+                },
+                status_code=400,
+            )
+        email = await self._verify_google_identity(code)
+        if not email or email.lower() not in self.allowed_emails:
+            self.log.warning("Brama tożsamości: ODMOWA dla %r", email or "nieznany")
+            return JSONResponse(
+                {
+                    "error": "access_denied",
+                    "error_description": "To konto Google nie ma dostępu do tego serwera.",
+                },
+                status_code=403,
+            )
+        self.log.info("Brama tożsamości: WPUSZCZONO %s", email)
+        return self._issue_code_and_redirect({f: pending.get(f, "") for f in _AUTHORIZE_FIELDS})
+
+    async def token(self, request: Request) -> JSONResponse:
+        """OAuth token endpoint — authorization_code + PKCE (zwraca master-token usługi)."""
+        try:
+            form = await _read_urlencoded(request)
+        except Exception:  # noqa: BLE001
+            return JSONResponse({"error": "invalid_request"}, status_code=400)
+        if form.get("grant_type", "") != "authorization_code":
+            return JSONResponse({"error": "unsupported_grant_type"}, status_code=400)
+
+        code = form.get("code", "")
+        redirect_uri = form.get("redirect_uri", "")
+        code_verifier = form.get("code_verifier", "")
+        self._cleanup_codes()
+        if code not in self._auth_codes:
+            return JSONResponse(
+                {
+                    "error": "invalid_grant",
+                    "error_description": "Invalid or expired code",
+                },
+                status_code=400,
+            )
+        data = self._auth_codes.pop(code)
+        if redirect_uri != data.get("redirect_uri", ""):
+            return JSONResponse(
+                {
+                    "error": "invalid_grant",
+                    "error_description": "redirect_uri mismatch",
+                },
+                status_code=400,
+            )
+        stored_challenge = data.get("code_challenge", "")
+        if not stored_challenge:
+            return JSONResponse(
+                {
+                    "error": "invalid_grant",
+                    "error_description": "missing PKCE challenge",
+                },
+                status_code=400,
+            )
+        if not code_verifier:
+            return JSONResponse(
+                {
+                    "error": "invalid_grant",
+                    "error_description": "code_verifier required",
+                },
+                status_code=400,
+            )
+        digest = hashlib.sha256(code_verifier.encode("ascii")).digest()
+        computed = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+        if not secrets.compare_digest(computed, stored_challenge):
+            return JSONResponse(
+                {
+                    "error": "invalid_grant",
+                    "error_description": "PKCE verification failed",
+                },
+                status_code=400,
+            )
+        self.log.info("token wydany via authorization_code grant")
+        return JSONResponse(
+            {
+                "access_token": self._master_token,
+                "token_type": "bearer",
+                "expires_in": 86400,
+            }
+        )
+
+    async def register(self, request: Request) -> JSONResponse:
+        """Dynamic client registration — public client (PKCE), bez współdzielonego sekretu."""
+        try:
+            body = await request.json()
+        except Exception:  # noqa: BLE001
+            body = {}
+        client_id = f"{self.service_name}-{secrets.token_hex(8)}"
+        return JSONResponse(
+            {
+                "client_id": client_id,
+                "client_name": body.get("client_name", self.service_name),
+                "redirect_uris": body.get("redirect_uris", list(self.redirect_allowlist)),
+                "token_endpoint_auth_method": "none",
+                "grant_types": ["authorization_code"],
+                "response_types": ["code"],
+            },
+            status_code=201,
+        )

--- a/src/obsidian_vault_mcp/oauth.py
+++ b/src/obsidian_vault_mcp/oauth.py
@@ -2,38 +2,58 @@
 
 Claude's MCP connector uses the full OAuth authorization code flow:
 1. Discovers metadata at /.well-known/oauth-authorization-server
-2. Dynamically registers at /oauth/register (or uses pre-configured credentials)
+2. Dynamically registers at /oauth/register
 3. Redirects user's browser to /oauth/authorize
 4. Server auto-approves (single-user) and redirects back with an auth code
 5. Claude exchanges the code at /oauth/token for a bearer token
 6. Claude uses the bearer token on all MCP requests
 
-Since this is a single-user personal server, the authorization page auto-approves
-immediately -- no login screen, no consent page. The security boundary is the
-client credentials + PKCE + the bearer token on every MCP request.
+Single-user personal server: the authorization page auto-approves immediately.
+
+Security hardening (audyt s693, KRYT — same class as jarvis_rag KRYT-1; this module
+is the original the RAG OAuth was adapted from):
+  1. redirect_uri allowlist — codes only go to a registered callback.
+  2. PKCE mandatory — no downgrade; authorize requires S256 challenge, token always verifies.
+  3. client_credentials grant removed — it minted the master token for any holder of the
+     shared client secret.
+  4. /oauth/register is a public client (PKCE), no shared secret handed out.
+The static Bearer (config.VAULT_MCP_TOKEN) still gates every MCP request (unchanged).
 """
 
+import base64
 import hashlib
 import hmac
 import logging
-import secrets
 import os
+import secrets
 import time
-from urllib.parse import urlencode, urlparse, parse_qs
+from urllib.parse import urlencode
 
 from starlette.requests import Request
-from starlette.responses import JSONResponse, RedirectResponse, HTMLResponse
+from starlette.responses import JSONResponse, RedirectResponse
 from starlette.routing import Route
 
 from . import config
 
 logger = logging.getLogger(__name__)
 
+# Allowlist of permitted OAuth redirect URIs (exact match). Without this, anyone can
+# drive /oauth/authorize and have the auth code delivered to an attacker host (KRYT,
+# audyt s693). Configurable via env (comma-separated); defaults to the claude.ai MCP
+# connector callback.
+REDIRECT_ALLOWLIST = frozenset(
+    u.strip()
+    for u in os.environ.get(
+        "VAULT_OAUTH_REDIRECT_ALLOWLIST",
+        "https://claude.ai/api/mcp/auth_callback",
+    ).split(",")
+    if u.strip()
+)
+
 # In-memory store for authorization codes (short-lived)
-# Maps code -> {client_id, redirect_uri, code_challenge, code_challenge_method, expires_at}
 _auth_codes: dict[str, dict] = {}
 
-# Clean up expired codes periodically
+
 def _cleanup_codes():
     now = time.time()
     expired = [k for k, v in _auth_codes.items() if v["expires_at"] < now]
@@ -41,28 +61,64 @@ def _cleanup_codes():
         del _auth_codes[k]
 
 
+def _public_base(request: Request) -> str:
+    """Zaufany publiczny URL bazowy. Z env VAULT_MCP_BASE_URL (anti-Host-spoofing, N69);
+    fallback do request.base_url gdy nieustawiony (środowisko dev)."""
+    if config.VAULT_MCP_BASE_URL:
+        return config.VAULT_MCP_BASE_URL
+    return str(request.base_url).rstrip("/")
+
+
+# Rate-limit publicznych endpointów OAuth (audyt s1099, S77/S81) — per-IP, in-memory.
+_OAUTH_WINDOW_S = 60
+_oauth_hits: dict[str, list[float]] = {}
+
+
+def _client_ip(request: Request) -> str:
+    """Realny adres za Funnel/Caddy z X-Forwarded-For (port bindowany na loopback)."""
+    fwd = request.headers.get("x-forwarded-for", "")
+    if fwd:
+        return fwd.split(",")[0].strip()
+    return request.client.host if request.client else "unknown"
+
+
+def _oauth_rate_limited(request: Request) -> bool:
+    """True gdy IP przekroczył limit żądań OAuth w oknie 60 s (S77/S81)."""
+    ip = _client_ip(request)
+    cutoff = time.time() - _OAUTH_WINDOW_S
+    for key in list(_oauth_hits):
+        fresh = [t for t in _oauth_hits[key] if t > cutoff]
+        if fresh:
+            _oauth_hits[key] = fresh
+        else:
+            del _oauth_hits[key]
+    hits = _oauth_hits.setdefault(ip, [])
+    hits.append(time.time())
+    return len(hits) > config.RATE_LIMIT_OAUTH_PER_MIN
+
+
 async def oauth_metadata(request: Request) -> JSONResponse:
     """RFC 8414 OAuth authorization server metadata."""
-    base_url = os.environ.get("PUBLIC_BASE_URL", str(request.base_url).rstrip("/")).rstrip("/")
-    return JSONResponse({
-        "issuer": base_url,
-        "authorization_endpoint": f"{base_url}/oauth/authorize",
-        "token_endpoint": f"{base_url}/oauth/token",
-        "registration_endpoint": f"{base_url}/oauth/register",
-        "grant_types_supported": ["authorization_code"],
-        "response_types_supported": ["code"],
-        "code_challenge_methods_supported": ["S256"],
-        "token_endpoint_auth_methods_supported": ["client_secret_post"],
-    })
+    base_url = _public_base(request)
+    return JSONResponse(
+        {
+            "issuer": base_url,
+            "authorization_endpoint": f"{base_url}/oauth/authorize",
+            "token_endpoint": f"{base_url}/oauth/token",
+            "registration_endpoint": f"{base_url}/oauth/register",
+            "grant_types_supported": ["authorization_code"],
+            "response_types_supported": ["code"],
+            "code_challenge_methods_supported": ["S256"],
+            # Public client + PKCE: no client secret used at the token endpoint.
+            "token_endpoint_auth_methods_supported": ["none"],
+        }
+    )
 
 
 async def oauth_authorize(request: Request):
-    """OAuth 2.0 authorization endpoint.
-
-    Claude redirects the user's browser here. Since this is a single-user
-    personal server, we auto-approve: generate an auth code and redirect
-    back to Claude immediately.
-    """
+    """OAuth 2.0 authorization endpoint (allowlisted redirect + mandatory PKCE)."""
+    if _oauth_rate_limited(request):
+        return JSONResponse({"error": "rate_limited"}, status_code=429)
     response_type = request.query_params.get("response_type", "")
     client_id = request.query_params.get("client_id", "")
     redirect_uri = request.query_params.get("redirect_uri", "")
@@ -74,7 +130,30 @@ async def oauth_authorize(request: Request):
         return JSONResponse({"error": "unsupported_response_type"}, status_code=400)
 
     if not redirect_uri:
-        return JSONResponse({"error": "invalid_request", "error_description": "redirect_uri required"}, status_code=400)
+        return JSONResponse(
+            {"error": "invalid_request", "error_description": "redirect_uri required"},
+            status_code=400,
+        )
+
+    # Allowlist check: refuse to issue a code to an unregistered redirect target.
+    if redirect_uri not in REDIRECT_ALLOWLIST:
+        logger.warning(f"OAuth authorize rejected: redirect_uri not in allowlist ({redirect_uri[:60]!r})")
+        return JSONResponse(
+            {"error": "invalid_request", "error_description": "redirect_uri not allowed"},
+            status_code=400,
+        )
+
+    # PKCE is mandatory (no downgrade): require an S256 challenge up front.
+    if not code_challenge:
+        return JSONResponse(
+            {"error": "invalid_request", "error_description": "code_challenge required (PKCE)"},
+            status_code=400,
+        )
+    if code_challenge_method != "S256":
+        return JSONResponse(
+            {"error": "invalid_request", "error_description": "code_challenge_method must be S256"},
+            status_code=400,
+        )
 
     # Generate authorization code
     _cleanup_codes()
@@ -89,7 +168,6 @@ async def oauth_authorize(request: Request):
 
     logger.info(f"OAuth authorization code issued, redirecting to {redirect_uri[:50]}...")
 
-    # Redirect back to Claude with the code
     params = {"code": code}
     if state:
         params["state"] = state
@@ -102,30 +180,26 @@ async def oauth_authorize(request: Request):
 
 
 async def oauth_token(request: Request) -> JSONResponse:
-    """OAuth 2.0 token endpoint -- authorization code grant with PKCE."""
+    """OAuth 2.0 token endpoint -- authorization_code + PKCE only."""
+    if _oauth_rate_limited(request):
+        return JSONResponse({"error": "rate_limited"}, status_code=429)
     try:
         form = await request.form()
     except Exception:
         return JSONResponse({"error": "invalid_request"}, status_code=400)
 
     grant_type = form.get("grant_type", "")
-    client_id = form.get("client_id", "")
-    client_secret = form.get("client_secret", "")
 
-    # Support both authorization_code and client_credentials grants
+    # Only authorization_code + PKCE is supported. client_credentials was removed
+    # (audyt s693): it minted the master VAULT_MCP_TOKEN for anyone holding the shared
+    # client secret handed out by /oauth/register.
     if grant_type == "authorization_code":
-        return await _handle_authorization_code(form, client_id, client_secret)
-    elif grant_type == "client_credentials":
-        return await _handle_client_credentials(client_id, client_secret)
-    else:
-        return JSONResponse(
-            {"error": "unsupported_grant_type"},
-            status_code=400,
-        )
+        return await _handle_authorization_code(form)
+    return JSONResponse({"error": "unsupported_grant_type"}, status_code=400)
 
 
-async def _handle_authorization_code(form, client_id: str, client_secret: str) -> JSONResponse:
-    """Exchange an authorization code for a bearer token."""
+async def _handle_authorization_code(form) -> JSONResponse:
+    """Exchange an authorization code for a bearer token (PKCE mandatory)."""
     code = form.get("code", "")
     redirect_uri = form.get("redirect_uri", "")
     code_verifier = form.get("code_verifier", "")
@@ -133,89 +207,93 @@ async def _handle_authorization_code(form, client_id: str, client_secret: str) -
     _cleanup_codes()
 
     if code not in _auth_codes:
-        return JSONResponse({"error": "invalid_grant", "error_description": "Invalid or expired code"}, status_code=400)
+        return JSONResponse(
+            {"error": "invalid_grant", "error_description": "Invalid or expired code"},
+            status_code=400,
+        )
 
     code_data = _auth_codes.pop(code)
 
-    # Verify redirect_uri matches
-    if redirect_uri and code_data["redirect_uri"] and redirect_uri != code_data["redirect_uri"]:
-        return JSONResponse({"error": "invalid_grant", "error_description": "redirect_uri mismatch"}, status_code=400)
+    # Bezwarunkowy exact-match (audyt s1099, bliźniak jarvis_rag N32): poprzedni warunek
+    # pomijał porównanie gdy obie strony były puste. Kod zawsze bindowany do redirect_uri
+    # z allowlisty przy wydaniu, więc stored nigdy nie jest pusty.
+    if redirect_uri != code_data.get("redirect_uri", ""):
+        return JSONResponse(
+            {"error": "invalid_grant", "error_description": "redirect_uri mismatch"},
+            status_code=400,
+        )
 
-    # Verify PKCE code_challenge if one was provided during authorization
-    if code_data["code_challenge"]:
-        if not code_verifier:
-            return JSONResponse({"error": "invalid_grant", "error_description": "code_verifier required"}, status_code=400)
+    # PKCE verification is mandatory. Codes are only issued with a stored challenge
+    # (oauth_authorize enforces it). A missing challenge here means a forged/legacy
+    # grant -- reject. Never fall through to issuing a token.
+    stored_challenge = code_data.get("code_challenge", "")
+    if not stored_challenge:
+        return JSONResponse(
+            {"error": "invalid_grant", "error_description": "missing PKCE challenge"},
+            status_code=400,
+        )
+    if not code_verifier:
+        return JSONResponse(
+            {"error": "invalid_grant", "error_description": "code_verifier required"},
+            status_code=400,
+        )
 
-        # S256: BASE64URL(SHA256(code_verifier)) must match code_challenge
-        import base64
-        digest = hashlib.sha256(code_verifier.encode("ascii")).digest()
-        computed_challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+    digest = hashlib.sha256(code_verifier.encode("ascii")).digest()
+    computed_challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
 
-        if not hmac.compare_digest(computed_challenge, code_data["code_challenge"]):
-            return JSONResponse({"error": "invalid_grant", "error_description": "PKCE verification failed"}, status_code=400)
+    if not hmac.compare_digest(computed_challenge, stored_challenge):
+        return JSONResponse(
+            {"error": "invalid_grant", "error_description": "PKCE verification failed"},
+            status_code=400,
+        )
 
     logger.info("OAuth token issued via authorization_code grant")
-    return JSONResponse({
-        "access_token": config.VAULT_MCP_TOKEN,
-        "token_type": "bearer",
-        "expires_in": 86400,
-    })
-
-
-async def _handle_client_credentials(client_id: str, client_secret: str) -> JSONResponse:
-    """Exchange client credentials for a bearer token."""
-    if not config.VAULT_OAUTH_CLIENT_SECRET:
-        return JSONResponse({"error": "server_error"}, status_code=500)
-
-    id_match = hmac.compare_digest(client_id, config.VAULT_OAUTH_CLIENT_ID)
-    secret_match = hmac.compare_digest(client_secret, config.VAULT_OAUTH_CLIENT_SECRET)
-
-    if not (id_match and secret_match):
-        logger.warning(f"OAuth client_credentials failed (client_id={client_id!r})")
-        return JSONResponse({"error": "invalid_client"}, status_code=401)
-
-    logger.info("OAuth token issued via client_credentials grant")
-    return JSONResponse({
-        "access_token": config.VAULT_MCP_TOKEN,
-        "token_type": "bearer",
-        "expires_in": 86400,
-    })
+    return JSONResponse(
+        {
+            "access_token": config.VAULT_MCP_TOKEN,
+            "token_type": "bearer",
+            "expires_in": 86400,
+        }
+    )
 
 
 async def oauth_register(request: Request) -> JSONResponse:
-    """Dynamic client registration endpoint.
-
-    Claude calls this during initial setup to register as an OAuth client.
-    Returns pre-configured credentials.
-    """
+    """Dynamic client registration -- public client (PKCE), no shared secret."""
+    if _oauth_rate_limited(request):
+        return JSONResponse({"error": "rate_limited"}, status_code=429)
     try:
         body = await request.json()
     except Exception:
         body = {}
 
-    # Generate a unique client_id for this registration
     client_id = f"vault-mcp-{secrets.token_hex(8)}"
 
-    return JSONResponse({
-        "client_id": client_id,
-        "client_secret": config.VAULT_OAUTH_CLIENT_SECRET,
-        "client_name": body.get("client_name", "Obsidian Vault MCP Client"),
-        "grant_types": ["authorization_code"],
-        "response_types": ["code"],
-        "redirect_uris": body.get("redirect_uris", []),
-        "token_endpoint_auth_method": "client_secret_post",
-    }, status_code=201)
+    # Public client (PKCE): no shared client secret handed out (audyt s693 + s1099 N71 —
+    # the dead VAULT_OAUTH_CLIENT_SECRET env was removed). authorization_code+PKCE needs
+    # no client secret, and client_credentials is disabled.
+    return JSONResponse(
+        {
+            "client_id": client_id,
+            "client_name": body.get("client_name", "Obsidian Vault MCP Client"),
+            "grant_types": ["authorization_code"],
+            "response_types": ["code"],
+            "redirect_uris": body.get("redirect_uris", []),
+            "token_endpoint_auth_method": "none",
+        },
+        status_code=201,
+    )
 
-
-# Starlette routes to mount on the app
 
 async def oauth_protected_resource(request: Request) -> JSONResponse:
     """RFC 9728 OAuth 2.0 Protected Resource Metadata."""
-    base_url = os.environ.get("PUBLIC_BASE_URL", str(request.base_url).rstrip("/")).rstrip("/")
-    return JSONResponse({
-        "resource": base_url,
-        "authorization_servers": [base_url],
-    })
+    base_url = _public_base(request)
+    return JSONResponse(
+        {
+            "resource": base_url,
+            "authorization_servers": [base_url],
+        }
+    )
+
 
 oauth_routes = [
     Route("/.well-known/oauth-authorization-server", oauth_metadata, methods=["GET"]),

--- a/src/obsidian_vault_mcp/oauth.py
+++ b/src/obsidian_vault_mcp/oauth.py
@@ -17,6 +17,7 @@ import hashlib
 import hmac
 import logging
 import secrets
+import os
 import time
 from urllib.parse import urlencode, urlparse, parse_qs
 
@@ -42,7 +43,7 @@ def _cleanup_codes():
 
 async def oauth_metadata(request: Request) -> JSONResponse:
     """RFC 8414 OAuth authorization server metadata."""
-    base_url = str(request.base_url).rstrip("/")
+    base_url = os.environ.get("PUBLIC_BASE_URL", str(request.base_url).rstrip("/")).rstrip("/")
     return JSONResponse({
         "issuer": base_url,
         "authorization_endpoint": f"{base_url}/oauth/authorize",
@@ -207,9 +208,20 @@ async def oauth_register(request: Request) -> JSONResponse:
 
 
 # Starlette routes to mount on the app
+
+async def oauth_protected_resource(request: Request) -> JSONResponse:
+    """RFC 9728 OAuth 2.0 Protected Resource Metadata."""
+    base_url = os.environ.get("PUBLIC_BASE_URL", str(request.base_url).rstrip("/")).rstrip("/")
+    return JSONResponse({
+        "resource": base_url,
+        "authorization_servers": [base_url],
+    })
+
 oauth_routes = [
     Route("/.well-known/oauth-authorization-server", oauth_metadata, methods=["GET"]),
     Route("/oauth/authorize", oauth_authorize, methods=["GET"]),
     Route("/oauth/token", oauth_token, methods=["POST"]),
     Route("/oauth/register", oauth_register, methods=["POST"]),
+    Route("/.well-known/oauth-protected-resource", oauth_protected_resource, methods=["GET"]),
+    Route("/.well-known/oauth-protected-resource/mcp", oauth_protected_resource, methods=["GET"]),
 ]

--- a/src/obsidian_vault_mcp/oauth.py
+++ b/src/obsidian_vault_mcp/oauth.py
@@ -1,46 +1,35 @@
-"""OAuth 2.0 authorization code flow with PKCE for Claude app MCP integration.
+"""Adapter OAuth dla vault-mcp — cienka warstwa nad reużywalną bramą `mcp_oauth`.
 
-Claude's MCP connector uses the full OAuth authorization code flow:
-1. Discovers metadata at /.well-known/oauth-authorization-server
-2. Dynamically registers at /oauth/register
-3. Redirects user's browser to /oauth/authorize
-4. Server auto-approves (single-user) and redirects back with an auth code
-5. Claude exchanges the code at /oauth/token for a bearer token
-6. Claude uses the bearer token on all MCP requests
+Cała logika OAuth (authorization_code + PKCE) i brama tożsamości Google żyją w
+`mcp_oauth.McpOAuthGate` (wendorowana kopia workos_shared — JEDEN mechanizm dla
+wszystkich serwerów MCP, kanon GOLDEN-PATTERNS Wzorzec 9). Ten moduł tylko:
 
-Single-user personal server: the authorization page auto-approves immediately.
+1. Buduje instancję bramy z `config` (token, base-url, klient Google, allowlista e-maili).
+2. Dokłada fork-owy rate-limit per-IP na publicznych wejściach OAuth (audyt s1099 S77/S81)
+   — komponent celowo go nie ma (różne usługi mają różne progi).
+3. Eksponuje `oauth_routes` (montowane w server.py) i `OPEN_PATHS` (wyjątek bearer-auth).
 
-Security hardening (audyt s693, KRYT — same class as jarvis_rag KRYT-1; this module
-is the original the RAG OAuth was adapted from):
-  1. redirect_uri allowlist — codes only go to a registered callback.
-  2. PKCE mandatory — no downgrade; authorize requires S256 challenge, token always verifies.
-  3. client_credentials grant removed — it minted the master token for any holder of the
-     shared client secret.
-  4. /oauth/register is a public client (PKCE), no shared secret handed out.
-The static Bearer (config.VAULT_MCP_TOKEN) still gates every MCP request (unchanged).
+Domknięcie K1 (s1286): poprzednia wersja auto-approve'owała (każdy znający URL Funnela
+wyciągał master-token). Teraz `/oauth/authorize` deleguje do logowania Google i wydaje kod
+tylko zweryfikowanemu e-mailowi z allowlisty. FAIL-CLOSED bez konfiguracji bramy.
 """
 
-import base64
-import hashlib
-import hmac
 import logging
 import os
-import secrets
 import time
-from urllib.parse import urlencode
 
 from starlette.requests import Request
-from starlette.responses import JSONResponse, RedirectResponse
+from starlette.responses import JSONResponse
 from starlette.routing import Route
 
 from . import config
+from .mcp_oauth import McpOAuthGate
 
 logger = logging.getLogger(__name__)
 
-# Allowlist of permitted OAuth redirect URIs (exact match). Without this, anyone can
-# drive /oauth/authorize and have the auth code delivered to an attacker host (KRYT,
-# audyt s693). Configurable via env (comma-separated); defaults to the claude.ai MCP
-# connector callback.
+# Allowlist of permitted OAuth redirect URIs (exact match). Bez tego ktokolwiek mógłby
+# poprowadzić /oauth/authorize i dostarczyć kod na host atakującego (KRYT, audyt s693).
+# Konfigurowalne env (przecinki); domyślnie callback konektora MCP claude.ai.
 REDIRECT_ALLOWLIST = frozenset(
     u.strip()
     for u in os.environ.get(
@@ -50,26 +39,28 @@ REDIRECT_ALLOWLIST = frozenset(
     if u.strip()
 )
 
-# In-memory store for authorization codes (short-lived)
-_auth_codes: dict[str, dict] = {}
+
+def _build_gate() -> McpOAuthGate:
+    """Brama z bieżącego configu. Wydzielone, by testy mogły zbudować wariant z bramą."""
+    return McpOAuthGate(
+        service_name="vault-mcp",
+        master_token=config.VAULT_MCP_TOKEN,
+        public_base=config.VAULT_MCP_BASE_URL,
+        resource_path="/mcp",
+        redirect_allowlist=REDIRECT_ALLOWLIST,
+        google_client_id=config.VAULT_MCP_GOOGLE_OAUTH_CLIENT_ID,
+        google_client_secret=config.VAULT_MCP_GOOGLE_OAUTH_SECRET,
+        google_redirect_uri=config.VAULT_MCP_GOOGLE_OAUTH_REDIRECT_URI,
+        allowed_emails=config.VAULT_MCP_ALLOWED_EMAILS,
+        dev_insecure=config.VAULT_MCP_OAUTH_DEV_INSECURE,
+    )
 
 
-def _cleanup_codes():
-    now = time.time()
-    expired = [k for k, v in _auth_codes.items() if v["expires_at"] < now]
-    for k in expired:
-        del _auth_codes[k]
+# Instancja modułowa — trasy referują ją DYNAMICZNIE (przez nazwę globalną), więc test
+# może podmienić `oauth._GATE` na wariant z włączoną bramą bez przebudowy tras.
+_GATE = _build_gate()
 
-
-def _public_base(request: Request) -> str:
-    """Zaufany publiczny URL bazowy. Z env VAULT_MCP_BASE_URL (anti-Host-spoofing, N69);
-    fallback do request.base_url gdy nieustawiony (środowisko dev)."""
-    if config.VAULT_MCP_BASE_URL:
-        return config.VAULT_MCP_BASE_URL
-    return str(request.base_url).rstrip("/")
-
-
-# Rate-limit publicznych endpointów OAuth (audyt s1099, S77/S81) — per-IP, in-memory.
+# ── rate-limit per-IP publicznych wejść OAuth (audyt s1099 S77/S81) ────────────
 _OAUTH_WINDOW_S = 60
 _oauth_hits: dict[str, list[float]] = {}
 
@@ -97,209 +88,61 @@ def _oauth_rate_limited(request: Request) -> bool:
     return len(hits) > config.RATE_LIMIT_OAUTH_PER_MIN
 
 
-async def oauth_metadata(request: Request) -> JSONResponse:
-    """RFC 8414 OAuth authorization server metadata."""
-    base_url = _public_base(request)
-    return JSONResponse(
-        {
-            "issuer": base_url,
-            "authorization_endpoint": f"{base_url}/oauth/authorize",
-            "token_endpoint": f"{base_url}/oauth/token",
-            "registration_endpoint": f"{base_url}/oauth/register",
-            "grant_types_supported": ["authorization_code"],
-            "response_types_supported": ["code"],
-            "code_challenge_methods_supported": ["S256"],
-            # Public client + PKCE: no client secret used at the token endpoint.
-            "token_endpoint_auth_methods_supported": ["none"],
-        }
-    )
+def _rate_limited(handler):
+    """Owija publiczne wejście OAuth limitem per-IP. Discovery (metadata/protected) NIE
+    limitowane — claude.ai odpytuje je często przy odkrywaniu."""
+
+    async def wrapped(request: Request):
+        if _oauth_rate_limited(request):
+            return JSONResponse({"error": "rate_limited"}, status_code=429)
+        return await handler(request)
+
+    return wrapped
 
 
-async def oauth_authorize(request: Request):
-    """OAuth 2.0 authorization endpoint (allowlisted redirect + mandatory PKCE)."""
+# Wrappery referują `_GATE` dynamicznie (nie wiążą bound-method przy konstrukcji trasy).
+async def _metadata(request: Request):
+    return await _GATE.metadata(request)
+
+
+async def _protected_resource(request: Request):
+    return await _GATE.protected_resource(request)
+
+
+async def _authorize(request: Request):
     if _oauth_rate_limited(request):
         return JSONResponse({"error": "rate_limited"}, status_code=429)
-    response_type = request.query_params.get("response_type", "")
-    client_id = request.query_params.get("client_id", "")
-    redirect_uri = request.query_params.get("redirect_uri", "")
-    state = request.query_params.get("state", "")
-    code_challenge = request.query_params.get("code_challenge", "")
-    code_challenge_method = request.query_params.get("code_challenge_method", "S256")
-
-    if response_type != "code":
-        return JSONResponse({"error": "unsupported_response_type"}, status_code=400)
-
-    if not redirect_uri:
-        return JSONResponse(
-            {"error": "invalid_request", "error_description": "redirect_uri required"},
-            status_code=400,
-        )
-
-    # Allowlist check: refuse to issue a code to an unregistered redirect target.
-    if redirect_uri not in REDIRECT_ALLOWLIST:
-        logger.warning(f"OAuth authorize rejected: redirect_uri not in allowlist ({redirect_uri[:60]!r})")
-        return JSONResponse(
-            {"error": "invalid_request", "error_description": "redirect_uri not allowed"},
-            status_code=400,
-        )
-
-    # PKCE is mandatory (no downgrade): require an S256 challenge up front.
-    if not code_challenge:
-        return JSONResponse(
-            {"error": "invalid_request", "error_description": "code_challenge required (PKCE)"},
-            status_code=400,
-        )
-    if code_challenge_method != "S256":
-        return JSONResponse(
-            {"error": "invalid_request", "error_description": "code_challenge_method must be S256"},
-            status_code=400,
-        )
-
-    # Generate authorization code
-    _cleanup_codes()
-    code = secrets.token_urlsafe(32)
-    _auth_codes[code] = {
-        "client_id": client_id,
-        "redirect_uri": redirect_uri,
-        "code_challenge": code_challenge,
-        "code_challenge_method": code_challenge_method,
-        "expires_at": time.time() + 300,  # 5 minute expiry
-    }
-
-    logger.info(f"OAuth authorization code issued, redirecting to {redirect_uri[:50]}...")
-
-    params = {"code": code}
-    if state:
-        params["state"] = state
-
-    separator = "&" if "?" in redirect_uri else "?"
-    return RedirectResponse(
-        url=f"{redirect_uri}{separator}{urlencode(params)}",
-        status_code=302,
-    )
+    return await _GATE.authorize(request)
 
 
-async def oauth_token(request: Request) -> JSONResponse:
-    """OAuth 2.0 token endpoint -- authorization_code + PKCE only."""
+async def _google_callback(request: Request):
     if _oauth_rate_limited(request):
         return JSONResponse({"error": "rate_limited"}, status_code=429)
-    try:
-        form = await request.form()
-    except Exception:
-        return JSONResponse({"error": "invalid_request"}, status_code=400)
-
-    grant_type = form.get("grant_type", "")
-
-    # Only authorization_code + PKCE is supported. client_credentials was removed
-    # (audyt s693): it minted the master VAULT_MCP_TOKEN for anyone holding the shared
-    # client secret handed out by /oauth/register.
-    if grant_type == "authorization_code":
-        return await _handle_authorization_code(form)
-    return JSONResponse({"error": "unsupported_grant_type"}, status_code=400)
+    return await _GATE.google_callback(request)
 
 
-async def _handle_authorization_code(form) -> JSONResponse:
-    """Exchange an authorization code for a bearer token (PKCE mandatory)."""
-    code = form.get("code", "")
-    redirect_uri = form.get("redirect_uri", "")
-    code_verifier = form.get("code_verifier", "")
-
-    _cleanup_codes()
-
-    if code not in _auth_codes:
-        return JSONResponse(
-            {"error": "invalid_grant", "error_description": "Invalid or expired code"},
-            status_code=400,
-        )
-
-    code_data = _auth_codes.pop(code)
-
-    # Bezwarunkowy exact-match (audyt s1099, bliźniak jarvis_rag N32): poprzedni warunek
-    # pomijał porównanie gdy obie strony były puste. Kod zawsze bindowany do redirect_uri
-    # z allowlisty przy wydaniu, więc stored nigdy nie jest pusty.
-    if redirect_uri != code_data.get("redirect_uri", ""):
-        return JSONResponse(
-            {"error": "invalid_grant", "error_description": "redirect_uri mismatch"},
-            status_code=400,
-        )
-
-    # PKCE verification is mandatory. Codes are only issued with a stored challenge
-    # (oauth_authorize enforces it). A missing challenge here means a forged/legacy
-    # grant -- reject. Never fall through to issuing a token.
-    stored_challenge = code_data.get("code_challenge", "")
-    if not stored_challenge:
-        return JSONResponse(
-            {"error": "invalid_grant", "error_description": "missing PKCE challenge"},
-            status_code=400,
-        )
-    if not code_verifier:
-        return JSONResponse(
-            {"error": "invalid_grant", "error_description": "code_verifier required"},
-            status_code=400,
-        )
-
-    digest = hashlib.sha256(code_verifier.encode("ascii")).digest()
-    computed_challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
-
-    if not hmac.compare_digest(computed_challenge, stored_challenge):
-        return JSONResponse(
-            {"error": "invalid_grant", "error_description": "PKCE verification failed"},
-            status_code=400,
-        )
-
-    logger.info("OAuth token issued via authorization_code grant")
-    return JSONResponse(
-        {
-            "access_token": config.VAULT_MCP_TOKEN,
-            "token_type": "bearer",
-            "expires_in": 86400,
-        }
-    )
-
-
-async def oauth_register(request: Request) -> JSONResponse:
-    """Dynamic client registration -- public client (PKCE), no shared secret."""
+async def _token(request: Request):
     if _oauth_rate_limited(request):
         return JSONResponse({"error": "rate_limited"}, status_code=429)
-    try:
-        body = await request.json()
-    except Exception:
-        body = {}
-
-    client_id = f"vault-mcp-{secrets.token_hex(8)}"
-
-    # Public client (PKCE): no shared client secret handed out (audyt s693 + s1099 N71 —
-    # the dead VAULT_OAUTH_CLIENT_SECRET env was removed). authorization_code+PKCE needs
-    # no client secret, and client_credentials is disabled.
-    return JSONResponse(
-        {
-            "client_id": client_id,
-            "client_name": body.get("client_name", "Obsidian Vault MCP Client"),
-            "grant_types": ["authorization_code"],
-            "response_types": ["code"],
-            "redirect_uris": body.get("redirect_uris", []),
-            "token_endpoint_auth_method": "none",
-        },
-        status_code=201,
-    )
+    return await _GATE.token(request)
 
 
-async def oauth_protected_resource(request: Request) -> JSONResponse:
-    """RFC 9728 OAuth 2.0 Protected Resource Metadata."""
-    base_url = _public_base(request)
-    return JSONResponse(
-        {
-            "resource": base_url,
-            "authorization_servers": [base_url],
-        }
-    )
+async def _register(request: Request):
+    if _oauth_rate_limited(request):
+        return JSONResponse({"error": "rate_limited"}, status_code=429)
+    return await _GATE.register(request)
 
 
 oauth_routes = [
-    Route("/.well-known/oauth-authorization-server", oauth_metadata, methods=["GET"]),
-    Route("/oauth/authorize", oauth_authorize, methods=["GET"]),
-    Route("/oauth/token", oauth_token, methods=["POST"]),
-    Route("/oauth/register", oauth_register, methods=["POST"]),
-    Route("/.well-known/oauth-protected-resource", oauth_protected_resource, methods=["GET"]),
-    Route("/.well-known/oauth-protected-resource/mcp", oauth_protected_resource, methods=["GET"]),
+    Route("/.well-known/oauth-authorization-server", _metadata, methods=["GET"]),
+    Route("/.well-known/oauth-protected-resource", _protected_resource, methods=["GET"]),
+    Route("/.well-known/oauth-protected-resource/mcp", _protected_resource, methods=["GET"]),
+    Route("/oauth/authorize", _authorize, methods=["GET", "POST"]),
+    Route("/oauth/google/callback", _google_callback, methods=["GET"]),
+    Route("/oauth/token", _token, methods=["POST"]),
+    Route("/oauth/register", _register, methods=["POST"]),
 ]
+
+# Ścieżki zwolnione z bearer-auth (pre-auth flow OAuth + odkrywania). Wyprowadzone z bramy
+# — single source, obejmuje /oauth/google/callback (nowy w s1286).
+OPEN_PATHS = _GATE.open_paths

--- a/src/obsidian_vault_mcp/server.py
+++ b/src/obsidian_vault_mcp/server.py
@@ -8,6 +8,8 @@ import json as _json
 import logging
 import os
 import sys
+import threading
+from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
 import httpx
@@ -55,12 +57,19 @@ logger = logging.getLogger(__name__)
 # at module level: built once, watched by watchdog, shared across sessions.
 frontmatter_index = FrontmatterIndex()
 _index_started = False
+# N72 (audyt s1099): check-then-act na fladze globalnej NIE jest „thread-safe via GIL"
+# (poprzedni komentarz wprowadzał w błąd) — między sprawdzeniem `if not _index_started`
+# a ustawieniem True inny wątek mógłby wejść i podwójnie wystartować indeks. Lock domyka
+# to do prawdziwej idempotencji (kontencja tylko na zimnym starcie).
+_index_lock = threading.Lock()
 
 
-def _ensure_index():
-    """Start the index exactly once (thread-safe via GIL)."""
+def _ensure_index() -> None:
+    """Start the index exactly once (idempotentne, strzeżone lockiem)."""
     global _index_started
-    if not _index_started:
+    with _index_lock:
+        if _index_started:
+            return
         logger.info(f"Starting vault MCP server. Vault: {VAULT_PATH}")
         frontmatter_index.start()
         logger.info(f"Frontmatter index built: {frontmatter_index.file_count} files indexed")
@@ -68,7 +77,7 @@ def _ensure_index():
 
 
 @asynccontextmanager
-async def lifespan(server):
+async def lifespan(server) -> AsyncIterator[dict]:
     """Ensure index is ready; yield it to the session."""
     _ensure_index()
     yield {"frontmatter_index": frontmatter_index}
@@ -302,7 +311,7 @@ class SecurityHeadersMiddleware:
         await self.app(scope, receive, send_with_headers)
 
 
-def main():
+def main() -> None:
     """Entry point. Run with streamable HTTP transport."""
     logging.basicConfig(
         level=logging.INFO,

--- a/src/obsidian_vault_mcp/server.py
+++ b/src/obsidian_vault_mcp/server.py
@@ -283,8 +283,10 @@ def rag_search(query: str, n_results: int = 5, source_type: str | None = None) -
                         return f"RAG error: {data['error'].get('message', 'unknown')}"
 
             return "RAG search: no response parsed"
-    except Exception as e:
-        return f"RAG search failed: {e}"
+    except Exception:
+        # Komunikat generyczny do klienta (audyt s1099, S78) — pełny kontekst w logach serwisu.
+        logger.exception("rag_search failed")
+        return "Internal error during RAG search"
 
 
 class SecurityHeadersMiddleware:

--- a/src/obsidian_vault_mcp/server.py
+++ b/src/obsidian_vault_mcp/server.py
@@ -17,19 +17,29 @@ from .frontmatter_index import FrontmatterIndex
 
 logger = logging.getLogger(__name__)
 
-# Global frontmatter index instance
+# Global frontmatter index — initialized once at import, not per-request.
+# With stateless_http=True, lifespan runs per session. Building the index
+# there caused 17s cold starts on every MCP request. Now the index lives
+# at module level: built once, watched by watchdog, shared across sessions.
 frontmatter_index = FrontmatterIndex()
+_index_started = False
+
+
+def _ensure_index():
+    """Start the index exactly once (thread-safe via GIL)."""
+    global _index_started
+    if not _index_started:
+        logger.info(f"Starting vault MCP server. Vault: {VAULT_PATH}")
+        frontmatter_index.start()
+        logger.info(f"Frontmatter index built: {frontmatter_index.file_count} files indexed")
+        _index_started = True
 
 
 @asynccontextmanager
 async def lifespan(server):
-    """Start frontmatter index on server startup, stop on shutdown."""
-    logger.info(f"Starting vault MCP server. Vault: {VAULT_PATH}")
-    frontmatter_index.start()
-    logger.info(f"Frontmatter index built: {frontmatter_index.file_count} files indexed")
+    """Ensure index is ready; yield it to the session."""
+    _ensure_index()
     yield {"frontmatter_index": frontmatter_index}
-    frontmatter_index.stop()
-    logger.info("Vault MCP server shut down.")
 
 
 # Create the MCP server
@@ -45,7 +55,8 @@ mcp = FastMCP(
             "localhost:*",
             "[::1]:*",
             # Add your tunnel hostname here, e.g.:
-            # "vault-mcp.example.com",
+            "vps-2557.tail301a28.ts.net",
+            "vault.grzegorzgolas.com",
         ],
     ),
 )
@@ -185,6 +196,70 @@ def vault_delete(path: str, confirm: bool = False) -> str:
     """Delete a file (move to .trash/)."""
     inp = VaultDeleteInput(path=path, confirm=confirm)
     return _vault_delete(inp.path, inp.confirm)
+
+
+# --- RAG search tool (proxied to jarvis-rag on localhost:8765) ---
+
+import os
+import httpx
+
+_RAG_URL = os.environ.get("RAG_INTERNAL_URL", "http://127.0.0.1:8765")
+_RAG_TOKEN = os.environ.get("RAG_TOKEN", "")
+
+
+@mcp.tool(
+    name="rag_search",
+    description="Search across all indexed documents (Obsidian vault, Google Drive files, meeting transcripts). "
+    "Returns the most relevant chunks with source info. "
+    "Use for questions like 'where is the SLK contract?', 'what did we decide about pricing?', "
+    "'find Borycka contact details'. Query in Polish or English.",
+    annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True, "openWorldHint": False},
+)
+def rag_search(query: str, n_results: int = 5, source_type: str | None = None) -> str:
+    """Search RAG index via internal HTTP call to jarvis-rag."""
+    try:
+        with httpx.Client(timeout=30) as client:
+            resp = client.post(
+                f"{_RAG_URL}/mcp",
+                headers={
+                    "Authorization": f"Bearer {_RAG_TOKEN}",
+                    "Content-Type": "application/json",
+                    "Accept": "application/json, text/event-stream",
+                },
+                json={
+                    "jsonrpc": "2.0",
+                    "method": "tools/call",
+                    "params": {
+                        "name": "rag_search",
+                        "arguments": {
+                            "query": query,
+                            "n_results": n_results,
+                            **({"source_type": source_type} if source_type else {}),
+                        },
+                    },
+                    "id": 1,
+                },
+            )
+
+            if resp.status_code != 200:
+                return f"RAG search error: HTTP {resp.status_code}"
+
+            # Parse SSE response (FastMCP returns event stream)
+            text = resp.text
+            for line in text.split("\n"):
+                if line.startswith("data: "):
+                    import json as _json
+                    data = _json.loads(line[6:])
+                    if "result" in data:
+                        content = data["result"].get("content", [])
+                        if content:
+                            return content[0].get("text", "No results")
+                    if "error" in data:
+                        return f"RAG error: {data['error'].get('message', 'unknown')}"
+
+            return "RAG search: no response parsed"
+    except Exception as e:
+        return f"RAG search failed: {e}"
 
 
 def main():

--- a/src/obsidian_vault_mcp/server.py
+++ b/src/obsidian_vault_mcp/server.py
@@ -4,16 +4,48 @@ Exposes read/write access to an Obsidian vault over Streamable HTTP.
 Designed to run behind Cloudflare Tunnel for secure remote access.
 """
 
-import json
+import json as _json
 import logging
+import os
 import sys
 from contextlib import asynccontextmanager
 
+import httpx
+import uvicorn
 from mcp.server.fastmcp import FastMCP
 from mcp.server.transport_security import TransportSecuritySettings
+from starlette.datastructures import MutableHeaders
 
-from .config import VAULT_MCP_PORT, VAULT_MCP_TOKEN, VAULT_PATH
+from .auth import BearerAuthMiddleware
+from .config import (
+    VAULT_MCP_ALLOWED_HOSTS,
+    VAULT_MCP_HOST,
+    VAULT_MCP_PORT,
+    VAULT_MCP_TOKEN,
+    VAULT_PATH,
+)
 from .frontmatter_index import FrontmatterIndex
+from .models import (
+    VaultBatchFrontmatterUpdateInput,
+    VaultBatchReadInput,
+    VaultDeleteInput,
+    VaultListInput,
+    VaultMoveInput,
+    VaultReadInput,
+    VaultSearchFrontmatterInput,
+    VaultSearchInput,
+    VaultWriteInput,
+)
+from .oauth import oauth_routes
+from .tools.manage import vault_delete as _vault_delete
+from .tools.manage import vault_list as _vault_list
+from .tools.manage import vault_move as _vault_move
+from .tools.read import vault_batch_read as _vault_batch_read
+from .tools.read import vault_read as _vault_read
+from .tools.search import vault_search as _vault_search
+from .tools.search import vault_search_frontmatter as _vault_search_frontmatter
+from .tools.write import vault_batch_frontmatter_update as _vault_batch_frontmatter_update
+from .tools.write import vault_write as _vault_write
 
 logger = logging.getLogger(__name__)
 
@@ -50,35 +82,13 @@ mcp = FastMCP(
     lifespan=lifespan,
     transport_security=TransportSecuritySettings(
         enable_dns_rebinding_protection=True,
-        allowed_hosts=[
-            "127.0.0.1:*",
-            "localhost:*",
-            "[::1]:*",
-            # Add your tunnel hostname here, e.g.:
-            "vps-2557.tail301a28.ts.net",
-            "vault.grzegorzgolas.com",
-        ],
+        # Allowlista hostów reverse-proxy (loopback + Funnel + Caddy) — patrz config.
+        allowed_hosts=VAULT_MCP_ALLOWED_HOSTS,
     ),
 )
 
 
 # --- Register all tools ---
-
-from .tools.read import vault_read as _vault_read, vault_batch_read as _vault_batch_read
-from .tools.write import vault_write as _vault_write, vault_batch_frontmatter_update as _vault_batch_frontmatter_update
-from .tools.search import vault_search as _vault_search, vault_search_frontmatter as _vault_search_frontmatter
-from .tools.manage import vault_list as _vault_list, vault_move as _vault_move, vault_delete as _vault_delete
-from .models import (
-    VaultReadInput,
-    VaultWriteInput,
-    VaultBatchReadInput,
-    VaultBatchFrontmatterUpdateInput,
-    VaultSearchInput,
-    VaultSearchFrontmatterInput,
-    VaultListInput,
-    VaultMoveInput,
-    VaultDeleteInput,
-)
 
 
 @mcp.tool(
@@ -138,7 +148,13 @@ def vault_search(
     context_lines: int = 2,
 ) -> str:
     """Search vault file contents."""
-    inp = VaultSearchInput(query=query, path_prefix=path_prefix, file_pattern=file_pattern, max_results=max_results, context_lines=context_lines)
+    inp = VaultSearchInput(
+        query=query,
+        path_prefix=path_prefix,
+        file_pattern=file_pattern,
+        max_results=max_results,
+        context_lines=context_lines,
+    )
     return _vault_search(inp.query, inp.path_prefix, inp.file_pattern, inp.max_results, inp.context_lines)
 
 
@@ -155,7 +171,9 @@ def vault_search_frontmatter(
     max_results: int = 20,
 ) -> str:
     """Search by frontmatter fields."""
-    inp = VaultSearchFrontmatterInput(field=field, value=value, match_type=match_type, path_prefix=path_prefix, max_results=max_results)
+    inp = VaultSearchFrontmatterInput(
+        field=field, value=value, match_type=match_type, path_prefix=path_prefix, max_results=max_results
+    )
     return _vault_search_frontmatter(inp.field, inp.value, inp.match_type, inp.path_prefix, inp.max_results)
 
 
@@ -172,7 +190,9 @@ def vault_list(
     pattern: str | None = None,
 ) -> str:
     """List vault directory contents."""
-    inp = VaultListInput(path=path, depth=depth, include_files=include_files, include_dirs=include_dirs, pattern=pattern)
+    inp = VaultListInput(
+        path=path, depth=depth, include_files=include_files, include_dirs=include_dirs, pattern=pattern
+    )
     return _vault_list(inp.path, inp.depth, inp.include_files, inp.include_dirs, inp.pattern)
 
 
@@ -199,9 +219,6 @@ def vault_delete(path: str, confirm: bool = False) -> str:
 
 
 # --- RAG search tool (proxied to jarvis-rag on localhost:8765) ---
-
-import os
-import httpx
 
 _RAG_URL = os.environ.get("RAG_INTERNAL_URL", "http://127.0.0.1:8765")
 _RAG_TOKEN = os.environ.get("RAG_TOKEN", "")
@@ -248,7 +265,6 @@ def rag_search(query: str, n_results: int = 5, source_type: str | None = None) -
             text = resp.text
             for line in text.split("\n"):
                 if line.startswith("data: "):
-                    import json as _json
                     data = _json.loads(line[6:])
                     if "result" in data:
                         content = data["result"].get("content", [])
@@ -260,6 +276,30 @@ def rag_search(query: str, n_results: int = 5, source_type: str | None = None) -
             return "RAG search: no response parsed"
     except Exception as e:
         return f"RAG search failed: {e}"
+
+
+class SecurityHeadersMiddleware:
+    """Pure-ASGI middleware — nagłówki bezpieczeństwa na każdej odpowiedzi (audyt s1099,
+    N70, GOLDEN-PATTERNS Wzorzec 8). vault_mcp zwraca JSON/MCP, więc bez CSP."""
+
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        async def send_with_headers(message):
+            if message["type"] == "http.response.start":
+                headers = MutableHeaders(scope=message)
+                headers.setdefault("X-Content-Type-Options", "nosniff")
+                headers.setdefault("X-Frame-Options", "DENY")
+                headers.setdefault("Referrer-Policy", "no-referrer")
+                headers.setdefault("Strict-Transport-Security", "max-age=31536000")
+            await send(message)
+
+        await self.app(scope, receive, send_with_headers)
 
 
 def main():
@@ -274,36 +314,35 @@ def main():
         logger.error(f"Vault path does not exist: {VAULT_PATH}")
         sys.exit(1)
 
+    # Fail-closed (audyt s1099, S79): bez tokenu NIE startujemy. Wcześniej awaryjna
+    # gałąź uruchamiała mcp.run() BEZ auth na publicznym Funnelu — krytyczna furtka.
     if not VAULT_MCP_TOKEN:
-        logger.warning("VAULT_MCP_TOKEN is not set -- auth will reject all requests")
-
-    # Build the Starlette app with auth middleware and OAuth endpoints
-    try:
-        from .auth import BearerAuthMiddleware
-        from .oauth import oauth_routes
-
-        app = mcp.streamable_http_app()
-
-        # Mount OAuth routes (these are excluded from bearer auth via the middleware)
-        for route in oauth_routes:
-            app.routes.insert(0, route)
-
-        app.add_middleware(BearerAuthMiddleware)
-        logger.info(f"Starting server on port {VAULT_MCP_PORT} with bearer auth + OAuth")
-
-        import uvicorn
-        uvicorn.run(
-            app,
-            host="0.0.0.0",
-            port=VAULT_MCP_PORT,
-            log_level="info",
-            proxy_headers=True,
-            forwarded_allow_ips="*",
+        raise RuntimeError(
+            "VAULT_MCP_TOKEN is not set — refusing to start without bearer auth "
+            "(fail-closed, audyt s1099 S79). Niezautentykowany dostęp do vaulta jest zbyt "
+            "niebezpieczny. Ustaw VAULT_MCP_TOKEN w EnvironmentFile."
         )
-    except Exception as e:
-        logger.warning(f"Could not build app ({e}), falling back to mcp.run()")
-        logger.warning("Auth will NOT be enforced in this mode")
-        mcp.run(transport="streamable-http", port=VAULT_MCP_PORT)
+
+    app = mcp.streamable_http_app()
+
+    # Mount OAuth routes (excluded from bearer auth via the middleware)
+    for route in oauth_routes:
+        app.routes.insert(0, route)
+
+    app.add_middleware(BearerAuthMiddleware)
+    # Nagłówki bezpieczeństwa na każdej odpowiedzi (audyt s1099, N70, Wzorzec 8) —
+    # dodane ostatnie = najbardziej zewnętrzne (obejmują też 401/błędy bramki).
+    app.add_middleware(SecurityHeadersMiddleware)
+    logger.info(f"Starting server on {VAULT_MCP_HOST}:{VAULT_MCP_PORT} with bearer auth + OAuth")
+
+    uvicorn.run(
+        app,
+        host=VAULT_MCP_HOST,
+        port=VAULT_MCP_PORT,
+        log_level="info",
+        proxy_headers=True,
+        forwarded_allow_ips="127.0.0.1",
+    )
 
 
 if __name__ == "__main__":

--- a/src/obsidian_vault_mcp/tools/json_utils.py
+++ b/src/obsidian_vault_mcp/tools/json_utils.py
@@ -1,0 +1,16 @@
+"""Custom JSON encoder for vault data — handles datetime.date from YAML frontmatter."""
+
+import json
+import datetime
+
+
+class VaultEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, (datetime.date, datetime.datetime)):
+            return obj.isoformat()
+        return super().default(obj)
+
+
+def dumps(obj, **kwargs):
+    """json.dumps with VaultEncoder — drop-in replacement."""
+    return json.dumps(obj, cls=VaultEncoder, **kwargs)

--- a/src/obsidian_vault_mcp/tools/json_utils.py
+++ b/src/obsidian_vault_mcp/tools/json_utils.py
@@ -1,7 +1,18 @@
-"""Custom JSON encoder for vault data — handles datetime.date from YAML frontmatter."""
+"""Custom JSON helpers for vault data — handles datetime.date from YAML frontmatter.
+
+Importowany jako `from . import json_utils as json`, więc MUSI być drop-inem dla
+funkcji stdlib, których używają narzędzia: `dumps` (z custom encoderem), `loads`
+oraz wyjątek `JSONDecodeError`. W21 (audyt s1099): brakowało `loads`/`JSONDecodeError`
+→ `search._search_ripgrep` (parsujący `rg --json`) wywalał się na AttributeError przy
+pierwszej linii wyniku, więc wyszukiwanie z ripgrepem było całkowicie zepsute na
+maszynach z `rg` (VPS). Domknięcie aliasu jako pełnego drop-ina naprawia ścieżkę.
+"""
 
 import datetime
 import json
+from json import JSONDecodeError  # re-export — alias `as json` wymaga `json.JSONDecodeError`
+
+__all__ = ["JSONDecodeError", "VaultEncoder", "dumps", "loads"]
 
 
 class VaultEncoder(json.JSONEncoder):
@@ -12,5 +23,10 @@ class VaultEncoder(json.JSONEncoder):
 
 
 def dumps(obj, **kwargs):
-    """json.dumps with VaultEncoder — drop-in replacement."""
+    """json.dumps z VaultEncoder — drop-in replacement."""
     return json.dumps(obj, cls=VaultEncoder, **kwargs)
+
+
+def loads(s, **kwargs):
+    """json.loads — drop-in replacement (parę z custom dumps; W21)."""
+    return json.loads(s, **kwargs)

--- a/src/obsidian_vault_mcp/tools/json_utils.py
+++ b/src/obsidian_vault_mcp/tools/json_utils.py
@@ -1,7 +1,7 @@
 """Custom JSON encoder for vault data — handles datetime.date from YAML frontmatter."""
 
-import json
 import datetime
+import json
 
 
 class VaultEncoder(json.JSONEncoder):

--- a/src/obsidian_vault_mcp/tools/manage.py
+++ b/src/obsidian_vault_mcp/tools/manage.py
@@ -1,10 +1,10 @@
 """Management tools for the Obsidian vault MCP server."""
 
-from . import json_utils as json
 import logging
 
 from ..git_ops import commit_vault_change
-from ..vault import list_directory, move_path, delete_path, resolve_vault_path
+from ..vault import delete_path, list_directory, move_path
+from . import json_utils as json
 
 logger = logging.getLogger(__name__)
 
@@ -39,11 +39,7 @@ def vault_move(source: str, destination: str, create_dirs: bool = True) -> str:
     """Move a file or directory within the vault."""
     try:
         moved = move_path(source, destination, create_dirs=create_dirs)
-
-        # PDCA-014 auto-commit: stage both source (delete) and destination (add)
-        if moved:
-            commit_vault_change([source, destination], "move")
-
+        commit_vault_change([source, destination], "move")
         return json.dumps({"source": source, "destination": destination, "moved": moved})
     except ValueError as e:
         return json.dumps({"error": str(e), "source": source, "destination": destination})
@@ -55,18 +51,16 @@ def vault_move(source: str, destination: str, create_dirs: bool = True) -> str:
 def vault_delete(path: str, confirm: bool = False) -> str:
     """Delete a file by moving it to .trash/ in the vault."""
     if not confirm:
-        return json.dumps({
-            "error": "Set confirm=true to execute deletion. Files are moved to .trash/, not hard deleted.",
-            "path": path,
-        })
+        return json.dumps(
+            {
+                "error": "Set confirm=true to execute deletion. Files are moved to .trash/, not hard deleted.",
+                "path": path,
+            }
+        )
 
     try:
         deleted = delete_path(path)
-
-        # PDCA-014 auto-commit: stage the removal (destination is .trash/ which is gitignored)
-        if deleted:
-            commit_vault_change([path], "delete")
-
+        commit_vault_change([path], "delete")
         return json.dumps({"path": path, "deleted": deleted})
     except ValueError as e:
         return json.dumps({"error": str(e), "path": path})

--- a/src/obsidian_vault_mcp/tools/manage.py
+++ b/src/obsidian_vault_mcp/tools/manage.py
@@ -1,8 +1,9 @@
 """Management tools for the Obsidian vault MCP server."""
 
-import json
+from . import json_utils as json
 import logging
 
+from ..git_ops import commit_vault_change
 from ..vault import list_directory, move_path, delete_path, resolve_vault_path
 
 logger = logging.getLogger(__name__)
@@ -38,6 +39,11 @@ def vault_move(source: str, destination: str, create_dirs: bool = True) -> str:
     """Move a file or directory within the vault."""
     try:
         moved = move_path(source, destination, create_dirs=create_dirs)
+
+        # PDCA-014 auto-commit: stage both source (delete) and destination (add)
+        if moved:
+            commit_vault_change([source, destination], "move")
+
         return json.dumps({"source": source, "destination": destination, "moved": moved})
     except ValueError as e:
         return json.dumps({"error": str(e), "source": source, "destination": destination})
@@ -56,6 +62,11 @@ def vault_delete(path: str, confirm: bool = False) -> str:
 
     try:
         deleted = delete_path(path)
+
+        # PDCA-014 auto-commit: stage the removal (destination is .trash/ which is gitignored)
+        if deleted:
+            commit_vault_change([path], "delete")
+
         return json.dumps({"path": path, "deleted": deleted})
     except ValueError as e:
         return json.dumps({"error": str(e), "path": path})

--- a/src/obsidian_vault_mcp/tools/manage.py
+++ b/src/obsidian_vault_mcp/tools/manage.py
@@ -26,13 +26,15 @@ def vault_list(
             pattern=pattern,
         )
         return json.dumps({"items": items, "total": len(items)})
-    except ValueError as e:
-        return json.dumps({"error": str(e)})
+    except ValueError:
+        # Komunikat generyczny do klienta (audyt s1099, S78) — pełny kontekst w logach serwisu.
+        logger.exception(f"vault_list invalid path: {path}")
+        return json.dumps({"error": "Invalid path", "path": path})
     except FileNotFoundError:
         return json.dumps({"error": f"Directory not found: {path}"})
-    except Exception as e:
-        logger.error(f"vault_list error: {e}")
-        return json.dumps({"error": str(e)})
+    except Exception:
+        logger.exception(f"vault_list unexpected error: {path}")
+        return json.dumps({"error": "Internal error listing directory", "path": path})
 
 
 def vault_move(source: str, destination: str, create_dirs: bool = True) -> str:
@@ -41,11 +43,13 @@ def vault_move(source: str, destination: str, create_dirs: bool = True) -> str:
         moved = move_path(source, destination, create_dirs=create_dirs)
         commit_vault_change([source, destination], "move")
         return json.dumps({"source": source, "destination": destination, "moved": moved})
-    except ValueError as e:
-        return json.dumps({"error": str(e), "source": source, "destination": destination})
-    except Exception as e:
-        logger.error(f"vault_move error: {e}")
-        return json.dumps({"error": str(e), "source": source, "destination": destination})
+    except ValueError:
+        # Komunikat generyczny do klienta (audyt s1099, S78) — pełny kontekst w logach serwisu.
+        logger.exception(f"vault_move invalid path: {source} -> {destination}")
+        return json.dumps({"error": "Invalid path", "source": source, "destination": destination})
+    except Exception:
+        logger.exception(f"vault_move unexpected error: {source} -> {destination}")
+        return json.dumps({"error": "Internal error moving path", "source": source, "destination": destination})
 
 
 def vault_delete(path: str, confirm: bool = False) -> str:
@@ -62,8 +66,10 @@ def vault_delete(path: str, confirm: bool = False) -> str:
         deleted = delete_path(path)
         commit_vault_change([path], "delete")
         return json.dumps({"path": path, "deleted": deleted})
-    except ValueError as e:
-        return json.dumps({"error": str(e), "path": path})
-    except Exception as e:
-        logger.error(f"vault_delete error: {e}")
-        return json.dumps({"error": str(e), "path": path})
+    except ValueError:
+        # Komunikat generyczny do klienta (audyt s1099, S78) — pełny kontekst w logach serwisu.
+        logger.exception(f"vault_delete invalid path: {path}")
+        return json.dumps({"error": "Invalid path", "path": path})
+    except Exception:
+        logger.exception(f"vault_delete unexpected error: {path}")
+        return json.dumps({"error": "Internal error deleting file", "path": path})

--- a/src/obsidian_vault_mcp/tools/read.py
+++ b/src/obsidian_vault_mcp/tools/read.py
@@ -1,11 +1,11 @@
 """Read tools for the Obsidian vault MCP server."""
 
-from . import json_utils as json
 import logging
 
 import frontmatter
 
-from ..vault import resolve_vault_path, read_file
+from ..vault import read_file
+from . import json_utils as json
 
 logger = logging.getLogger(__name__)
 
@@ -13,7 +13,6 @@ logger = logging.getLogger(__name__)
 def vault_read(path: str) -> str:
     """Read a file from the vault, returning content, metadata, and parsed frontmatter."""
     try:
-        resolved = resolve_vault_path(path)
         content, metadata = read_file(path)
 
         fm_data = None
@@ -24,19 +23,23 @@ def vault_read(path: str) -> str:
         except Exception:
             pass
 
-        return json.dumps({
-            "path": path,
-            "content": content,
-            "metadata": metadata,
-            "frontmatter": fm_data,
-        })
-    except ValueError as e:
-        return json.dumps({"error": str(e), "path": path})
+        return json.dumps(
+            {
+                "path": path,
+                "content": content,
+                "metadata": metadata,
+                "frontmatter": fm_data,
+            }
+        )
+    except ValueError:
+        # Komunikat generyczny do klienta (audyt s1099, S78) — pełny w logach serwisu.
+        logger.exception(f"vault_read invalid content: {path}")
+        return json.dumps({"error": "Invalid file content", "path": path})
     except FileNotFoundError:
-        return json.dumps({"error": f"File not found: {path}", "path": path})
-    except Exception as e:
-        logger.error(f"vault_read error for {path}: {e}")
-        return json.dumps({"error": str(e), "path": path})
+        return json.dumps({"error": "File not found", "path": path})
+    except Exception:
+        logger.exception(f"vault_read unexpected error: {path}")
+        return json.dumps({"error": "Internal error reading file", "path": path})
 
 
 def vault_batch_read(paths: list[str], include_content: bool = True) -> str:
@@ -67,11 +70,13 @@ def vault_batch_read(paths: list[str], include_content: bool = True) -> str:
 
             results.append(entry)
             found += 1
-        except (ValueError, FileNotFoundError) as e:
-            results.append({"path": path, "error": str(e)})
+        except (ValueError, FileNotFoundError):
+            # Generyczny komunikat do klienta (audyt s1099, S78).
+            results.append({"path": path, "error": "Not found or invalid"})
             missing += 1
-        except Exception as e:
-            results.append({"path": path, "error": str(e)})
+        except Exception:
+            logger.exception(f"vault_batch_read unexpected error: {path}")
+            results.append({"path": path, "error": "Internal error reading file"})
             missing += 1
 
     return json.dumps({"files": results, "found": found, "missing": missing})

--- a/src/obsidian_vault_mcp/tools/read.py
+++ b/src/obsidian_vault_mcp/tools/read.py
@@ -1,6 +1,6 @@
 """Read tools for the Obsidian vault MCP server."""
 
-import json
+from . import json_utils as json
 import logging
 
 import frontmatter

--- a/src/obsidian_vault_mcp/tools/read.py
+++ b/src/obsidian_vault_mcp/tools/read.py
@@ -20,7 +20,7 @@ def vault_read(path: str) -> str:
             post = frontmatter.loads(content)
             if post.metadata:
                 fm_data = post.metadata
-        except Exception:
+        except Exception:  # noqa: S110  # brak/uszkodzony frontmatter jest dozwolony — fm_data zostaje None
             pass
 
         return json.dumps(
@@ -57,7 +57,7 @@ def vault_batch_read(paths: list[str], include_content: bool = True) -> str:
                 post = frontmatter.loads(content)
                 if post.metadata:
                     fm_data = post.metadata
-            except Exception:
+            except Exception:  # noqa: S110  # brak/uszkodzony frontmatter jest dozwolony — fm_data zostaje None
                 pass
 
             entry = {

--- a/src/obsidian_vault_mcp/tools/search.py
+++ b/src/obsidian_vault_mcp/tools/search.py
@@ -1,6 +1,6 @@
 """Search tools for the Obsidian vault MCP server."""
 
-import json
+from . import json_utils as json
 import logging
 import shutil
 import subprocess

--- a/src/obsidian_vault_mcp/tools/search.py
+++ b/src/obsidian_vault_mcp/tools/search.py
@@ -29,12 +29,16 @@ def _search_ripgrep(
         f"--glob={file_pattern}",
         "-i",
         f"--context={context_lines}",
-        query,
-        str(search_path),
     ]
 
     for excluded in config.EXCLUDED_DIRS:
-        cmd.insert(-2, f"--glob=!{excluded}/")
+        cmd.append(f"--glob=!{excluded}/")
+
+    # S53 (audyt s1099): `--` kończy opcje rg — query/ścieżka są pozycyjne nawet gdy query
+    # zaczyna się od `-`. Bez tego query typu `--pre=<cmd>` byłby interpretowany jako flaga
+    # ripgrepa (m.in. `--pre` = uruchomienie preprocesora → RCE). Wykluczenia (--glob=!) muszą
+    # zostać PRZED `--`, dlatego budujemy flagi najpierw, a pozycyjne dokładamy po separatorze.
+    cmd += ["--", query, str(search_path)]
 
     try:
         result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)

--- a/src/obsidian_vault_mcp/tools/search.py
+++ b/src/obsidian_vault_mcp/tools/search.py
@@ -180,11 +180,13 @@ def vault_search(
                 "truncated": truncated,
             }
         )
-    except ValueError as e:
-        return json.dumps({"error": str(e)})
-    except Exception as e:
-        logger.error(f"vault_search error: {e}")
-        return json.dumps({"error": str(e)})
+    except ValueError:
+        # Komunikat generyczny do klienta (audyt s1099, S78) — pełny kontekst w logach serwisu.
+        logger.exception(f"vault_search invalid argument (path_prefix={path_prefix!r})")
+        return json.dumps({"error": "Invalid search path"})
+    except Exception:
+        logger.exception(f"vault_search unexpected error (query={query!r})")
+        return json.dumps({"error": "Internal error during search"})
 
 
 def vault_search_frontmatter(
@@ -227,6 +229,7 @@ def vault_search_frontmatter(
                 "truncated": truncated,
             }
         )
-    except Exception as e:
-        logger.error(f"vault_search_frontmatter error: {e}")
-        return json.dumps({"error": str(e)})
+    except Exception:
+        # Komunikat generyczny do klienta (audyt s1099, S78) — pełny kontekst w logach serwisu.
+        logger.exception(f"vault_search_frontmatter unexpected error (field={field!r})")
+        return json.dumps({"error": "Internal error during search"})

--- a/src/obsidian_vault_mcp/tools/search.py
+++ b/src/obsidian_vault_mcp/tools/search.py
@@ -1,6 +1,5 @@
 """Search tools for the Obsidian vault MCP server."""
 
-from . import json_utils as json
 import logging
 import shutil
 import subprocess
@@ -10,6 +9,7 @@ import frontmatter
 
 from .. import config
 from ..vault import resolve_vault_path
+from . import json_utils as json
 
 logger = logging.getLogger(__name__)
 
@@ -42,7 +42,6 @@ def _search_ripgrep(
         return []
 
     matches = []
-    current_match = None
 
     for line in result.stdout.splitlines():
         try:
@@ -61,11 +60,13 @@ def _search_ripgrep(
             line_number = match_data["line_number"]
             line_text = match_data["lines"]["text"].rstrip("\n")
 
-            matches.append({
-                "path": rel_path,
-                "line_number": line_number,
-                "match_context": line_text,
-            })
+            matches.append(
+                {
+                    "path": rel_path,
+                    "line_number": line_number,
+                    "match_context": line_text,
+                }
+            )
 
             if len(matches) >= max_results:
                 break
@@ -113,11 +114,13 @@ def _search_python(
                 except ValueError:
                     continue
 
-                matches.append({
-                    "path": rel_path,
-                    "line_number": i + 1,
-                    "match_context": context,
-                })
+                matches.append(
+                    {
+                        "path": rel_path,
+                        "line_number": i + 1,
+                        "match_context": context,
+                    }
+                )
 
                 if len(matches) >= max_results:
                     return matches
@@ -166,11 +169,13 @@ def vault_search(
 
         truncated = len(matches) >= max_results
 
-        return json.dumps({
-            "results": matches,
-            "total_matches": len(matches),
-            "truncated": truncated,
-        })
+        return json.dumps(
+            {
+                "results": matches,
+                "total_matches": len(matches),
+                "truncated": truncated,
+            }
+        )
     except ValueError as e:
         return json.dumps({"error": str(e)})
     except Exception as e:
@@ -201,19 +206,23 @@ def vault_search_frontmatter(
             path = item["path"]
             fm = item["frontmatter"]
             title = fm.get("title", Path(path).stem)
-            formatted.append({
-                "path": path,
-                "frontmatter": fm,
-                "title": title,
-            })
+            formatted.append(
+                {
+                    "path": path,
+                    "frontmatter": fm,
+                    "title": title,
+                }
+            )
 
         truncated = len(results) > max_results
 
-        return json.dumps({
-            "results": formatted,
-            "total": len(formatted),
-            "truncated": truncated,
-        })
+        return json.dumps(
+            {
+                "results": formatted,
+                "total": len(formatted),
+                "truncated": truncated,
+            }
+        )
     except Exception as e:
         logger.error(f"vault_search_frontmatter error: {e}")
         return json.dumps({"error": str(e)})

--- a/src/obsidian_vault_mcp/tools/write.py
+++ b/src/obsidian_vault_mcp/tools/write.py
@@ -1,10 +1,11 @@
 """Write tools for the Obsidian vault MCP server."""
 
-import json
+from . import json_utils as json
 import logging
 
 import frontmatter
 
+from ..git_ops import commit_vault_change
 from ..vault import resolve_vault_path, read_file, write_file_atomic
 
 logger = logging.getLogger(__name__)
@@ -33,6 +34,9 @@ def vault_write(path: str, content: str, create_dirs: bool = True, merge_frontma
 
         is_new, size = write_file_atomic(path, content, create_dirs=create_dirs)
 
+        # PDCA-014 auto-commit: keep git tracking consistent for MCP writes
+        commit_vault_change([path], "write")
+
         return json.dumps({"path": path, "created": is_new, "size": size})
     except ValueError as e:
         return json.dumps({"error": str(e), "path": path})
@@ -44,6 +48,7 @@ def vault_write(path: str, content: str, create_dirs: bool = True, merge_frontma
 def vault_batch_frontmatter_update(updates: list[dict]) -> str:
     """Update frontmatter fields on multiple files without changing body content."""
     results = []
+    updated_paths = []
 
     for update in updates:
         file_path = update.get("path", "")
@@ -60,11 +65,16 @@ def vault_batch_frontmatter_update(updates: list[dict]) -> str:
             write_file_atomic(file_path, new_content, create_dirs=False)
 
             results.append({"path": file_path, "updated": True})
+            updated_paths.append(file_path)
         except FileNotFoundError:
             results.append({"path": file_path, "updated": False, "error": "File not found"})
         except ValueError as e:
             results.append({"path": file_path, "updated": False, "error": str(e)})
         except Exception as e:
             results.append({"path": file_path, "updated": False, "error": str(e)})
+
+    # PDCA-014 auto-commit: single commit for the whole batch
+    if updated_paths:
+        commit_vault_change(updated_paths, "batch_frontmatter")
 
     return json.dumps({"results": results})

--- a/src/obsidian_vault_mcp/tools/write.py
+++ b/src/obsidian_vault_mcp/tools/write.py
@@ -38,11 +38,13 @@ def vault_write(path: str, content: str, create_dirs: bool = True, merge_frontma
         commit_vault_change([path], "write")
 
         return json.dumps({"path": path, "created": is_new, "size": size})
-    except ValueError as e:
-        return json.dumps({"error": str(e), "path": path})
-    except Exception as e:
-        logger.error(f"vault_write error for {path}: {e}")
-        return json.dumps({"error": str(e), "path": path})
+    except ValueError:
+        # Komunikat generyczny do klienta (audyt s1099, S78) — pełny kontekst w logach serwisu.
+        logger.exception(f"vault_write invalid path/content: {path}")
+        return json.dumps({"error": "Invalid path or content", "path": path})
+    except Exception:
+        logger.exception(f"vault_write unexpected error: {path}")
+        return json.dumps({"error": "Internal error writing file", "path": path})
 
 
 def vault_batch_frontmatter_update(updates: list[dict]) -> str:
@@ -68,10 +70,13 @@ def vault_batch_frontmatter_update(updates: list[dict]) -> str:
             updated_paths.append(file_path)
         except FileNotFoundError:
             results.append({"path": file_path, "updated": False, "error": "File not found"})
-        except ValueError as e:
-            results.append({"path": file_path, "updated": False, "error": str(e)})
-        except Exception as e:
-            results.append({"path": file_path, "updated": False, "error": str(e)})
+        except ValueError:
+            # Komunikat generyczny do klienta (audyt s1099, S78) — pełny kontekst w logach serwisu.
+            logger.exception(f"batch_frontmatter_update invalid: {file_path}")
+            results.append({"path": file_path, "updated": False, "error": "Invalid path or content"})
+        except Exception:
+            logger.exception(f"batch_frontmatter_update unexpected error: {file_path}")
+            results.append({"path": file_path, "updated": False, "error": "Internal error updating frontmatter"})
 
     # PDCA-014 auto-commit zaktualizowanych plików (łatka git_ops)
     if updated_paths:

--- a/src/obsidian_vault_mcp/tools/write.py
+++ b/src/obsidian_vault_mcp/tools/write.py
@@ -1,12 +1,12 @@
 """Write tools for the Obsidian vault MCP server."""
 
-from . import json_utils as json
 import logging
 
 import frontmatter
 
 from ..git_ops import commit_vault_change
-from ..vault import resolve_vault_path, read_file, write_file_atomic
+from ..vault import read_file, resolve_vault_path, write_file_atomic
+from . import json_utils as json
 
 logger = logging.getLogger(__name__)
 
@@ -34,7 +34,7 @@ def vault_write(path: str, content: str, create_dirs: bool = True, merge_frontma
 
         is_new, size = write_file_atomic(path, content, create_dirs=create_dirs)
 
-        # PDCA-014 auto-commit: keep git tracking consistent for MCP writes
+        # PDCA-014 auto-commit: utrzymuje tracking git dla zapisów MCP (łatka git_ops)
         commit_vault_change([path], "write")
 
         return json.dumps({"path": path, "created": is_new, "size": size})
@@ -73,7 +73,7 @@ def vault_batch_frontmatter_update(updates: list[dict]) -> str:
         except Exception as e:
             results.append({"path": file_path, "updated": False, "error": str(e)})
 
-    # PDCA-014 auto-commit: single commit for the whole batch
+    # PDCA-014 auto-commit zaktualizowanych plików (łatka git_ops)
     if updated_paths:
         commit_vault_change(updated_paths, "batch_frontmatter")
 

--- a/src/obsidian_vault_mcp/vault.py
+++ b/src/obsidian_vault_mcp/vault.py
@@ -4,7 +4,7 @@ import fnmatch
 import os
 import shutil
 import tempfile
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 from . import config
@@ -38,7 +38,7 @@ def resolve_vault_path(relative_path: str) -> Path:
 
 def _iso_timestamp(ts: float) -> str:
     """Convert a Unix timestamp to an ISO 8601 string in UTC."""
-    return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat()
+    return datetime.fromtimestamp(ts, tz=UTC).isoformat()
 
 
 def read_file(relative_path: str) -> tuple[str, dict]:
@@ -63,9 +63,7 @@ def read_file(relative_path: str) -> tuple[str, dict]:
     return content, metadata
 
 
-def write_file_atomic(
-    relative_path: str, content: str, create_dirs: bool = True
-) -> tuple[bool, int]:
+def write_file_atomic(relative_path: str, content: str, create_dirs: bool = True) -> tuple[bool, int]:
     """Write content to a file atomically.
 
     Returns (is_new_file, bytes_written). Writes to a tempfile in the same
@@ -73,9 +71,7 @@ def write_file_atomic(
     """
     encoded = content.encode("utf-8")
     if len(encoded) > config.MAX_CONTENT_SIZE:
-        raise ValueError(
-            f"Content size {len(encoded)} bytes exceeds limit of {config.MAX_CONTENT_SIZE} bytes"
-        )
+        raise ValueError(f"Content size {len(encoded)} bytes exceeds limit of {config.MAX_CONTENT_SIZE} bytes")
 
     path = resolve_vault_path(relative_path)
     is_new = not path.exists()
@@ -100,9 +96,7 @@ def write_file_atomic(
     return is_new, len(encoded)
 
 
-def move_path(
-    source: str, destination: str, create_dirs: bool = True
-) -> bool:
+def move_path(source: str, destination: str, create_dirs: bool = True) -> bool:
     """Move a file or directory from source to destination.
 
     Both paths are relative to the vault root. Raises if the destination
@@ -144,7 +138,7 @@ def delete_path(relative_path: str) -> bool:
 
     # Avoid collisions in .trash by appending a timestamp
     if dest.exists():
-        ts = datetime.now(tz=timezone.utc).strftime("%Y%m%d%H%M%S")
+        ts = datetime.now(tz=UTC).strftime("%Y%m%d%H%M%S")
         dest = trash_dir / f"{path.stem}_{ts}{path.suffix}"
 
     shutil.move(str(path), str(dest))
@@ -209,13 +203,15 @@ def list_directory(
 
             rel = str(entry.relative_to(vault_root))
 
-            results.append({
-                "name": entry.name,
-                "path": rel,
-                "type": "dir" if is_dir else "file",
-                "size": stat.st_size,
-                "modified": _iso_timestamp(stat.st_mtime),
-            })
+            results.append(
+                {
+                    "name": entry.name,
+                    "path": rel,
+                    "type": "dir" if is_dir else "file",
+                    "size": stat.st_size,
+                    "modified": _iso_timestamp(stat.st_mtime),
+                }
+            )
 
             if is_dir:
                 _walk(entry, current_depth + 1)


### PR DESCRIPTION
## Summary
Jawna podłoga tranzytywnej zależności `pydantic-settings>=2.14.2` w `pyproject.toml`, zamyka alert Dependabota **GHSA-4xgf-cpjx-pc3j** (MEDIUM) w usłudze `jarvis-mcp.service` na VPS. Wzorzec identyczny jak jarvis-infra #231.

## Changes
- `pyproject.toml`: dodana podłoga `pydantic-settings>=2.14.2` (tranzytywna przez `mcp[cli]`) + komentarz z genezą alertu.

## Test plan
- [x] `uv lock` rozwiązuje `pydantic-settings` 2.13.1 → **2.14.2** (walidacja podłogi + poprawność pyproject)
- [x] Blast radius: `grep -rniE "pydantic_settings|BaseSettings|secrets_dir"` w `src/` → zero trafień (czysto tranzytywne)
- [ ] VPS: `uv sync` → `2.14.2` zainstalowana → restart `jarvis-mcp.service` → health OK

## Risk / Rollback
Ryzyko minimalne: minor bump tranzytywnej deps, brak importów w kodzie. Rollback: revert commitu + `uv sync` na VPS (wróci do rozwiązania z pyproject bez podłogi).

Uwaga: `uv.lock` jest gitignorowany w tym forku — lock regeneruje `uv sync` na VPS. langsmith N/D (nieobecna w repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)