### PR TITLE
fix: claude.ai connector interop — OIDC discovery alias, root-level oauth endpoint aliases, longer keep-alive

### DIFF
--- a/src/obsidian_vault_mcp/auth.py
+++ b/src/obsidian_vault_mcp/auth.py
@@ -16,9 +16,13 @@ _AUTH_EXEMPT_PATHS = {
     "/health",
     "/.well-known/oauth-authorization-server",
     "/.well-known/oauth-protected-resource",
+    "/.well-known/openid-configuration",
     "/oauth/authorize",
     "/oauth/token",
     "/oauth/register",
+    "/register",
+    "/authorize",
+    "/token",
 }
 
 # (method, path) pairs exempt from auth. The MCP spec 2025-06-18 probe on / must

--- a/src/obsidian_vault_mcp/oauth.py
+++ b/src/obsidian_vault_mcp/oauth.py
@@ -458,8 +458,17 @@ async def oauth_register(request: Request) -> JSONResponse:
 # Starlette routes to mount on the app
 oauth_routes = [
     Route("/.well-known/oauth-authorization-server", oauth_metadata, methods=["GET"]),
+    # Alias: some clients (claude.ai, 2026-08) probe the OIDC discovery path and treat
+    # a non-2xx as fatal instead of falling back to oauth-authorization-server.
+    Route("/.well-known/openid-configuration", oauth_metadata, methods=["GET"]),
     Route("/.well-known/oauth-protected-resource", oauth_protected_resource, methods=["GET"]),
     Route("/oauth/authorize", oauth_authorize, methods=["GET", "POST"]),
     Route("/oauth/token", oauth_token, methods=["POST"]),
     Route("/oauth/register", oauth_register, methods=["POST"]),
+    # Alias: RFC-default registration path clients fall back to when OIDC discovery fails.
+    Route("/register", oauth_register, methods=["POST"]),
+    # Aliases: clients that registered via the fallback path also assume root-level
+    # authorize/token endpoints instead of reading them from AS metadata.
+    Route("/authorize", oauth_authorize, methods=["GET", "POST"]),
+    Route("/token", oauth_token, methods=["POST"]),
 ]

--- a/src/obsidian_vault_mcp/server.py
+++ b/src/obsidian_vault_mcp/server.py
@@ -841,6 +841,10 @@ def serve(extensions=()):
         # caller spoof the advertised OAuth origin via X-Forwarded-Host.
         proxy_headers=True,
         forwarded_allow_ips=VAULT_MCP_FORWARDED_ALLOW_IPS,
+        # Default 5s closes idle keep-alive sockets faster than remote clients
+        # (claude.ai's connection pool, via the Funnel relay) notice, so they
+        # reuse dead connections and see 502s. 75s matches nginx's default.
+        timeout_keep_alive=75,
     )
 
 


### PR DESCRIPTION
Three small interop fixes (17 lines) that together let the claude.ai remote connector complete OAuth and stay connected. Observed against claude.ai as of Aug 2026, server exposed via Tailscale Funnel.

## Problems

1. **claude.ai probes `/.well-known/openid-configuration` and treats a non-2xx as fatal** instead of falling back to `/.well-known/oauth-authorization-server`, so the connector never reaches the authorize step.
2. **Clients that register via the RFC-default `/register` fallback assume root-level `/authorize` and `/token`** rather than reading endpoint URLs from AS metadata — those paths 404/401 here.
3. **uvicorn's 5s `timeout_keep_alive` closes idle sockets faster than claude.ai's connection pool (via the Funnel relay) notices**, so it reuses dead connections and surfaces intermittent 502s after a successful connect.

## Changes

- Serve the existing AS metadata handler at `/.well-known/openid-configuration` as an alias.
- Alias `/register`, `/authorize`, `/token` to the existing `/oauth/*` handlers and add them to the auth-exempt set.
- `timeout_keep_alive=75` (matches nginx's default).

No behavior change for clients already using the `/oauth/*` paths and standard discovery.

## Testing

Deployed on the fork behind Tailscale Funnel: claude.ai connector previously failed at auth; with this patch it completes the OAuth flow and lists tools/resources/prompts (verified in server logs). Local `/oauth/*` paths still work unchanged.

Related to the interop line of #19/#33; offered per #50.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VfBnn64rraj4PUcwA7tUUU