### PR TITLE
Fix startup with MCP SDK v2 releases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Secure remote MCP server for Obsidian vaults -- access your notes
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "mcp[cli]>=1.9.0",
+    "mcp[cli]>=1.9.0,<2",
     "python-frontmatter>=1.1.0",
     "ruamel.yaml>=0.18",
     "pydantic>=2.0",


### PR DESCRIPTION
Pins the MCP Python SDK below v2 because the project still uses the v1 mcp.server.fastmcp API. Without this constraint, fresh installations can resolve v2 and fail at startup.

Fixes #69.