### PR TITLE
feat: opt-in Cloudflare Access auth mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,104 @@ This is a server that provides network access to your personal notes. Security i
 
 **Your vault is never exposed directly to the internet.** The recommended deployment uses a Cloudflare Tunnel -- an outbound-only encrypted connection. Your machine opens no inbound ports, and the server itself binds to loopback (`127.0.0.1`) by default. The login above is the authentication boundary; you can additionally layer Cloudflare Access (SSO, device posture, IP restrictions) on top for defense in depth.
 
+### Cloudflare Access mode (opt-in)
+
+Instead of the built-in password login + static bearer token, you can hand
+authentication entirely to **Cloudflare Access**. Cloudflare authenticates the user at
+its edge (per-identity SSO / one-time-PIN) and, on every request it forwards through the
+tunnel, injects a signed `Cf-Access-Jwt-Assertion` header carrying the caller's identity.
+The server's only job is to verify that header.
+
+**Enable it** by setting **both** of these (both-or-neither — if either is unset the mode
+is off and the server behaves exactly as it does by default):
+
+| Setting | Description |
+|---------|-------------|
+| `VAULT_MCP_CF_ACCESS_TEAM_DOMAIN` | Your Cloudflare team domain, e.g. `myteam.cloudflareaccess.com` (a bare `myteam` or a full URL is accepted). |
+| `VAULT_MCP_CF_ACCESS_AUD` | The Access application **audience (AUD)** tag from the Cloudflare dashboard. |
+
+Install the extra dependencies (PyJWT + cryptography):
+
+```bash
+pip install 'obsidian-web-mcp[cloudflare-access]'
+```
+
+#### Setting up Cloudflare (Managed OAuth)
+
+This walkthrough exposes the server through a Cloudflare Tunnel and puts Cloudflare
+Access + Managed OAuth in front of it, so an MCP client (e.g. Claude) authenticates
+against Cloudflare and Cloudflare injects the `Cf-Access-Jwt-Assertion` header the server
+verifies. It also shows where the two settings above come from.
+
+1. **Create the Access application.** In the Cloudflare dashboard go to
+   **Access → Access Controls → Create new application → Self-hosted and private →
+   Private destinations**. Set the **subdomain** (e.g. `my-vault-mcp`), the **domain** to
+   one you own (`domain-you-own.com`), and leave the **path** empty. This is the public
+   hostname (`my-vault-mcp.domain-you-own.com`) that your Cloudflare Tunnel forwards to the
+   server on loopback.
+2. **Enable an identity provider.** For the simplest setup, use the built-in
+   **`onetimepin`** provider, which emails a one-time code — enable it under
+   **Access → Identity providers**. (Any other SSO provider works too.)
+3. **Restrict who can get in.** Add an Access **policy** that allows only your own email
+   address (an *Allow* rule with an `Emails` / `Include` condition). This is your
+   per-identity, revocable gate — kill it in the dashboard to cut off access, no redeploy.
+4. **Enable Managed OAuth.** On the application's **Advanced settings** tab, turn on
+   **Managed OAuth** (it is opt-in for self-hosted applications). In **Allowed redirect
+   URIs** — the allowlist for dynamically-registered OAuth clients; entries must use
+   `https` and may end in `/*` — add the Claude client callbacks:
+   - `https://claude.ai/api/mcp/auth_callback`
+   - `https://claude.com/api/mcp/auth_callback`
+5. **Set sensible token lifetimes** (also on **Advanced settings**). Cloudflare uses two
+   durations: **Access token lifetime** (how long each token authenticates a request;
+   default is short, 5–15 min) and **Grant session duration** (how long the refresh token
+   lives; Cloudflare suggests 1–2 weeks for agent/CLI use). Raise the **Grant session
+   duration** so clients are not forced to re-authenticate too often — the refresh happens
+   silently while Cloudflare re-evaluates your policy on each new token.
+6. **Copy the two server settings.** Take the **AUD** from the application's **AUD tag**
+   tab → `VAULT_MCP_CF_ACCESS_AUD`. Find your **team domain** under **Access → Settings**
+   (it looks like `something.cloudflareaccess.com`) → `VAULT_MCP_CF_ACCESS_TEAM_DOMAIN`.
+
+Cloudflare's own guidance confirms the origin's role here: for MCP applications, "the MCP
+server must validate the Access JWT sent in the `Cf-Access-Jwt-Assertion` header" — which
+is exactly what this mode does (RS256 signature against the team's rotating keys at
+`/cdn-cgi/access/certs`, plus `iss`/`aud`/`exp`). See Cloudflare's
+[Managed OAuth](https://developers.cloudflare.com/cloudflare-one/access-controls/applications/http-apps/managed-oauth/)
+and [Validate JWTs](https://developers.cloudflare.com/cloudflare-one/access-controls/applications/http-apps/authorization-cookie/validating-json/)
+docs for the authoritative reference.
+
+Also set `VAULT_MCP_ALLOWED_HOSTS` to that public hostname (e.g.
+`my-vault-mcp.domain-you-own.com`) — the transport's host-allowlist is still enforced in
+this mode. In Claude, add the MCP server using the public URL; Cloudflare's Managed OAuth
+handles the login and forwards authenticated requests to the origin.
+
+When the mode is **on**:
+
+- Every request (except the `/health` liveness probe) must carry a valid
+  `Cf-Access-Jwt-Assertion`. The server verifies its **signature, expiry, audience, and
+  issuer** against Cloudflare's published keys (`https://<team-domain>/cdn-cgi/access/certs`).
+  Anything missing, malformed, expired, wrong-signature, or wrong-audience is rejected
+  with `401`. It **fails closed** — there is no fallback to unauthenticated access or to
+  the static bearer.
+- The app's **own OAuth flow is not served**: the `/oauth/*` routes and the
+  `/.well-known/oauth-*` discovery endpoints are not mounted, and `VAULT_MCP_TOKEN` is not
+  accepted. Cloudflare is the sole auth authority, so there is no public password endpoint
+  to brute-force.
+- The audit log records the caller's **identity** (the token's `email` claim, or its `sub`
+  for service tokens) instead of a shared-token hash.
+
+> **Run it behind Cloudflare — keep the origin unreachable directly.** The signature
+> proves the token is *authentic* (Cloudflare minted it for your team + AUD, and the
+> server rejects anything else); it does **not** prove the *request* transited Cloudflare.
+> An attacker cannot forge a token — they lack Cloudflare's signing key — but a valid,
+> unexpired assertion is just a bearer string. If one leaks (logs, a proxy, a compromised
+> client) or is replayed by a lower-trust user, hitting the origin directly would validate
+> it while bypassing Cloudflare's **Access policy** (per-identity allow-list, device
+> posture, IP rules), its **rate-limiting / bot protection**, and the containment of the
+> token's replay window. The edge is what enforces the policy; the origin only checks
+> authenticity. So keep the server on loopback behind the Cloudflare Tunnel (the default),
+> with `VAULT_MCP_FORWARDED_ALLOW_IPS` trusting only the local proxy — that, not the
+> signature check, is what makes the policy binding.
+
 **Path traversal is blocked at the filesystem layer.** Every file operation resolves paths against the vault root directory and rejects any attempt to escape it -- `..` traversal, symlink following, null byte injection, and dotfile access (`.obsidian`, `.git`, `.trash`) are all caught before they reach the filesystem. The server will never read or write outside your vault directory.
 
 **Writes are atomic.** Every file write goes to a temporary file first, then atomically replaces the target via `os.replace()`. This guarantees that neither Obsidian nor Obsidian Sync ever sees a partially-written file -- the operation either completes fully or doesn't happen at all.
@@ -117,8 +215,8 @@ All configuration is via environment variables:
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `VAULT_PATH` | Yes | `~/Obsidian/MyVault` | Absolute path to your Obsidian vault directory |
-| `VAULT_MCP_TOKEN` | Yes | (none) | 256-bit bearer token validated on every MCP request |
-| `VAULT_OAUTH_PASSWORD` | **Yes** | (none) | Password for the interactive login at `/oauth/authorize`. **If unset, the server refuses to authorize any client (fail-closed).** |
+| `VAULT_MCP_TOKEN` | Yes¹ | (none) | 256-bit bearer token validated on every MCP request. ¹Not used (and not required) in [Cloudflare Access mode](#cloudflare-access-mode-opt-in). |
+| `VAULT_OAUTH_PASSWORD` | **Yes**¹ | (none) | Password for the interactive login at `/oauth/authorize`. **If unset, the server refuses to authorize any client (fail-closed).** ¹Not used in [Cloudflare Access mode](#cloudflare-access-mode-opt-in), where the app's own OAuth is not served. |
 | `VAULT_OAUTH_USERNAME` | No | `obsidian` | Username for the interactive login |
 | `VAULT_MCP_HOST` | No | `127.0.0.1` | Bind address. Loopback by default; set `0.0.0.0` only for deliberate LAN exposure |
 | `VAULT_MCP_PORT` | No | `8420` | Port the HTTP server listens on |
@@ -129,6 +227,8 @@ All configuration is via environment variables:
 | `VAULT_OAUTH_CLIENT_ID` | No | `vault-mcp-client` | Client ID for the headless `client_credentials` grant |
 | `VAULT_OAUTH_CLIENT_SECRET` | No | (none) | Only required for the headless `client_credentials` grant. The Claude/ChatGPT browser flow uses dynamic client registration and does **not** need this. |
 | `VAULT_OAUTH_REDIRECT_URIS` | No | (none) | Comma-separated allowlist of redirect URIs for the static `VAULT_OAUTH_CLIENT_ID` when using the browser flow. Dynamically-registered clients (Claude/ChatGPT) carry their own; leave unset unless you connect a static client through `/oauth/authorize`. |
+| `VAULT_MCP_CF_ACCESS_TEAM_DOMAIN` | No | (none) | Cloudflare team domain, e.g. `myteam.cloudflareaccess.com` (a bare `myteam` or a full URL is accepted). Set **together with** `VAULT_MCP_CF_ACCESS_AUD` to enable [Cloudflare Access mode](#cloudflare-access-mode-opt-in) (both-or-neither; if either is unset the mode is off). When on, the app's own OAuth routes are not served and `VAULT_MCP_TOKEN` / `VAULT_OAUTH_*` are unused — Cloudflare is the sole auth authority. **Validated at startup:** a malformed domain fails the server closed with a clear message. Requires the `cloudflare-access` extra (missing → fail closed at startup). |
+| `VAULT_MCP_CF_ACCESS_AUD` | No | (none) | Cloudflare Access application **audience (AUD)** tag (from the application's *AUD tag* tab). The second half of Cloudflare Access mode; see `VAULT_MCP_CF_ACCESS_TEAM_DOMAIN` above. |
 | `VAULT_DAILY_NOTES_FOLDER` | No | (none) | Folder for the daily-note tools; empty means the vault root |
 | `VAULT_DAILY_NOTES_FORMAT` | No | `%Y-%m-%d` | `strftime` pattern for the daily-note filename |
 | `VAULT_DAILY_NOTES_TEMPLATE` | No | (none) | `strftime` template prepended when a daily note is first created |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,10 @@ dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23",
 ]
+cloudflare-access = [
+    "pyjwt>=2.8",
+    "cryptography>=42",
+]
 
 [project.scripts]
 vault-mcp = "obsidian_vault_mcp.server:main"

--- a/src/obsidian_vault_mcp/cf_access.py
+++ b/src/obsidian_vault_mcp/cf_access.py
@@ -1,0 +1,225 @@
+"""Cloudflare Access authentication mode (optional, opt-in).
+
+When VAULT_MCP_CF_ACCESS_TEAM_DOMAIN and VAULT_MCP_CF_ACCESS_AUD are BOTH set, the
+server trusts Cloudflare Access to authenticate callers at its edge and verifies the
+signed `Cf-Access-Jwt-Assertion` header Cloudflare injects on every request it forwards
+through the tunnel. When either is unset the mode is OFF and this module's middleware is
+never attached.
+
+Fail closed: any verification failure -- missing/malformed/expired token, bad signature,
+wrong audience/issuer, or an unreachable/unparseable key set -- is a 401. PyJWT and
+cryptography are imported lazily so the OFF path never touches them.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import uuid
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+from . import config
+from .context import reset_request_context, set_request_context
+
+logger = logging.getLogger(__name__)
+
+# The header Cloudflare Access injects on every request it forwards through the tunnel.
+_CF_ACCESS_HEADER = "Cf-Access-Jwt-Assertion"
+
+# Only the liveness probe is exempt; every other path requires a valid token.
+_CF_EXEMPT_PATHS = {"/health"}
+
+# Lazily-built PyJWKClient, cached across requests (see _get_jwk_client).
+_jwk_client = None
+_jwk_client_lock = threading.Lock()
+
+
+def _normalize_team_domain(raw: str) -> str:
+    """Return the bare Cloudflare team domain (no scheme, no trailing slash).
+
+    Accepts "myteam", "myteam.cloudflareaccess.com", or a full URL. A bare team name
+    (no dot) gets ".cloudflareaccess.com" appended.
+    """
+    domain = (raw or "").strip()
+    if "://" in domain:
+        domain = domain.split("://", 1)[1]
+    domain = domain.strip("/").strip()
+    if not domain:
+        return ""
+    if "." not in domain:
+        domain = f"{domain}.cloudflareaccess.com"
+    return domain
+
+
+def team_domain() -> str:
+    """The normalized team domain, or "" when unset."""
+    return _normalize_team_domain(config.VAULT_MCP_CF_ACCESS_TEAM_DOMAIN)
+
+
+def _aud() -> str:
+    return (config.VAULT_MCP_CF_ACCESS_AUD or "").strip()
+
+
+def cf_access_enabled() -> bool:
+    """True only when BOTH the team domain and the AUD are configured (both-or-neither)."""
+    return bool(team_domain()) and bool(_aud())
+
+
+def issuer() -> str:
+    """The expected JWT issuer, "https://<team-domain>"."""
+    return f"https://{team_domain()}"
+
+
+def certs_url() -> str:
+    """Cloudflare's JWKS endpoint for the configured team."""
+    return f"https://{team_domain()}/cdn-cgi/access/certs"
+
+
+# A conservative DNS-hostname shape: dot-separated labels of letters/digits/hyphens, no
+# leading/trailing hyphen per label. Cloudflare team domains are always
+# <team>.cloudflareaccess.com, so this is deliberately strict -- it exists to catch a
+# typo, not to accept every RFC-legal name.
+_HOSTNAME_LABEL = r"[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?"
+
+
+def validate_cf_access_config() -> None:
+    """When CF Access mode is on, reject a team domain that isn't a plausible hostname.
+
+    A typo'd VAULT_MCP_CF_ACCESS_TEAM_DOMAIN would otherwise boot a server that
+    fail-closes every request (safe, but silently broken) -- so catch a malformed value
+    at startup with a clear message, matching how VAULT_MCP_PATH is validated. This is a
+    pure FORMAT check: connectivity to the JWKS endpoint is NOT probed here (warm_jwks
+    stays non-fatal so a transient Cloudflare blip can't wedge startup). A no-op unless
+    both settings are set (a half-config is mode-off and only warns, in serve()).
+    """
+    import re
+
+    if not cf_access_enabled():
+        return
+    domain = team_domain()
+    if not re.fullmatch(rf"{_HOSTNAME_LABEL}(?:\.{_HOSTNAME_LABEL})+", domain):
+        raise ValueError(
+            "VAULT_MCP_CF_ACCESS_TEAM_DOMAIN does not look like a valid hostname "
+            f"(normalized to {domain!r}); expected e.g. 'myteam.cloudflareaccess.com'"
+        )
+
+
+class CfAccessError(Exception):
+    """Any failure to verify a Cloudflare Access token. Always maps to a 401."""
+
+
+def require_dependencies() -> None:
+    """Import the JWT libraries, raising CfAccessError with install guidance if absent.
+
+    Called once at startup so a mode-on server with the extra missing fails CLOSED with a
+    clear message, instead of 401ing every request forever at runtime.
+    """
+    try:
+        import cryptography  # noqa: F401
+        import jwt  # noqa: F401
+    except Exception as e:
+        raise CfAccessError(
+            "Cloudflare Access mode is enabled but its dependencies are missing. "
+            "Install them with: pip install 'obsidian-web-mcp[cloudflare-access]'"
+        ) from e
+
+
+def _get_jwk_client():
+    """Return a cached PyJWKClient for the configured team's JWKS endpoint.
+
+    Built on first use (not at import) so the OFF path never imports PyJWT. PyJWKClient
+    caches fetched keys in-process and refreshes on an unknown kid, so verification does
+    not hit Cloudflare per request.
+
+    Thread-safe: double-checked locking ensures only one PyJWKClient is ever constructed
+    even when concurrent requests race on the first call.
+    """
+    global _jwk_client
+    if _jwk_client is None:
+        with _jwk_client_lock:
+            if _jwk_client is None:
+                from jwt import PyJWKClient
+                _jwk_client = PyJWKClient(certs_url())
+    return _jwk_client
+
+
+def verify_access_token(header_value: str) -> dict:
+    """Verify a Cf-Access-Jwt-Assertion value; return its claims or raise CfAccessError.
+
+    Enforces signature (RS256, against Cloudflare's published keys), expiry, audience
+    (AUD), and issuer. Every failure path -- missing/empty header, malformed token,
+    unreachable JWKS, bad signature, expired, wrong aud/iss -- raises CfAccessError.
+    """
+    token = (header_value or "").strip()
+    if not token:
+        raise CfAccessError("missing Cf-Access-Jwt-Assertion header")
+
+    import jwt
+
+    try:
+        signing_key = _get_jwk_client().get_signing_key_from_jwt(token)
+        claims = jwt.decode(
+            token,
+            signing_key.key,
+            algorithms=["RS256"],
+            audience=_aud(),
+            issuer=issuer(),
+            options={"require": ["exp", "iss", "aud"]},
+        )
+    except Exception as e:
+        # Covers PyJWKClientError (unreachable/unparseable JWKS) and every
+        # InvalidTokenError subclass (expired, bad signature, wrong aud/iss, malformed,
+        # missing required claim). Fail closed on all of them.
+        raise CfAccessError(f"token verification failed: {type(e).__name__}") from e
+
+    return claims
+
+
+def warm_jwks() -> None:
+    """Best-effort prefetch of the signing keys at startup. Never raises.
+
+    Per-request verification is fail-closed regardless; this only surfaces an obviously
+    broken team domain early in the logs instead of on the first real request.
+    """
+    try:
+        _get_jwk_client().get_signing_keys()
+    except Exception as e:
+        logger.warning(
+            "Could not prefetch Cloudflare Access signing keys: %s", type(e).__name__
+        )
+
+
+class CloudflareAccessMiddleware(BaseHTTPMiddleware):
+    """Validate the Cf-Access-Jwt-Assertion header on every request except /health.
+
+    Fail closed: any CfAccessError -> 401. No WWW-Authenticate challenge is emitted --
+    that header bootstraps the app's OWN OAuth flow, which is not served in this mode, so
+    advertising it would point clients at a nonexistent auth surface.
+    """
+
+    async def dispatch(self, request: Request, call_next):
+        if request.url.path in _CF_EXEMPT_PATHS:
+            return await call_next(request)
+
+        try:
+            claims = verify_access_token(request.headers.get(_CF_ACCESS_HEADER, ""))
+        except CfAccessError:
+            return JSONResponse(
+                {"error": "Invalid or missing Cloudflare Access token"},
+                status_code=401,
+            )
+
+        # Prefer the human email; fall back to the opaque subject for service tokens so
+        # the audit principal is never empty for a validly-authenticated request. This
+        # only labels the audit record -- it has no bearing on the auth decision above.
+        principal = claims.get("email") or claims.get("sub") or None
+        ctx_token = set_request_context(
+            principal=principal, request_id=uuid.uuid4().hex, client=principal
+        )
+        try:
+            return await call_next(request)
+        finally:
+            reset_request_context(ctx_token)

--- a/src/obsidian_vault_mcp/config.py
+++ b/src/obsidian_vault_mcp/config.py
@@ -80,6 +80,19 @@ VAULT_MCP_FORWARDED_ALLOW_IPS = os.environ.get("VAULT_MCP_FORWARDED_ALLOW_IPS", 
 # the server falls back to the per-request base_url. A trailing slash is ignored.
 VAULT_MCP_PUBLIC_URL = os.environ.get("VAULT_MCP_PUBLIC_URL", "").strip()
 
+# --- Cloudflare Access (optional, opt-in) ------------------------------------------
+# When BOTH of these are set, the server runs in "Cloudflare Access" mode: it trusts
+# Cloudflare to authenticate the caller at its edge (per-identity SSO / one-time-PIN)
+# and verifies the signed Cf-Access-Jwt-Assertion header Cloudflare injects on every
+# request forwarded through the tunnel. When either is empty the mode is OFF and
+# behaviour is identical to today (the app's own OAuth + static bearer). Both-or-neither,
+# mirroring the sibling telegram-catcher deployment.
+#   TEAM_DOMAIN: the Cloudflare team domain, e.g. "myteam.cloudflareaccess.com" (a bare
+#     "myteam" or a full URL is normalized in cf_access.team_domain()).
+#   AUD: the Access application audience (AUD) tag from the Cloudflare dashboard.
+VAULT_MCP_CF_ACCESS_TEAM_DOMAIN = os.environ.get("VAULT_MCP_CF_ACCESS_TEAM_DOMAIN", "").strip()
+VAULT_MCP_CF_ACCESS_AUD = os.environ.get("VAULT_MCP_CF_ACCESS_AUD", "").strip()
+
 
 def advertised_base_url(request_base_url: str) -> str:
     """Return the canonical origin to advertise, with no trailing slash.
@@ -226,3 +239,7 @@ def validate_config() -> None:
     CLOSED with a clear message instead of booting a broken or insecure server.
     """
     _validate_mcp_path(VAULT_MCP_PATH)
+    # Imported lazily: cf_access imports config, so a top-level import here would cycle.
+    # A no-op unless Cloudflare Access mode is on (both settings set).
+    from .cf_access import validate_cf_access_config
+    validate_cf_access_config()

--- a/src/obsidian_vault_mcp/server.py
+++ b/src/obsidian_vault_mcp/server.py
@@ -634,7 +634,10 @@ def build_app(extensions=()):
     from starlette.routing import Route
 
     from .auth import BearerAuthMiddleware
+    from .cf_access import CloudflareAccessMiddleware, cf_access_enabled
     from .oauth import oauth_routes
+
+    cf_on = cf_access_enabled()
 
     app = mcp.streamable_http_app()
 
@@ -651,9 +654,13 @@ def build_app(extensions=()):
 
         app.routes.insert(0, Route("/", mcp_root_probe, methods=["GET", "HEAD"]))
 
-    # Mount OAuth routes (these are excluded from bearer auth via the middleware)
-    for route in oauth_routes:
-        app.routes.insert(0, route)
+    # Mount OAuth routes (excluded from bearer auth via the middleware) -- but NOT in
+    # Cloudflare Access mode: there, Cloudflare is the sole auth authority, so serving
+    # the app's own OAuth + /.well-known discovery would advertise a second, competing
+    # (unauthenticated-login) surface. Skip them entirely.
+    if not cf_on:
+        for route in oauth_routes:
+            app.routes.insert(0, route)
 
     # Health endpoint (bearer-exempt, see auth._AUTH_EXEMPT_PATHS). Surfaces audit status
     # so an operator can confirm the log is enabled and being written.
@@ -724,7 +731,12 @@ def build_app(extensions=()):
                     f"extension route {getattr(r, 'path', r)!r} covers auth-exempt "
                     f"{m} {p!r}; it would be served without bearer authentication"
                 )
-    app.add_middleware(BearerAuthMiddleware)
+    # Cloudflare Access mode swaps the static-bearer middleware for CF JWT verification;
+    # the static bearer is never checked in that mode.
+    if cf_on:
+        app.add_middleware(CloudflareAccessMiddleware)
+    else:
+        app.add_middleware(BearerAuthMiddleware)
     return app
 
 
@@ -760,7 +772,34 @@ def serve(extensions=()):
         logger.error(f"Invalid configuration: {e}")
         sys.exit(1)
 
-    if not VAULT_MCP_TOKEN:
+    # Cloudflare Access mode: fail CLOSED on missing deps, warm the key set, and (below)
+    # suppress the static-token warning that is irrelevant when Cloudflare is the auth
+    # authority. A half-configured pair (exactly one of the two settings) means mode OFF;
+    # warn so it is not silently insecure-by-omission.
+    from .cf_access import (
+        cf_access_enabled,
+        require_dependencies,
+        team_domain,
+        warm_jwks,
+    )
+    from .config import VAULT_MCP_CF_ACCESS_AUD, VAULT_MCP_CF_ACCESS_TEAM_DOMAIN
+
+    cf_on = cf_access_enabled()
+    if cf_on:
+        try:
+            require_dependencies()
+        except Exception as e:
+            logger.error(str(e))
+            sys.exit(1)
+        logger.info("Cloudflare Access mode ENABLED (team: %s)", team_domain())
+        warm_jwks()
+    elif bool(VAULT_MCP_CF_ACCESS_TEAM_DOMAIN) != bool(VAULT_MCP_CF_ACCESS_AUD):
+        logger.warning(
+            "Only one of VAULT_MCP_CF_ACCESS_TEAM_DOMAIN / VAULT_MCP_CF_ACCESS_AUD is "
+            "set; Cloudflare Access mode requires BOTH and is therefore OFF."
+        )
+
+    if not cf_on and not VAULT_MCP_TOKEN:
         logger.warning("VAULT_MCP_TOKEN is not set -- auth will reject all requests")
 
     # Fail CLOSED on a misconfigured audit log: if auditing is requested but the log path
@@ -824,7 +863,10 @@ def serve(extensions=()):
     # Build the Starlette app with auth middleware and OAuth endpoints
     try:
         app = build_app(extensions)
-        logger.info(f"Starting server on {VAULT_MCP_HOST}:{VAULT_MCP_PORT} with bearer auth + OAuth")
+        _auth_mode = "Cloudflare Access" if cf_on else "bearer auth + OAuth"
+        logger.info(
+            f"Starting server on {VAULT_MCP_HOST}:{VAULT_MCP_PORT} with {_auth_mode}"
+        )
     except Exception as e:
         # Fail CLOSED: never fall back to an unauthenticated server.
         logger.error(f"Could not build the authenticated app: {e}")

--- a/tests/test_cf_access.py
+++ b/tests/test_cf_access.py
@@ -1,0 +1,373 @@
+"""Tests for the opt-in Cloudflare Access auth mode."""
+
+import pytest
+
+from obsidian_vault_mcp import cf_access
+from obsidian_vault_mcp import config
+
+
+@pytest.fixture
+def cf_on(monkeypatch):
+    """Enable CF Access mode with a canonical team domain + AUD."""
+    monkeypatch.setattr(config, "VAULT_MCP_CF_ACCESS_TEAM_DOMAIN", "myteam.cloudflareaccess.com")
+    monkeypatch.setattr(config, "VAULT_MCP_CF_ACCESS_AUD", "test-aud-tag")
+
+
+def test_disabled_by_default(monkeypatch):
+    monkeypatch.setattr(config, "VAULT_MCP_CF_ACCESS_TEAM_DOMAIN", "")
+    monkeypatch.setattr(config, "VAULT_MCP_CF_ACCESS_AUD", "")
+    assert cf_access.cf_access_enabled() is False
+
+
+def test_both_or_neither_team_only(monkeypatch):
+    monkeypatch.setattr(config, "VAULT_MCP_CF_ACCESS_TEAM_DOMAIN", "myteam.cloudflareaccess.com")
+    monkeypatch.setattr(config, "VAULT_MCP_CF_ACCESS_AUD", "")
+    assert cf_access.cf_access_enabled() is False
+
+
+def test_both_or_neither_aud_only(monkeypatch):
+    monkeypatch.setattr(config, "VAULT_MCP_CF_ACCESS_TEAM_DOMAIN", "")
+    monkeypatch.setattr(config, "VAULT_MCP_CF_ACCESS_AUD", "test-aud-tag")
+    assert cf_access.cf_access_enabled() is False
+
+
+def test_enabled_when_both_set(cf_on):
+    assert cf_access.cf_access_enabled() is True
+
+
+def test_normalizes_bare_team_name(monkeypatch):
+    monkeypatch.setattr(config, "VAULT_MCP_CF_ACCESS_TEAM_DOMAIN", "myteam")
+    monkeypatch.setattr(config, "VAULT_MCP_CF_ACCESS_AUD", "aud")
+    assert cf_access.team_domain() == "myteam.cloudflareaccess.com"
+
+
+def test_normalizes_full_url(monkeypatch):
+    monkeypatch.setattr(config, "VAULT_MCP_CF_ACCESS_TEAM_DOMAIN", "https://myteam.cloudflareaccess.com/")
+    monkeypatch.setattr(config, "VAULT_MCP_CF_ACCESS_AUD", "aud")
+    assert cf_access.team_domain() == "myteam.cloudflareaccess.com"
+
+
+def test_issuer_and_certs_url(cf_on):
+    assert cf_access.issuer() == "https://myteam.cloudflareaccess.com"
+    assert cf_access.certs_url() == "https://myteam.cloudflareaccess.com/cdn-cgi/access/certs"
+
+
+import time
+
+# --- verify_access_token -----------------------------------------------------------
+
+_TEAM = "myteam.cloudflareaccess.com"
+_ISSUER = f"https://{_TEAM}"
+_AUD = "test-aud-tag"
+
+
+@pytest.fixture(scope="module")
+def rsa_keys():
+    from cryptography.hazmat.primitives.asymmetric import rsa
+    priv = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    return priv, priv.public_key()
+
+
+class _FakeKey:
+    def __init__(self, key):
+        self.key = key
+
+
+class _FakeJwkClient:
+    """Stand-in for PyJWKClient: returns a fixed public key for any token."""
+
+    def __init__(self, public_key):
+        self._public_key = public_key
+
+    def get_signing_key_from_jwt(self, token):
+        return _FakeKey(self._public_key)
+
+
+def _mint(priv, claims, headers=None):
+    import jwt
+    return jwt.encode(claims, priv, algorithm="RS256", headers=headers or {"kid": "test-kid"})
+
+
+def _base_claims(**overrides):
+    claims = {
+        "aud": _AUD,
+        "iss": _ISSUER,
+        "exp": int(time.time()) + 3600,
+        "iat": int(time.time()) - 10,
+        "email": "claude@toye.io",
+        "sub": "cf-subject-123",
+    }
+    claims.update(overrides)
+    return claims
+
+
+@pytest.fixture
+def verify_env(monkeypatch, rsa_keys):
+    """CF mode on + JWKS client stubbed to the in-test public key."""
+    priv, pub = rsa_keys
+    monkeypatch.setattr(config, "VAULT_MCP_CF_ACCESS_TEAM_DOMAIN", _TEAM)
+    monkeypatch.setattr(config, "VAULT_MCP_CF_ACCESS_AUD", _AUD)
+    monkeypatch.setattr(cf_access, "_get_jwk_client", lambda: _FakeJwkClient(pub))
+    return priv, pub
+
+
+def test_valid_token_returns_claims(verify_env):
+    priv, _ = verify_env
+    token = _mint(priv, _base_claims())
+    claims = cf_access.verify_access_token(token)
+    assert claims["email"] == "claude@toye.io"
+    assert claims["sub"] == "cf-subject-123"
+
+
+def test_missing_header_rejected(verify_env):
+    with pytest.raises(cf_access.CfAccessError):
+        cf_access.verify_access_token("")
+
+
+def test_malformed_token_rejected(verify_env):
+    with pytest.raises(cf_access.CfAccessError):
+        cf_access.verify_access_token("not-a-jwt")
+
+
+def test_wrong_audience_rejected(verify_env):
+    priv, _ = verify_env
+    token = _mint(priv, _base_claims(aud="some-other-aud"))
+    with pytest.raises(cf_access.CfAccessError):
+        cf_access.verify_access_token(token)
+
+
+def test_wrong_issuer_rejected(verify_env):
+    priv, _ = verify_env
+    token = _mint(priv, _base_claims(iss="https://evil.cloudflareaccess.com"))
+    with pytest.raises(cf_access.CfAccessError):
+        cf_access.verify_access_token(token)
+
+
+def test_expired_token_rejected(verify_env):
+    priv, _ = verify_env
+    token = _mint(priv, _base_claims(exp=int(time.time()) - 3600))
+    with pytest.raises(cf_access.CfAccessError):
+        cf_access.verify_access_token(token)
+
+
+def test_bad_signature_rejected(verify_env, rsa_keys):
+    from cryptography.hazmat.primitives.asymmetric import rsa
+    attacker = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    token = _mint(attacker, _base_claims())  # signed by the wrong key
+    with pytest.raises(cf_access.CfAccessError):
+        cf_access.verify_access_token(token)
+
+
+def test_missing_exp_rejected(verify_env):
+    priv, _ = verify_env
+    claims = _base_claims()
+    del claims["exp"]
+    token = _mint(priv, claims)
+    with pytest.raises(cf_access.CfAccessError):
+        cf_access.verify_access_token(token)
+
+
+def test_unreachable_jwks_rejected(monkeypatch, rsa_keys):
+    priv, _ = rsa_keys
+    monkeypatch.setattr(config, "VAULT_MCP_CF_ACCESS_TEAM_DOMAIN", _TEAM)
+    monkeypatch.setattr(config, "VAULT_MCP_CF_ACCESS_AUD", _AUD)
+
+    class _Boom:
+        def get_signing_key_from_jwt(self, token):
+            raise RuntimeError("cannot reach Cloudflare")
+
+    monkeypatch.setattr(cf_access, "_get_jwk_client", lambda: _Boom())
+    token = _mint(priv, _base_claims())
+    with pytest.raises(cf_access.CfAccessError):
+        cf_access.verify_access_token(token)
+
+
+def test_alg_none_token_rejected(verify_env):
+    # A forged token with "alg": "none" (unsigned) must be rejected — RS256 is pinned.
+    import jwt
+    try:
+        token = jwt.encode(_base_claims(), key=None, algorithm="none")
+    except Exception:
+        # PyJWT may refuse to mint an alg=none token; that itself means the attack
+        # can't be mounted. Nothing to verify.
+        return
+    with pytest.raises(cf_access.CfAccessError):
+        cf_access.verify_access_token(token)
+
+
+def test_hs256_token_signed_with_public_key_rejected(verify_env, rsa_keys):
+    # Algorithm-confusion: an attacker who knows the RS256 *public* key tries to pass it
+    # as an HS256 shared secret. Must be rejected — only RS256 is accepted.
+    import jwt
+    from cryptography.hazmat.primitives import serialization
+    _priv, pub = rsa_keys
+    pub_pem = pub.public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    try:
+        forged = jwt.encode(_base_claims(), key=pub_pem, algorithm="HS256")
+    except Exception:
+        # PyJWT may refuse to sign HS256 with an asymmetric-looking key; that itself
+        # means the confusion attack can't even be mounted. Nothing to verify.
+        return
+    with pytest.raises(cf_access.CfAccessError):
+        cf_access.verify_access_token(forged)
+
+
+def test_require_dependencies_ok_when_installed():
+    cf_access.require_dependencies()  # installed in the dev env -> no raise
+
+
+def test_require_dependencies_raises_when_missing(monkeypatch):
+    import sys
+    monkeypatch.setitem(sys.modules, "jwt", None)  # forces ImportError on `import jwt`
+    with pytest.raises(cf_access.CfAccessError):
+        cf_access.require_dependencies()
+
+
+def test_warm_jwks_never_raises(monkeypatch):
+    class _Boom:
+        def get_signing_keys(self):
+            raise RuntimeError("down")
+
+    monkeypatch.setattr(cf_access, "_get_jwk_client", lambda: _Boom())
+    cf_access.warm_jwks()  # must swallow and return
+
+
+def test_jwk_client_constructed_once(monkeypatch):
+    """_get_jwk_client() must build exactly one PyJWKClient and return the same instance."""
+    monkeypatch.setattr(config, "VAULT_MCP_CF_ACCESS_TEAM_DOMAIN", _TEAM)
+    monkeypatch.setattr(config, "VAULT_MCP_CF_ACCESS_AUD", _AUD)
+    monkeypatch.setattr(cf_access, "_jwk_client", None)  # reset module cache
+
+    call_count = 0
+
+    class _CountingClient:
+        pass
+
+    def _fake_pyjwkclient(url):
+        nonlocal call_count
+        call_count += 1
+        return _CountingClient()
+
+    monkeypatch.setattr("jwt.PyJWKClient", _fake_pyjwkclient)
+
+    first = cf_access._get_jwk_client()
+    second = cf_access._get_jwk_client()
+
+    assert first is second, "expected the same client instance on both calls"
+    assert call_count == 1, f"PyJWKClient constructed {call_count} times, expected 1"
+
+
+# --- CloudflareAccessMiddleware ----------------------------------------------------
+
+from starlette.applications import Starlette
+from starlette.responses import PlainTextResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from obsidian_vault_mcp import context as context_module
+
+
+@pytest.fixture
+def mw_client(monkeypatch):
+    """A tiny app guarded by the CF middleware, with verify_access_token stubbed.
+
+    The sentinel header value "good-token" verifies to a fixed claim set; anything else
+    raises CfAccessError. Captures the principal the middleware threaded into context.
+    """
+    captured = {}
+
+    def fake_verify(header_value):
+        if header_value == "good-token":
+            return {"email": "claude@toye.io", "sub": "cf-subject-123"}
+        if header_value == "service-token":
+            return {"sub": "svc-abc"}  # service token: no email claim
+        raise cf_access.CfAccessError("bad")
+
+    monkeypatch.setattr(cf_access, "verify_access_token", fake_verify)
+
+    async def echo(request):
+        captured["principal"] = context_module.current_request_context().get("principal")
+        captured["client"] = context_module.current_request_context().get("client")
+        return PlainTextResponse("ok")
+
+    async def health(request):
+        return PlainTextResponse("health-ok")
+
+    app = Starlette(routes=[Route("/", echo), Route("/health", health)])
+    app.add_middleware(cf_access.CloudflareAccessMiddleware)
+    return TestClient(app), captured
+
+
+def test_valid_header_passes_and_sets_email_principal(mw_client):
+    client, captured = mw_client
+    r = client.get("/", headers={"Cf-Access-Jwt-Assertion": "good-token"})
+    assert r.status_code == 200
+    assert r.text == "ok"
+    assert captured["principal"] == "claude@toye.io"
+    assert captured["client"] == "claude@toye.io"
+
+
+def test_service_token_falls_back_to_sub(mw_client):
+    client, captured = mw_client
+    r = client.get("/", headers={"Cf-Access-Jwt-Assertion": "service-token"})
+    assert r.status_code == 200
+    assert captured["principal"] == "svc-abc"
+
+
+def test_missing_header_is_401(mw_client):
+    client, _ = mw_client
+    r = client.get("/")
+    assert r.status_code == 401
+
+
+def test_invalid_header_is_401(mw_client):
+    client, _ = mw_client
+    r = client.get("/", headers={"Cf-Access-Jwt-Assertion": "nope"})
+    assert r.status_code == 401
+
+
+def test_health_is_exempt(mw_client):
+    client, _ = mw_client
+    r = client.get("/health")
+    assert r.status_code == 200
+    assert r.text == "health-ok"
+
+
+# --- validate_cf_access_config (startup format check) ------------------------------
+
+
+def test_validate_cf_access_config_noop_when_off(monkeypatch):
+    monkeypatch.setattr(config, "VAULT_MCP_CF_ACCESS_TEAM_DOMAIN", "")
+    monkeypatch.setattr(config, "VAULT_MCP_CF_ACCESS_AUD", "")
+    cf_access.validate_cf_access_config()  # must not raise
+
+
+def test_validate_cf_access_config_noop_when_half_configured(monkeypatch):
+    # Half-config = mode OFF; the startup check must not fire (serve() warns instead).
+    monkeypatch.setattr(config, "VAULT_MCP_CF_ACCESS_TEAM_DOMAIN", "not a domain!!")
+    monkeypatch.setattr(config, "VAULT_MCP_CF_ACCESS_AUD", "")
+    cf_access.validate_cf_access_config()  # off -> no validation, no raise
+
+
+def test_validate_cf_access_config_accepts_valid_domain(monkeypatch):
+    monkeypatch.setattr(config, "VAULT_MCP_CF_ACCESS_TEAM_DOMAIN", "myteam.cloudflareaccess.com")
+    monkeypatch.setattr(config, "VAULT_MCP_CF_ACCESS_AUD", "aud")
+    cf_access.validate_cf_access_config()  # must not raise
+
+
+def test_validate_cf_access_config_accepts_bare_team_name(monkeypatch):
+    # A bare name normalizes to <name>.cloudflareaccess.com, which is a valid hostname.
+    monkeypatch.setattr(config, "VAULT_MCP_CF_ACCESS_TEAM_DOMAIN", "myteam")
+    monkeypatch.setattr(config, "VAULT_MCP_CF_ACCESS_AUD", "aud")
+    cf_access.validate_cf_access_config()  # must not raise
+
+
+@pytest.mark.parametrize("bad", ["not a domain!!", "team@evil", "has space.com", "under_score.com"])
+def test_validate_cf_access_config_rejects_malformed_domain(monkeypatch, bad):
+    monkeypatch.setattr(config, "VAULT_MCP_CF_ACCESS_TEAM_DOMAIN", bad)
+    monkeypatch.setattr(config, "VAULT_MCP_CF_ACCESS_AUD", "aud")
+    with pytest.raises(ValueError):
+        cf_access.validate_cf_access_config()

--- a/tests/test_cf_access_app.py
+++ b/tests/test_cf_access_app.py
@@ -1,0 +1,81 @@
+"""Integration tests for build_app() under Cloudflare Access mode."""
+
+import pytest
+from starlette.testclient import TestClient
+
+from obsidian_vault_mcp import cf_access, config, server
+
+
+@pytest.fixture
+def cf_app(monkeypatch, tmp_path):
+    """build_app() with CF mode ON and verify_access_token stubbed.
+
+    "good-token" verifies; anything else raises CfAccessError.
+    """
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    monkeypatch.setattr(config, "VAULT_PATH", vault)
+    monkeypatch.setattr(config, "VAULT_MCP_CF_ACCESS_TEAM_DOMAIN", "myteam.cloudflareaccess.com")
+    monkeypatch.setattr(config, "VAULT_MCP_CF_ACCESS_AUD", "test-aud")
+    monkeypatch.setattr(config, "VAULT_MCP_TOKEN", "static-secret")  # must NOT be accepted
+
+    def fake_verify(header_value):
+        if header_value == "good-token":
+            return {"email": "claude@toye.io", "sub": "s"}
+        raise cf_access.CfAccessError("bad")
+
+    monkeypatch.setattr(cf_access, "verify_access_token", fake_verify)
+    return TestClient(server.build_app(), raise_server_exceptions=False)
+
+
+def test_health_ok_without_token(cf_app):
+    assert cf_app.get("/health").status_code == 200
+
+
+def test_oauth_routes_not_served(cf_app):
+    # Probe WITH a valid token: past the auth gate, these routes are simply not mounted
+    # in CF mode, so the router returns 404. (Unauthenticated they'd 401 — only /health
+    # is exempt — so a valid token is what proves "not served".)
+    hdr = {"Cf-Access-Jwt-Assertion": "good-token"}
+    for path in (
+        "/.well-known/oauth-authorization-server",
+        "/.well-known/oauth-protected-resource",
+    ):
+        assert cf_app.get(path, headers=hdr).status_code == 404, path
+    assert cf_app.get("/oauth/authorize", headers=hdr).status_code == 404
+    assert cf_app.post("/oauth/token", headers=hdr).status_code == 404
+    assert cf_app.post("/oauth/register", headers=hdr).status_code == 404
+
+
+def test_static_bearer_not_accepted(cf_app):
+    # A valid static bearer, but no CF header -> rejected in CF mode.
+    r = cf_app.post("/", headers={"Authorization": "Bearer static-secret"})
+    assert r.status_code == 401
+
+
+def test_no_cf_header_is_401(cf_app):
+    assert cf_app.post("/").status_code == 401
+
+
+def test_invalid_cf_header_is_401(cf_app):
+    r = cf_app.post("/", headers={"Cf-Access-Jwt-Assertion": "nope"})
+    assert r.status_code == 401
+
+
+def test_valid_cf_header_reaches_transport(cf_app):
+    # A valid CF token clears auth; the request reaches the MCP transport, which then
+    # rejects this non-MCP GET on its own terms (i.e. NOT a 401 from our middleware).
+    r = cf_app.get("/", headers={"Cf-Access-Jwt-Assertion": "good-token"})
+    assert r.status_code != 401
+
+
+def test_mode_off_still_mounts_oauth(monkeypatch, tmp_path):
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    monkeypatch.setattr(config, "VAULT_PATH", vault)
+    monkeypatch.setattr(config, "VAULT_MCP_CF_ACCESS_TEAM_DOMAIN", "")
+    monkeypatch.setattr(config, "VAULT_MCP_CF_ACCESS_AUD", "")
+    monkeypatch.setattr(config, "VAULT_MCP_TOKEN", "static-secret")
+    client = TestClient(server.build_app(), raise_server_exceptions=False)
+    # Discovery endpoint is served (bearer-exempt) when CF mode is off.
+    assert client.get("/.well-known/oauth-protected-resource").status_code == 200


### PR DESCRIPTION
## What & why

Adds an **opt-in Cloudflare Access** authentication mode. Instead of exposing the built-in password login + static bearer token on the public internet, you can run the server behind a Cloudflare Tunnel with **Cloudflare Access + Managed OAuth**: Cloudflare authenticates the user at its edge (per-identity SSO / one-time-PIN) and injects a signed `Cf-Access-Jwt-Assertion` header on every request; the server's only job is to verify it.

This *reduces* the server's attack surface rather than widening it: it removes the public password endpoint (a brute-force target), gives per-identity, dashboard-revocable access (no redeploy), and lets Cloudflare handle rate-limiting / bot protection. It's strictly opt-in and off by default.

## Activation (both-or-neither)

| Setting | Description |
|---------|-------------|
| `VAULT_MCP_CF_ACCESS_TEAM_DOMAIN` | Cloudflare team domain, e.g. `myteam.cloudflareaccess.com` (bare name or full URL accepted). |
| `VAULT_MCP_CF_ACCESS_AUD` | Access application **AUD** tag. |

Set **both** to enable; if either is unset the mode is off and behavior is **byte-identical to today** (the app's own OAuth + static bearer). Install the deps with `pip install '.[cloudflare-access]'`.

## Behavior when on

- Every request except `/health` must carry a valid `Cf-Access-Jwt-Assertion`. The server verifies **signature (RS256, against Cloudflare's published keys at `/cdn-cgi/access/certs`), expiry, audience, and issuer**, and requires the `exp`/`iss`/`aud` claims. Missing / malformed / expired / wrong-signature / wrong-audience / wrong-issuer / unreachable-JWKS → `401`. **Fails closed** — never falls back to unauthenticated access or the static bearer.
- The app's own OAuth routes and `/.well-known/oauth-*` discovery are **not mounted**, and `VAULT_MCP_TOKEN` is **not accepted**. Cloudflare is the sole auth authority (no second, competing auth surface).
- The audit log records the caller's **identity** (`email` claim, or `sub` for service tokens) instead of a shared-token hash.

## Implementation notes

- New self-contained `src/obsidian_vault_mcp/cf_access.py` (config gate, JWKS verification, `CloudflareAccessMiddleware`). `build_app()` branches once on `cf_access_enabled()`; the off path is unchanged.
- **New dependency:** `pyjwt` + `cryptography`, shipped as the optional extra `cloudflare-access` (not in the base install) and imported lazily, so the default install and the off path never touch them. CF mode on + libs missing → **fail closed at startup** (`sys.exit(1)` with an install hint).
- Team domain is **validated at startup** (fail closed on a malformed value); connectivity stays a non-fatal warm-up warning so a transient Cloudflare blip can't wedge boot.
- Transport host-allowlist and the `/health` probe are unchanged. Alg-confusion (`alg=none`, HS256-with-public-key) is covered by the RS256 pin and regression tests.

## Security note on the JWKS fetch

The JWKS is fetched via PyJWT's `PyJWKClient`, which restricts schemes to `http(s)` and uses a request timeout, but does not itself block redirects or cap the response body. This is intentionally left as-is: the fetch URL is **operator config** (`VAULT_MCP_CF_ACCESS_TEAM_DOMAIN`), not request-influenced, and is always `https://<team>.cloudflareaccess.com/...`, so it isn't an attacker-controlled/SSRF vector. Happy to add a no-redirect + size-capped opener (mirroring the heartbeat) if you'd prefer belt-and-suspenders.

## Testing

Full suite green locally (no CI on the repo): **415 passed** (373 pre-existing + 42 new). New tests mint real RS256 tokens with an in-test RSA key and exercise the real `jwt.decode` path (only the JWKS *fetch* is stubbed). Coverage includes both modes and the abuse cases: missing / malformed / expired / wrong-aud / wrong-iss / bad-signature / `alg=none` / HS256-confusion → 401; OAuth routes not served; static bearer not accepted; `/health` open; and mode-off still mounts OAuth (non-breaking).

## Docs

README gets a "Cloudflare Access mode (opt-in)" section (what it does, the two settings, the install extra, a Cloudflare Managed OAuth setup walkthrough, and a "run behind Cloudflare" caveat about token replay / policy bypass), and both settings are added to the master configuration table.

## Checklist

- [x] One self-contained change, rebased on `main` (not stacked on another PR)
- [x] Full test suite passes locally (`pytest`) — 415 passed
- [x] New/abuse inputs covered by tests; the tool wiring is tested, not just helpers
- [x] Auth: no new routes; the new middleware exempts only `/health` and fails closed; `VAULT_MCP_PATH` still can't collide with an exempt path
- [x] Paths go through `resolve_vault_path` — N/A (no new path handling)
- [x] No `shell=True` on request input; subprocess env scrubbed — N/A (no subprocess)
- [x] Outbound requests: the JWKS fetch is `https`/scheme-restricted + timed out; URL is operator-config, not request-influenced (redirect/size-cap rationale above)
- [x] No secrets/tokens/capability URLs in logs (only exception type + the public team domain)
- [x] New config validated at startup, fails closed, off by default (both-or-neither; malformed domain and missing deps both fail closed)
- [x] Optional/heavy deps are an optional extra (`.[cloudflare-access]`), imported lazily; CF mode on + missing → fail closed at startup
- [x] Writes go through the atomic write path — N/A (no writes)
- [x] README updated for new env vars / dependencies
