### PR TITLE
Harden OAuth with per-client tokens and server-side read-only policy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,24 @@
+# Required runtime paths and credentials
+VAULT_PATH=/absolute/path/to/ObsidianVault
+VAULT_MCP_TOKEN=replace-with-32-byte-random-hex
+VAULT_OAUTH_USERNAME=obsidian
+VAULT_OAUTH_PASSWORD=replace-with-an-interactive-login-secret
+
+# Pin the public OAuth resource in reverse-proxy deployments
+VAULT_MCP_PUBLIC_URL=https://vault-mcp.example.com
+VAULT_MCP_ALLOWED_HOSTS=vault-mcp.example.com
+
+# Persistent per-client OAuth lifecycle state. Keep this outside VAULT_PATH.
+VAULT_OAUTH_STATE_PATH=~/.local/share/vault-mcp/oauth_state.sqlite3
+VAULT_OAUTH_ACCESS_TOKEN_TTL_SECONDS=86400
+
+# One-way import from the legacy plaintext client registry. Leave the approval
+# list empty unless specific reviewed client IDs may temporarily retain
+# legacy_full policy during migration.
+OAUTH_CLIENTS_PATH=~/.local/share/vault-mcp/oauth_clients.json
+VAULT_OAUTH_APPROVED_LEGACY_CLIENT_IDS=
+
+# Optional static confidential client for client_credentials or browser flow.
+VAULT_OAUTH_CLIENT_ID=vault-mcp-client
+VAULT_OAUTH_CLIENT_SECRET=
+VAULT_OAUTH_REDIRECT_URIS=

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ All configuration is via environment variables:
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
 | `VAULT_PATH` | Yes | `~/Obsidian/MyVault` | Absolute path to your Obsidian vault directory |
-| `VAULT_MCP_TOKEN` | Yes | (none) | 256-bit bearer token validated on every MCP request |
+| `VAULT_MCP_TOKEN` | Yes | (none) | 256-bit master bearer. Protected requests also accept validated durable OAuth access tokens under their stored policy. |
 | `VAULT_OAUTH_PASSWORD` | **Yes** | (none) | Password for the interactive login at `/oauth/authorize`. **If unset, the server refuses to authorize any client (fail-closed).** |
 | `VAULT_OAUTH_USERNAME` | No | `obsidian` | Username for the interactive login |
 | `VAULT_MCP_HOST` | No | `127.0.0.1` | Bind address. Loopback by default; set `0.0.0.0` only for deliberate LAN exposure |
@@ -166,11 +166,7 @@ outside-vault, ownership, mode, and symlink checks as the live state. Neither
 inventory nor revoke output includes client secrets, authorization codes, or
 complete bearer tokens.
 
-**Deployment boundary:** the OAuth endpoints now issue durable per-client
-tokens, while MCP request dispatch still recognizes the existing
-`VAULT_MCP_TOKEN`. Per-client bearer validation and capability enforcement are
-a separate server-boundary change. Do not deploy this revision alone as a
-connector cutover.
+Every protected request accepts either the configured `VAULT_MCP_TOKEN` master credential or a durable `v1.*` OAuth access token. Dynamic and freshly reauthorized clients receive the fail-closed `vault_readonly_v1` policy: discovery and dispatch expose exactly `vault_batch_read`, `vault_list`, `vault_read`, `vault_search`, and `vault_search_frontmatter`; resources and prompts remain unavailable. Approved imported clients temporarily retain `legacy_full`, matching master access. Invalid, expired, revoked, wrong-resource, and unknown-policy credentials are rejected before MCP dispatch. Non-MCP extension routes require full access.
 
 ## Audit logging
 
@@ -179,13 +175,10 @@ JSON line. Auditing is **off by default**; with no path set there is no overhead
 searches are logged too when `VAULT_AUDIT_LOG_INCLUDE_READS` is on (off by default, since
 reads are high-volume).
 
-Each record carries: `timestamp` (UTC), `token_id_hash` (SHA-256 of the bearer token -- the
-raw token is never written), `client_id` (a best-effort User-Agent hint), `operation`,
-`target_path`, `size_before`/`size_after`, `checksum_before`/`checksum_after` (SHA-256),
-`request_id`, `operation_status`, and `error`. Example line:
+Each record carries: `timestamp` (UTC), `token_id_hash` (the validated credential's stable SHA-256 identifier; the raw bearer is never retained), `principal_id` (`master` or `oauth:<client-id>`), `client_id` (the durable OAuth client ID, or `null` for master), `auth_policy`, `operation`, `target_path`, `size_before`/`size_after`, `checksum_before`/`checksum_after` (SHA-256), `request_id`, `operation_status`, and `error`. Example line:
 
 ```json
-{"checksum_after":"9f86d0…","checksum_before":null,"client_id":"claude","error":null,"operation":"vault_write","operation_status":"success","request_id":"a1b2…","size_after":42,"size_before":null,"target_path":"notes/today.md","timestamp":"2026-06-14T18:30:00+00:00","token_id_hash":"5e88…"}
+{"auth_policy":"legacy_full","checksum_after":"9f86d0…","checksum_before":null,"client_id":"vault-mcp-a1b2…","error":null,"operation":"vault_write","operation_status":"success","principal_id":"oauth:vault-mcp-a1b2…","request_id":"a1b2…","size_after":42,"size_before":null,"target_path":"notes/today.md","timestamp":"2026-08-17T18:30:00+00:00","token_id_hash":"5e88…"}
 ```
 
 **Put the log outside the vault.** `VAULT_AUDIT_LOG_PATH` must resolve outside `VAULT_PATH`.
@@ -213,7 +206,7 @@ The Claude desktop and mobile apps can connect to remote MCP servers via OAuth.
 4. Claude registers automatically (dynamic client registration) and discovers the OAuth endpoints
 5. Claude opens a browser window at the server's `/oauth/authorize`
 6. **Sign in** with your `VAULT_OAUTH_USERNAME` / `VAULT_OAUTH_PASSWORD`; the server then issues the authorization and redirects back
-7. Claude now has access to all nine vault tools -- on desktop and mobile
+7. Claude now has read-only access to the five authorized vault tools on desktop and mobile
 
 For local-only use (no tunnel), point Claude at `http://localhost:8420`.
 
@@ -357,9 +350,12 @@ from obsidian_vault_mcp.write_events import register_write_listener
 
 
 class MyExtension(Extension):
-    def register_tools(self, mcp):
-        # add @mcp.tool tools BEFORE the app/tool schema is built
-        ...
+    def register_tools(self, registrar):
+        # tools registered here are denied to restricted clients by default;
+        # set required_capability only when intentionally reusing a capability
+        @registrar.tool(name="my_tool")
+        def my_tool():
+            return "ok"
 
     def before_indexes_start(self, frontmatter_index):
         # e.g. attach a change listener so no change is missed once the index starts
@@ -372,7 +368,7 @@ class MyExtension(Extension):
         ...
 
     def register_routes(self, app):
-        # add Starlette routes (bearer-protected like the rest of the surface)
+        # add a protected non-MCP route; never shadow the MCP transport path
         ...
 
     def shutdown(self):
@@ -396,11 +392,12 @@ Two things worth knowing:
 - **Extension routes are authenticated, with a footgun guard.** Routes are registered
   before the bearer-auth middleware, so they require the bearer token like every other
   route. As a guardrail against honest mistakes, `build_app()` **fails closed** if an
-  extension adds a route that would cover an auth-exempt path (`/health`, `/oauth/*`,
-  `/.well-known/*`, or the off-root `GET/HEAD /` probe) — including via a wildcard
-  pattern — and rejects extension `Mount`s and `WebSocketRoute`s outright. This catches
-  accidents; it is **not** a boundary against a hostile extension (which, running
-  in-process, could bypass it anyway — see the trust model above).
+  extension route covers the MCP transport path (which would bypass per-client MCP policy)
+  or an auth-exempt path (`/health`, `/oauth/*`, `/.well-known/*`, or the off-root
+  `GET/HEAD /` probe), including via a wildcard pattern. Extension `Mount`s and
+  `WebSocketRoute`s are rejected outright. This catches accidents; it is **not** a
+  boundary against a hostile extension (which, running in-process, could bypass it anyway
+  — see the trust model above).
 - **The stock server is unaffected.** With no extensions, `serve()` behaves exactly like
   the previous `main()`; `FrontmatterIndex` change listeners and write listeners are a no-op
   with none registered.

--- a/README.md
+++ b/README.md
@@ -129,6 +129,10 @@ All configuration is via environment variables:
 | `VAULT_OAUTH_CLIENT_ID` | No | `vault-mcp-client` | Client ID for the headless `client_credentials` grant |
 | `VAULT_OAUTH_CLIENT_SECRET` | No | (none) | Only required for the headless `client_credentials` grant. The Claude/ChatGPT browser flow uses dynamic client registration and does **not** need this. |
 | `VAULT_OAUTH_REDIRECT_URIS` | No | (none) | Comma-separated allowlist of redirect URIs for the static `VAULT_OAUTH_CLIENT_ID` when using the browser flow. Dynamically-registered clients (Claude/ChatGPT) carry their own; leave unset unless you connect a static client through `/oauth/authorize`. |
+| `VAULT_OAUTH_STATE_PATH` | No | `~/.local/share/vault-mcp/oauth_state.sqlite3` | Versioned SQLite lifecycle store. Must remain outside `VAULT_PATH`; its final directory must be owner-only (`0700`). The database and SQLite sidecars must be owner-only (`0600`). Unsafe paths, ownership, modes, or symlinks fail startup before SQLite opens. |
+| `VAULT_OAUTH_ACCESS_TOKEN_TTL_SECONDS` | No | `86400` | Lifetime of newly issued per-client access tokens. Must be an integer from 1 second through 30 days (`2592000`); invalid values fail startup. |
+| `VAULT_OAUTH_APPROVED_LEGACY_CLIENT_IDS` | No | (none) | Comma-separated IDs from the legacy JSON registry that may retain temporary `legacy_full` policy during the one-way import. Every other imported client requires fresh interactive authorization and receives `vault_readonly_v1`. An allowlisted ID absent from the source aborts migration. |
+| `OAUTH_CLIENTS_PATH` | No | `~/.local/share/vault-mcp/oauth_clients.json` | Legacy plaintext client registry read once for migration. The source must be an owner-only regular file outside the vault. It is removed only after the SQLite import commits durably. |
 | `VAULT_DAILY_NOTES_FOLDER` | No | (none) | Folder for the daily-note tools; empty means the vault root |
 | `VAULT_DAILY_NOTES_FORMAT` | No | `%Y-%m-%d` | `strftime` pattern for the daily-note filename |
 | `VAULT_DAILY_NOTES_TEMPLATE` | No | (none) | `strftime` template prepended when a daily note is first created |
@@ -138,6 +142,35 @@ All configuration is via environment variables:
 | `VAULT_AUDIT_LOG_INCLUDE_READS` | No | `false` | Also record read/search operations (`1`/`true`/`yes`/`on`). Off by default; mutations are always logged once the audit log is enabled. |
 
 Generate secrets with: `python -c "import secrets; print(secrets.token_hex(32))"`
+
+### OAuth lifecycle state
+
+Dynamic client secrets, authorization codes, and access tokens are never stored
+in plaintext. SQLite contains domain-separated verifiers plus metadata. Codes
+expire after exactly five minutes and are consumed atomically; access tokens use
+the versioned `v1.<identifier>.<secret>` wire format, bounded expiry, independent
+revocation, canonical resource binding, and a capability snapshot.
+
+Local operator commands expose metadata only:
+
+```bash
+vault-mcp-oauth clients list
+vault-mcp-oauth clients revoke <client-id>
+vault-mcp-oauth tokens list [--client-id <client-id>] [--active-only]
+vault-mcp-oauth tokens revoke <token-id>
+vault-mcp-oauth backup /secure/path/oauth_state.sqlite3
+```
+
+The backup command uses SQLite's online backup API and applies the same
+outside-vault, ownership, mode, and symlink checks as the live state. Neither
+inventory nor revoke output includes client secrets, authorization codes, or
+complete bearer tokens.
+
+**Deployment boundary:** the OAuth endpoints now issue durable per-client
+tokens, while MCP request dispatch still recognizes the existing
+`VAULT_MCP_TOKEN`. Per-client bearer validation and capability enforcement are
+a separate server-boundary change. Do not deploy this revision alone as a
+connector cutover.
 
 ## Audit logging
 
@@ -284,7 +317,9 @@ src/obsidian_vault_mcp/
     extensions.py           # Extension seam: base class for adding tools/routes/hooks
     frontmatter_index.py    # In-memory YAML frontmatter index with filesystem watcher
     models.py               # Pydantic input validation models
-    oauth.py                # OAuth 2.0 authorization code flow with PKCE
+    oauth.py                # OAuth routes and confidential-client exchange
+    oauth_admin.py          # Metadata-only lifecycle inventory/revoke/backup CLI
+    oauth_state.py          # Transactional SQLite OAuth lifecycle store
     serialization.py        # JSON encoder for tool responses (dates, etc.)
     server.py               # FastMCP server setup, tool registration, entry point
     vault.py                # Core filesystem operations (path security, atomic writes)
@@ -300,6 +335,8 @@ tests/
     test_frontmatter.py     # Frontmatter index and query tests
     test_issues_5_28.py     # Regression tests for date serialization + index rebuild
     test_oauth.py           # OAuth flow, PKCE, and auth-bypass regression tests
+    test_oauth_admin.py     # Metadata-only local operator operations
+    test_oauth_state.py     # Persistence, migration, expiry, and concurrency
     test_tools.py           # Integration tests for tool functions
     test_vault.py           # Path resolution and file operation tests
 scripts/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Secure remote MCP server for Obsidian vaults -- access your notes
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "mcp[cli]>=1.9.0",
+    "mcp[cli]==1.28.1",
     "python-frontmatter>=1.1.0",
     "ruamel.yaml>=0.18",
     "pydantic>=2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dev = [
 
 [project.scripts]
 vault-mcp = "obsidian_vault_mcp.server:main"
+vault-mcp-oauth = "obsidian_vault_mcp.oauth_admin:_entrypoint"
 
 [build-system]
 requires = ["hatchling"]

--- a/src/obsidian_vault_mcp/audit.py
+++ b/src/obsidian_vault_mcp/audit.py
@@ -127,12 +127,6 @@ def _now_utc() -> datetime:
     return datetime.now(timezone.utc)
 
 
-def _hash_value(value: str | None) -> str | None:
-    if not value:
-        return None
-    return hashlib.sha256(value.encode("utf-8")).hexdigest()
-
-
 def _sha256_file(path: Path) -> str | None:
     if not path.is_file():
         return None
@@ -168,7 +162,9 @@ def before_target_path(operation: str, context: dict[str, Any]) -> Any:
     return context.get("path") or context.get("source")
 
 
-def infer_target_path(operation: str, context: dict[str, Any], result: dict[str, Any] | None = None) -> Any:
+def infer_target_path(
+    operation: str, context: dict[str, Any], result: dict[str, Any] | None = None
+) -> Any:
     """Best-effort target path from the call context and the parsed result payload."""
     result = result or {}
     if operation == "vault_move":
@@ -176,7 +172,11 @@ def infer_target_path(operation: str, context: dict[str, Any], result: dict[str,
     if operation == "vault_batch_frontmatter_update":
         results = result.get("results")
         if isinstance(results, list):
-            paths = [item.get("path") for item in results if isinstance(item, dict) and item.get("path")]
+            paths = [
+                item.get("path")
+                for item in results
+                if isinstance(item, dict) and item.get("path")
+            ]
             if paths:
                 return paths
     return result.get("path") or context.get("path") or context.get("source")
@@ -193,19 +193,22 @@ def build_audit_record(
 ) -> dict[str, Any]:
     """Build one normalized audit record from the current request context."""
     ctx = current_request_context()
+    principal = ctx.principal if ctx is not None else None
     before = before or {"size": None, "checksum": None}
     after = after or {"size": None, "checksum": None}
     return {
         "timestamp": _now_utc().isoformat(),
-        "token_id_hash": _hash_value(ctx.get("principal")),
-        "client_id": ctx.get("client"),
+        "token_id_hash": (principal.credential_id if principal is not None else None),
+        "principal_id": (principal.principal_id if principal is not None else None),
+        "client_id": principal.client_id if principal is not None else None,
+        "auth_policy": principal.policy if principal is not None else None,
+        "request_id": ctx.request_id if ctx is not None else uuid.uuid4().hex,
         "operation": operation,
         "target_path": target_path,
         "size_before": before.get("size"),
         "size_after": after.get("size"),
         "checksum_before": before.get("checksum"),
         "checksum_after": after.get("checksum"),
-        "request_id": ctx.get("request_id") or uuid.uuid4().hex,
         "operation_status": operation_status,
         "error": error,
     }

--- a/src/obsidian_vault_mcp/auth.py
+++ b/src/obsidian_vault_mcp/auth.py
@@ -1,5 +1,8 @@
-"""Bearer token authentication middleware for the vault MCP server."""
+"""Bearer authentication and principal binding for the vault MCP server."""
 
+from __future__ import annotations
+
+import hashlib
 import hmac
 import uuid
 
@@ -9,9 +12,17 @@ from starlette.responses import JSONResponse
 
 from . import config
 from .config import VAULT_MCP_TOKEN
-from .context import reset_request_context, set_request_context
+from .context import (
+    AuthenticatedPrincipal,
+    reset_request_context,
+    set_request_context,
+)
+from .oauth_state import (
+    LEGACY_FULL,
+    VAULT_READONLY_CAPABILITIES,
+    VAULT_READONLY_V1,
+)
 
-# Paths that don't require bearer auth (OAuth flow + health)
 _AUTH_EXEMPT_PATHS = {
     "/health",
     "/.well-known/oauth-authorization-server",
@@ -21,32 +32,100 @@ _AUTH_EXEMPT_PATHS = {
     "/oauth/register",
 }
 
-# (method, path) pairs exempt from auth. The MCP spec 2025-06-18 probe on / must
-# answer GET/HEAD without credentials. This is ONLY active when MCP is mounted off
-# root (VAULT_MCP_PATH != "/"); when MCP is at root the transport owns GET/HEAD /
-# and must stay fully authenticated, so the set is empty and behaviour is unchanged.
 _AUTH_EXEMPT_METHOD_PATHS = (
     {("GET", "/"), ("HEAD", "/")} if config.VAULT_MCP_PATH != "/" else set()
 )
 
 
 def _www_authenticate(request: Request, error: str) -> str:
-    """RFC 9728 challenge header pointing clients at the protected-resource metadata.
-
-    Without it a 401 just looks like a failed request; with it, a spec-compliant MCP
-    client (e.g. Claude Code, ChatGPT) knows to fetch the metadata and start the OAuth
-    flow -- "Needs authentication" instead of "Failed to connect". The resource URL is
-    derived from VAULT_MCP_PUBLIC_URL when set (otherwise request.base_url), matching the
-    oauth_metadata / oauth_protected_resource endpoints. Pinning the public URL keeps a
-    spoofed Host/X-Forwarded-Host header from pointing clients at an attacker's server.
-    """
+    """Build an RFC 9728 challenge pinned to the advertised resource."""
     base_url = config.advertised_base_url(str(request.base_url))
     resource_metadata = f"{base_url}/.well-known/oauth-protected-resource"
-    return f'Bearer realm="mcp", resource_metadata="{resource_metadata}", error="{error}"'
+    return (
+        f'Bearer realm="mcp", resource_metadata="{resource_metadata}", error="{error}"'
+    )
+
+
+def _credential_digest(token: str) -> str:
+    """Return a stable audit identifier without retaining the bearer."""
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def _master_matches(token: str) -> bool:
+    """Compare fixed-length digests so token length does not affect comparison."""
+    if not VAULT_MCP_TOKEN:
+        return False
+    candidate = hashlib.sha256(token.encode("utf-8")).digest()
+    configured = hashlib.sha256(VAULT_MCP_TOKEN.encode("utf-8")).digest()
+    return hmac.compare_digest(candidate, configured)
+
+
+def _canonical_resource(request: Request) -> str:
+    return config.advertised_base_url(str(request.base_url)).rstrip("/")
+
+
+def _authenticate_bearer(
+    request: Request,
+    token: str,
+) -> AuthenticatedPrincipal | None:
+    credential_id = _credential_digest(token)
+    if _master_matches(token):
+        return AuthenticatedPrincipal(
+            principal_id="master",
+            credential_id=credential_id,
+            client_id=None,
+            policy=LEGACY_FULL,
+            capabilities=frozenset(),
+            full_access=True,
+        )
+
+    if not token.startswith("v1."):
+        return None
+
+    from .oauth import get_oauth_state
+
+    metadata = get_oauth_state().lookup_access_token(token)
+    if metadata is None or metadata.resource != _canonical_resource(request):
+        return None
+
+    capabilities = frozenset(metadata.capabilities)
+    if metadata.policy == LEGACY_FULL:
+        if capabilities:
+            return None
+        full_access = True
+    elif metadata.policy == VAULT_READONLY_V1:
+        if capabilities != frozenset(VAULT_READONLY_CAPABILITIES):
+            return None
+        full_access = False
+    else:
+        return None
+
+    return AuthenticatedPrincipal(
+        principal_id=f"oauth:{metadata.client_id}",
+        credential_id=credential_id,
+        client_id=metadata.client_id,
+        policy=metadata.policy,
+        capabilities=capabilities,
+        full_access=full_access,
+    )
+
+
+def _auth_error(
+    request: Request,
+    *,
+    message: str,
+    status_code: int,
+    error: str,
+) -> JSONResponse:
+    return JSONResponse(
+        {"error": message},
+        status_code=status_code,
+        headers={"WWW-Authenticate": _www_authenticate(request, error)},
+    )
 
 
 class BearerAuthMiddleware(BaseHTTPMiddleware):
-    """Validates Bearer tokens on all requests except OAuth and health endpoints."""
+    """Authenticate master and OAuth bearers through one fail-closed path."""
 
     async def dispatch(self, request: Request, call_next):
         if request.url.path in _AUTH_EXEMPT_PATHS:
@@ -62,29 +141,35 @@ class BearerAuthMiddleware(BaseHTTPMiddleware):
             )
 
         auth_header = request.headers.get("Authorization", "")
-        if not auth_header.startswith("Bearer "):
-            return JSONResponse(
-                {"error": "Missing or malformed Authorization header"},
+        if not auth_header.startswith("Bearer ") or not auth_header[7:]:
+            return _auth_error(
+                request,
+                message="Missing or malformed Authorization header",
                 status_code=401,
-                headers={"WWW-Authenticate": _www_authenticate(request, "invalid_request")},
+                error="invalid_request",
             )
 
-        token = auth_header[7:]
-        # Constant-time compare: avoid leaking the token via response timing (#2).
-        if not hmac.compare_digest(token, VAULT_MCP_TOKEN):
-            return JSONResponse(
-                {"error": "Invalid token"},
+        principal = _authenticate_bearer(request, auth_header[7:])
+        if principal is None:
+            return _auth_error(
+                request,
+                message="Invalid token",
                 status_code=401,
-                headers={"WWW-Authenticate": _www_authenticate(request, "invalid_token")},
+                error="invalid_token",
             )
 
-        # Thread the authenticated principal (plus a request id and best-effort client
-        # hint) to the tool layer for the audit log. The raw token never leaves this
-        # context; audit.build_audit_record stores only its SHA-256 hash. client_id is a
-        # User-Agent-derived hint -- it becomes a true per-client id if the static bearer
-        # token is ever replaced with per-client tokens.
-        client = request.headers.get("user-agent", "").strip()[:200] or None
-        ctx_token = set_request_context(principal=token, request_id=uuid.uuid4().hex, client=client)
+        if not principal.full_access and request.url.path != config.VAULT_MCP_PATH:
+            return _auth_error(
+                request,
+                message="Insufficient scope",
+                status_code=403,
+                error="insufficient_scope",
+            )
+
+        ctx_token = set_request_context(
+            principal=principal,
+            request_id=uuid.uuid4().hex,
+        )
         try:
             return await call_next(request)
         finally:

--- a/src/obsidian_vault_mcp/authorization.py
+++ b/src/obsidian_vault_mcp/authorization.py
@@ -1,0 +1,131 @@
+"""Principal-aware MCP discovery, dispatch, and tool registration."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Sequence
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp.exceptions import ResourceError, ToolError
+
+from .context import current_principal
+
+
+class PolicyFastMCP(FastMCP):
+    """FastMCP server that enforces request-principal capabilities."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        self._required_tool_capabilities: dict[str, str] = {}
+        super().__init__(*args, **kwargs)
+
+    def record_tool_capability(self, tool_name: str, capability: str) -> None:
+        """Bind one registered tool to the capability required to discover/call it."""
+        if not capability:
+            raise ValueError("tool capability must not be empty")
+        self._required_tool_capabilities[tool_name] = capability
+
+    def required_capability(self, tool_name: str) -> str | None:
+        """Return the recorded capability, or None for an unclassified tool."""
+        return self._required_tool_capabilities.get(tool_name)
+
+    def _tool_allowed(self, tool_name: str) -> bool:
+        principal = current_principal()
+        if principal is None:
+            return False
+        if principal.full_access:
+            return True
+        required = self.required_capability(tool_name)
+        return required is not None and required in principal.capabilities
+
+    @staticmethod
+    def _full_access() -> bool:
+        principal = current_principal()
+        return principal is not None and principal.full_access
+
+    async def list_tools(self):
+        """Return only tools authorized for the current principal."""
+        tools = await super().list_tools()
+        return [tool for tool in tools if self._tool_allowed(tool.name)]
+
+    async def call_tool(
+        self,
+        name: str,
+        arguments: dict[str, Any],
+    ) -> Sequence[Any] | dict[str, Any]:
+        """Reject unauthorized dispatch before invoking tool code."""
+        if not self._tool_allowed(name):
+            raise ToolError("Forbidden: tool is not permitted for this principal")
+        return await super().call_tool(name, arguments)
+
+    async def list_resources(self):
+        """Resources remain unavailable to capability-limited principals."""
+        return await super().list_resources() if self._full_access() else []
+
+    async def list_resource_templates(self):
+        """Resource templates remain unavailable to restricted principals."""
+        return await super().list_resource_templates() if self._full_access() else []
+
+    async def read_resource(self, uri) -> Iterable[Any]:
+        """Deny direct resource reads before resource resolution."""
+        if not self._full_access():
+            raise ResourceError(
+                "Forbidden: resources are not permitted for this principal"
+            )
+        return await super().read_resource(uri)
+
+    async def list_prompts(self):
+        """Prompts remain unavailable to capability-limited principals."""
+        return await super().list_prompts() if self._full_access() else []
+
+    async def get_prompt(
+        self,
+        name: str,
+        arguments: dict[str, Any] | None = None,
+    ):
+        """Deny direct prompt access before rendering."""
+        if not self._full_access():
+            raise ValueError("Forbidden: prompts are not permitted for this principal")
+        return await super().get_prompt(name, arguments)
+
+
+class ToolRegistrar:
+    """Narrow policy-aware registration surface for core and extension tools."""
+
+    __slots__ = ("_server",)
+
+    def __init__(self, server: PolicyFastMCP) -> None:
+        self._server = server
+
+    def tool(
+        self,
+        name: str | None = None,
+        title: str | None = None,
+        description: str | None = None,
+        annotations: Any | None = None,
+        icons: list[Any] | None = None,
+        meta: dict[str, Any] | None = None,
+        structured_output: bool | None = None,
+        *,
+        required_capability: str | None = None,
+    ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+        """Register a tool; its final name is the default required capability."""
+        if callable(name):
+            raise TypeError("Use @tool() rather than @tool when registering a tool")
+
+        def decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
+            effective_name = name or fn.__name__
+            capability = required_capability or effective_name
+            self._server.add_tool(
+                fn,
+                name=name,
+                title=title,
+                description=description,
+                annotations=annotations,
+                icons=icons,
+                meta=meta,
+                structured_output=structured_output,
+            )
+            self._server.record_tool_capability(effective_name, capability)
+            return fn
+
+        return decorator

--- a/src/obsidian_vault_mcp/config.py
+++ b/src/obsidian_vault_mcp/config.py
@@ -40,15 +40,51 @@ VAULT_OAUTH_PASSWORD = os.environ.get("VAULT_OAUTH_PASSWORD", "")
 # browser authorization-code flow (it can still use the client_credentials grant).
 VAULT_OAUTH_REDIRECT_URIS = [u.strip() for u in os.environ.get("VAULT_OAUTH_REDIRECT_URIS", "").split(",") if u.strip()]
 
-# Where the dynamically-registered OAuth client registry is persisted. The registry is
-# otherwise in-memory and wiped on every restart, which breaks already-connected MCP
-# clients (they replay a client_id the restarted server no longer knows). Persisting it
-# keeps connectors working across restarts. It holds per-client secrets, so it is written
-# with 0600 perms (see oauth._save_clients). Override with OAUTH_CLIENTS_PATH.
-OAUTH_CLIENTS_PATH = Path(os.environ.get(
-    "OAUTH_CLIENTS_PATH",
-    Path.home() / ".local" / "share" / "vault-mcp" / "oauth_clients.json",
-))
+# Legacy plaintext dynamic-client registry. Read once by the versioned SQLite
+# migration, then removed only after a durable commit. Override only to locate
+# an existing deployment's source file.
+OAUTH_CLIENTS_PATH = Path(
+    os.environ.get(
+        "OAUTH_CLIENTS_PATH",
+        Path.home() / ".local" / "share" / "vault-mcp" / "oauth_clients.json",
+    )
+)
+
+# Versioned OAuth lifecycle state. Kept outside the vault so credentials and
+# authorization metadata can never be synchronized with note content.
+VAULT_OAUTH_STATE_PATH = Path(
+    os.environ.get(
+        "VAULT_OAUTH_STATE_PATH",
+        Path.home() / ".local/share/vault-mcp/oauth_state.sqlite3",
+    )
+).expanduser()
+VAULT_OAUTH_APPROVED_LEGACY_CLIENT_IDS = frozenset(
+    item.strip()
+    for item in os.environ.get(
+        "VAULT_OAUTH_APPROVED_LEGACY_CLIENT_IDS", ""
+    ).split(",")
+    if item.strip()
+)
+_OAUTH_ACCESS_TOKEN_TTL_RAW = os.environ.get(
+    "VAULT_OAUTH_ACCESS_TOKEN_TTL_SECONDS", "86400"
+)
+
+
+def oauth_access_token_ttl_seconds() -> int:
+    """Return the configured access-token TTL, bounded to 30 days."""
+    try:
+        ttl = int(_OAUTH_ACCESS_TOKEN_TTL_RAW)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            "VAULT_OAUTH_ACCESS_TOKEN_TTL_SECONDS must be an integer "
+            "between 1 and 2592000"
+        ) from exc
+    if not 1 <= ttl <= 2_592_000:
+        raise ValueError(
+            "VAULT_OAUTH_ACCESS_TOKEN_TTL_SECONDS must be between "
+            "1 and 2592000"
+        )
+    return ttl
 
 # Network bind address. Defaults to loopback so the server is NOT exposed on the LAN;
 # Cloudflare Tunnel reaches it over localhost. Set to 0.0.0.0 only if you deliberately
@@ -226,3 +262,4 @@ def validate_config() -> None:
     CLOSED with a clear message instead of booting a broken or insecure server.
     """
     _validate_mcp_path(VAULT_MCP_PATH)
+    oauth_access_token_ttl_seconds()

--- a/src/obsidian_vault_mcp/context.py
+++ b/src/obsidian_vault_mcp/context.py
@@ -1,34 +1,58 @@
-"""Request-scoped context shared by the bearer middleware and the audit log.
-
-The middleware records, per authenticated request, the principal (the bearer token), a
-generated request id, and a best-effort client hint. The audit module reads them when
-building a record. It lives in its own module so auth.py (the writer) and audit.py (the
-reader) share one ContextVar without importing each other.
-"""
+"""Secret-free request context shared by authentication and MCP dispatch."""
 
 from __future__ import annotations
 
 from contextvars import ContextVar, Token
-from typing import Any
-
-# A single context var carrying the per-request audit context. Threading the principal
-# to the tool layer this way -- rather than as a function argument -- keeps every tool
-# signature untouched and works through FastMCP's call path.
-_request_context: ContextVar[dict[str, Any] | None] = ContextVar("request_context", default=None)
+from dataclasses import dataclass
 
 
-def set_request_context(principal: str | None, request_id: str | None, client: str | None) -> Token:
-    """Bind the audit context for the current request. Returns a reset token."""
+@dataclass(frozen=True)
+class AuthenticatedPrincipal:
+    """Stable authorization metadata for one validated bearer."""
+
+    principal_id: str
+    credential_id: str
+    client_id: str | None
+    policy: str
+    capabilities: frozenset[str]
+    full_access: bool
+
+
+@dataclass(frozen=True)
+class RequestContext:
+    """Metadata bound to one authenticated request."""
+
+    principal: AuthenticatedPrincipal
+    request_id: str
+
+
+_request_context: ContextVar[RequestContext | None] = ContextVar(
+    "request_context",
+    default=None,
+)
+
+
+def set_request_context(
+    principal: AuthenticatedPrincipal,
+    request_id: str,
+) -> Token[RequestContext | None]:
+    """Bind validated metadata for the current request."""
     return _request_context.set(
-        {"principal": principal, "request_id": request_id, "client": client}
+        RequestContext(principal=principal, request_id=request_id)
     )
 
 
-def reset_request_context(token: Token) -> None:
-    """Restore the previous audit context (call in a finally block)."""
+def reset_request_context(token: Token[RequestContext | None]) -> None:
+    """Restore the previous request context."""
     _request_context.reset(token)
 
 
-def current_request_context() -> dict[str, Any]:
-    """Return the current request's audit context, or an empty dict outside a request."""
-    return _request_context.get() or {}
+def current_request_context() -> RequestContext | None:
+    """Return the current request metadata, if authentication bound one."""
+    return _request_context.get()
+
+
+def current_principal() -> AuthenticatedPrincipal | None:
+    """Return the current authenticated principal without credential material."""
+    context = current_request_context()
+    return context.principal if context is not None else None

--- a/src/obsidian_vault_mcp/extensions.py
+++ b/src/obsidian_vault_mcp/extensions.py
@@ -39,6 +39,7 @@ if TYPE_CHECKING:  # imported lazily / only for typing to avoid import cycles
     from starlette.applications import Starlette
 
     from .frontmatter_index import FrontmatterIndex
+    from .authorization import ToolRegistrar
 
 
 class Extension:
@@ -46,8 +47,8 @@ class Extension:
 
     Lifecycle, in the order `server.serve()` invokes them:
 
-      1. register_tools(mcp)          add @mcp.tool tools BEFORE the ASGI app /
-                                      tool schema is built, so they're advertised.
+      1. register_tools(registrar)    add tools through the policy-aware registrar
+                                      before the ASGI app / schema is built.
       2. before_indexes_start(index)  runs before the frontmatter index starts --
                                       e.g. attach a change listener so no change is
                                       missed between build and listener attach.
@@ -56,19 +57,17 @@ class Extension:
       4. register_routes(app)         add Starlette routes BEFORE the bearer-auth
                                       middleware is attached, so the routes are
                                       bearer-protected. Do NOT register a route on
-                                      an auth-exempt path (/health, /oauth/*,
-                                      /.well-known/*, or the off-root GET/HEAD /
-                                      probe) -- the middleware skips those before
-                                      routing, so such a route would be served
-                                      UNAUTHENTICATED. build_app() rejects a
-                                      collision with an exempt *path* at startup
-                                      (fail closed); the method-only / probe is
-                                      your responsibility to avoid.
+                                      the MCP transport path or an auth-exempt path
+                                      (/health, /oauth/*, /.well-known/*, or the
+                                      off-root GET/HEAD / probe). A transport
+                                      collision could bypass per-client MCP policy;
+                                      an exempt collision would be unauthenticated.
+                                      build_app() rejects both at startup.
       5. shutdown()                   registered with atexit; runs at process exit.
     """
 
-    def register_tools(self, mcp) -> None:  # noqa: D401
-        """Register additional MCP tools on the FastMCP instance."""
+    def register_tools(self, registrar: "ToolRegistrar") -> None:  # noqa: D401
+        """Register MCP tools through the policy-aware registrar."""
 
     def before_indexes_start(self, frontmatter_index: "FrontmatterIndex") -> None:
         """Prepare before the frontmatter index is built and starts watching."""

--- a/src/obsidian_vault_mcp/oauth.py
+++ b/src/obsidian_vault_mcp/oauth.py
@@ -1,464 +1,426 @@
-"""OAuth 2.0 authorization-code flow with PKCE + an interactive login gate.
+"""OAuth 2.0 endpoints backed by durable per-client lifecycle state."""
 
-The Claude / ChatGPT MCP connectors drive this flow automatically:
-1. Discover metadata at /.well-known/oauth-authorization-server
-2. Dynamically register at /oauth/register (gets a client_id + a per-client secret)
-3. Open the user's browser at /oauth/authorize
-4. >>> The user logs in (username + password) -- THEN an authorization code is issued <<<
-5. The client exchanges the code at /oauth/token (PKCE verified) for a bearer token
-6. The client sends the bearer token on every MCP request
+from __future__ import annotations
 
-Security model (fix for issues #8 / #29)
-----------------------------------------
-The previous version auto-approved every /oauth/authorize request with no user
-check, so anyone who could reach the URL could obtain the vault bearer token.
-This version closes that hole:
-
-- /oauth/authorize authenticates the human (login form) before issuing any code.
-  It NEVER auto-approves anonymous requests; with no VAULT_OAUTH_PASSWORD set it
-  fails closed (503). The password is required on every authorization, so there is
-  no ambient session for a cross-site request (or a self-registered attacker
-  client) to ride on.
-- /oauth/register is non-authorizing: it stores a client record and returns a
-  freshly generated per-client secret. It NEVER echoes the server's configured
-  secret or the vault bearer token.
-- redirect_uri must be https (or loopback http) and -- for a dynamically
-  registered client -- must exactly match a registered URI, at both authorize and
-  token time. This prevents open-redirect / code-exfiltration.
-- PKCE S256 is mandatory on the authorization-code grant.
-
-Remaining hardening tracked separately (see the fix write-up): the issued bearer
-token is still the single static VAULT_MCP_TOKEN. Replacing it with per-client,
-expiring, revocable tokens is a follow-up.
-"""
-
-import base64
-import hashlib
 import hmac
 import html
-import json
 import logging
-import os
-import secrets
-import time
-from urllib.parse import urlencode, urlparse
+import urllib.parse
+from collections.abc import Mapping
+from typing import Any
 
 from starlette.requests import Request
-from starlette.responses import JSONResponse, RedirectResponse, HTMLResponse
+from starlette.responses import HTMLResponse, JSONResponse, RedirectResponse
 from starlette.routing import Route
 
 from . import config
+from .oauth_state import (
+    LEGACY_FULL,
+    REAUTHORIZATION_REQUIRED,
+    InvalidClient,
+    InvalidGrant,
+    InvalidTarget,
+    OAuthState,
+)
 
 logger = logging.getLogger(__name__)
 
-# In-memory store for authorization codes (short-lived).
-# Maps code -> {client_id, redirect_uri, code_challenge, code_challenge_method, expires_at}
-_auth_codes: dict[str, dict] = {}
-
-# Registry of dynamically registered clients.
-# Maps client_id -> {client_secret, redirect_uris: [...], created_at}
-# Persisted to config.OAUTH_CLIENTS_PATH so registrations survive a restart. An
-# in-memory-only registry is wiped on every restart, which breaks already-connected MCP
-# clients: they replay a client_id the restarted server no longer recognizes, so
-# /oauth/authorize rejects it with "Invalid or unregistered redirect_uri" and the only
-# recourse is removing and re-adding the connector.
-_clients: dict[str, dict] = {}
+_oauth_state: OAuthState | None = None
 
 
-def _load_clients() -> None:
-    """Populate _clients from the on-disk registry. Best-effort; never raises."""
-    path = config.OAUTH_CLIENTS_PATH
-    try:
-        with open(path, "r") as f:
-            data = json.load(f)
-    except FileNotFoundError:
-        return
-    except (OSError, json.JSONDecodeError) as e:
-        logger.warning("OAuth client registry unreadable at %s (%s); starting empty", path, e)
-        return
-    if isinstance(data, dict):
-        valid = {}
-        for cid, rec in data.items():
-            if (isinstance(cid, str) and isinstance(rec, dict)
-                    and isinstance(rec.get("client_secret"), str)
-                    and isinstance(rec.get("redirect_uris"), list)
-                    and all(isinstance(u, str) for u in rec["redirect_uris"])):
-                valid[cid] = rec
-        _clients.clear()
-        _clients.update(valid)
-        logger.info("Loaded %d registered OAuth client(s) from %s", len(_clients), path)
+def _static_client_authenticator(client_id: str, client_secret: str) -> bool:
+    return bool(
+        config.VAULT_OAUTH_CLIENT_ID
+        and config.VAULT_OAUTH_CLIENT_SECRET
+        and hmac.compare_digest(client_id, config.VAULT_OAUTH_CLIENT_ID)
+        and hmac.compare_digest(client_secret, config.VAULT_OAUTH_CLIENT_SECRET)
+    )
 
 
-def _save_clients() -> None:
-    """Persist _clients atomically with owner-only perms (it holds per-client secrets)."""
-    path = config.OAUTH_CLIENTS_PATH
-    try:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = path.with_name(f"{path.name}.tmp-{os.getpid()}")
-        # O_CREAT with 0o600 so the secrets are never briefly world-readable; fchmod
-        # forces 0600 even if a stale tmp from a crashed write pre-existed wider.
-        fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-        os.fchmod(fd, 0o600)
-        with os.fdopen(fd, "w") as f:
-            json.dump(_clients, f)
-            f.flush()
-            os.fsync(f.fileno())  # durable before the atomic swap
-        os.replace(tmp, path)  # atomic on POSIX
-    except OSError as e:
-        logger.error("Could not persist OAuth client registry to %s (%s)", path, e)
+def initialize_oauth_state() -> OAuthState:
+    """Open durable OAuth state and ensure the configured static identity."""
+    global _oauth_state
+    configured_path = config.VAULT_OAUTH_STATE_PATH.expanduser().absolute()
+    if _oauth_state is not None and _oauth_state.path != configured_path:
+        close_oauth_state()
+    if _oauth_state is None:
+        _oauth_state = OAuthState(
+            configured_path,
+            vault_path=config.VAULT_PATH,
+            legacy_path=config.OAUTH_CLIENTS_PATH,
+            approved_legacy_client_ids=(config.VAULT_OAUTH_APPROVED_LEGACY_CLIENT_IDS),
+            access_token_ttl_seconds=(config.oauth_access_token_ttl_seconds()),
+            static_client_authenticator=_static_client_authenticator,
+        )
+    if config.VAULT_OAUTH_CLIENT_ID:
+        _oauth_state.ensure_static_client(
+            config.VAULT_OAUTH_CLIENT_ID,
+            config.VAULT_OAUTH_REDIRECT_URIS,
+            policy=LEGACY_FULL,
+            capabilities=(),
+        )
+    return _oauth_state
 
 
-# Load any persisted registrations at import (process startup).
-_load_clients()
+def get_oauth_state() -> OAuthState:
+    """Return the process state handle, opening it lazily when necessary."""
+    return initialize_oauth_state()
 
 
-def _cleanup_codes():
-    now = time.time()
-    expired = [k for k, v in _auth_codes.items() if v["expires_at"] < now]
-    for k in expired:
-        del _auth_codes[k]
+def close_oauth_state() -> None:
+    """Close the process state handle without changing durable state."""
+    global _oauth_state
+    if _oauth_state is not None:
+        _oauth_state.close()
+        _oauth_state = None
+
+
+def _canonical_resource(request: Request) -> str:
+    return config.advertised_base_url(str(request.base_url)).rstrip("/")
+
+
+async def oauth_metadata(request: Request) -> JSONResponse:
+    """OAuth authorization-server metadata (RFC 8414)."""
+    base = _canonical_resource(request)
+    return JSONResponse(
+        {
+            "issuer": base,
+            "authorization_endpoint": f"{base}/oauth/authorize",
+            "token_endpoint": f"{base}/oauth/token",
+            "registration_endpoint": f"{base}/oauth/register",
+            "resource": base,
+            "response_types_supported": ["code"],
+            "grant_types_supported": [
+                "authorization_code",
+                "client_credentials",
+            ],
+            "code_challenge_methods_supported": ["S256"],
+            "token_endpoint_auth_methods_supported": ["client_secret_post"],
+        }
+    )
+
+
+async def oauth_protected_resource(request: Request) -> JSONResponse:
+    """Protected-resource metadata (RFC 9728)."""
+    base = _canonical_resource(request)
+    return JSONResponse(
+        {
+            "resource": base,
+            "authorization_servers": [base],
+            "bearer_methods_supported": ["header"],
+        }
+    )
+
+
+def _request_parameters(
+    request: Request, form: Mapping[str, Any] | None
+) -> dict[str, str]:
+    source: Mapping[str, Any] = form if form is not None else request.query_params
+    names = (
+        "response_type",
+        "client_id",
+        "redirect_uri",
+        "state",
+        "code_challenge",
+        "code_challenge_method",
+        "resource",
+    )
+    params = {name: str(source.get(name, "") or "") for name in names}
+    if not params["code_challenge_method"]:
+        params["code_challenge_method"] = "S256"
+    return params
+
+
+def _validate_authorization_request(request: Request, params: Mapping[str, str]):
+    if params["response_type"] != "code":
+        return JSONResponse({"error": "unsupported_response_type"}, status_code=400)
+    state = get_oauth_state()
+    client = state.get_client(params["client_id"])
+    if client is None or client.revoked_at is not None:
+        return JSONResponse({"error": "invalid_client"}, status_code=400)
+    if not state.client_redirect_uri_allowed(
+        params["client_id"], params["redirect_uri"]
+    ):
+        return JSONResponse(
+            {
+                "error": "invalid_request",
+                "error_description": "Invalid or unregistered redirect_uri",
+            },
+            status_code=400,
+        )
+    if not params["code_challenge"] or params["code_challenge_method"] != "S256":
+        return JSONResponse(
+            {
+                "error": "invalid_request",
+                "error_description": "PKCE with S256 is required",
+            },
+            status_code=400,
+        )
+    if params["resource"] != _canonical_resource(request):
+        return JSONResponse(
+            {
+                "error": "invalid_target",
+                "error_description": "resource must match this server",
+            },
+            status_code=400,
+        )
+    return None
 
 
 def _login_configured() -> bool:
-    """True if an interactive login credential is configured."""
     return bool(config.VAULT_OAUTH_PASSWORD)
 
 
 def _check_credentials(username: str, password: str) -> bool:
-    """Constant-time check of the submitted login credentials."""
-    if not config.VAULT_OAUTH_PASSWORD:
-        return False
-    user_ok = hmac.compare_digest(username or "", config.VAULT_OAUTH_USERNAME)
-    pass_ok = hmac.compare_digest(password or "", config.VAULT_OAUTH_PASSWORD)
-    return user_ok and pass_ok
-
-
-def _redirect_uri_ok(client_id: str, redirect_uri: str) -> bool:
-    """Validate redirect_uri: must be https (or loopback http) AND exact-match an
-    allowlist for the client -- no open fallthrough (#4):
-      - DCR-registered client  -> must match one of its registered redirect_uris.
-      - operator-configured client -> must match VAULT_OAUTH_REDIRECT_URIS.
-    A client with no allowlisted URIs cannot use the browser authorization-code flow.
-    """
-    if not redirect_uri:
-        return False
-    parsed = urlparse(redirect_uri)
-    is_loopback = parsed.scheme == "http" and (parsed.hostname in {"127.0.0.1", "localhost", "::1"})
-    if parsed.scheme != "https" and not is_loopback:
-        return False
-    record = _clients.get(client_id)
-    if record is not None:
-        # DCR-registered client: exact-match its registered URIs (empty list -> deny).
-        return redirect_uri in (record.get("redirect_uris") or [])
-    if client_id == config.VAULT_OAUTH_CLIENT_ID:
-        # Operator-configured client: only the explicit allowlist is accepted.
-        return redirect_uri in config.VAULT_OAUTH_REDIRECT_URIS
-    return False
-
-
-def _client_known(client_id: str) -> bool:
-    return client_id in _clients or (
-        bool(config.VAULT_OAUTH_CLIENT_ID) and client_id == config.VAULT_OAUTH_CLIENT_ID
+    expected_username = config.VAULT_OAUTH_USERNAME or "obsidian"
+    return bool(
+        _login_configured()
+        and hmac.compare_digest(username, expected_username)
+        and hmac.compare_digest(password, config.VAULT_OAUTH_PASSWORD)
     )
 
 
-def _issue_code_redirect(client_id: str, redirect_uri: str, state: str,
-                         code_challenge: str, code_challenge_method: str):
-    """Mint an authorization code and 302 back to the client."""
-    _cleanup_codes()
-    code = secrets.token_urlsafe(32)
-    _auth_codes[code] = {
-        "client_id": client_id,
-        "redirect_uri": redirect_uri,
-        "code_challenge": code_challenge,
-        "code_challenge_method": code_challenge_method,
-        "expires_at": time.time() + 300,  # 5 minute expiry
-    }
-    logger.info("OAuth authorization code issued after successful login.")
-    params = {"code": code}
-    if state:
-        params["state"] = state
-    separator = "&" if "?" in redirect_uri else "?"
-    return RedirectResponse(url=f"{redirect_uri}{separator}{urlencode(params)}", status_code=302)
-
-
-def _login_form(params: dict, error: str = "") -> HTMLResponse:
-    """Render the login page, carrying the OAuth params as hidden fields.
-
-    Every reflected value is HTML-escaped to avoid reflected XSS.
-    """
+def _login_form(
+    params: Mapping[str, str],
+    *,
+    error: str | None = None,
+    status_code: int = 200,
+) -> HTMLResponse:
     hidden = "\n".join(
-        f'<input type="hidden" name="{html.escape(k)}" value="{html.escape(v)}">'
-        for k, v in params.items() if v
+        f'<input type="hidden" name="{html.escape(name)}" '
+        f'value="{html.escape(value, quote=True)}">'
+        for name, value in params.items()
     )
-    err_html = f'<p class="err">{html.escape(error)}</p>' if error else ""
-    status = 401 if error else 200
-    page = f"""<!doctype html>
-<html><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Authorize Obsidian Vault access</title>
-<style>
- body{{font-family:-apple-system,system-ui,sans-serif;background:#1e1e2e;color:#cdd6f4;display:flex;min-height:100vh;align-items:center;justify-content:center;margin:0}}
- form{{background:#313244;padding:2rem;border-radius:12px;width:300px;box-shadow:0 8px 24px rgba(0,0,0,.4)}}
- h1{{font-size:1.1rem;margin:0 0 1rem}}
- label{{display:block;font-size:.8rem;margin:.6rem 0 .2rem;color:#a6adc8}}
- input[type=text],input[type=password]{{width:100%;box-sizing:border-box;padding:.5rem;border-radius:6px;border:1px solid #45475a;background:#1e1e2e;color:#cdd6f4}}
- button{{margin-top:1rem;width:100%;padding:.6rem;border:0;border-radius:6px;background:#89b4fa;color:#1e1e2e;font-weight:600;cursor:pointer}}
- .err{{color:#f38ba8;font-size:.8rem;margin:.4rem 0 0}}
- .sub{{font-size:.75rem;color:#6c7086;margin-top:1rem}}
-</style></head>
+    error_html = f'<p role="alert">{html.escape(error)}</p>' if error else ""
+    content = f"""<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><title>Authorize Obsidian Vault MCP</title></head>
 <body>
- <form method="post" action="/oauth/authorize">
-  <h1>🔒 Authorize access to your vault</h1>
-  {hidden}
-  <label for="u">Username</label>
-  <input id="u" type="text" name="username" autocomplete="username" autofocus>
-  <label for="p">Password</label>
-  <input id="p" type="password" name="password" autocomplete="current-password">
-  {err_html}
-  <button type="submit">Authorize</button>
-  <p class="sub">A client is requesting access to your Obsidian vault.</p>
- </form>
-</body></html>"""
-    return HTMLResponse(page, status_code=status)
+  <main>
+    <h1>Authorize Obsidian Vault MCP</h1>
+    {error_html}
+    <form method="post" action="/oauth/authorize">
+      {hidden}
+      <label>Username <input name="username" autocomplete="username"></label>
+      <label>Password <input name="password" type="password" autocomplete="current-password"></label>
+      <button type="submit">Authorize</button>
+    </form>
+  </main>
+</body>
+</html>"""
+    return HTMLResponse(content, status_code=status_code)
 
 
-def _misconfigured_page() -> HTMLResponse:
+def _login_misconfigured() -> HTMLResponse:
     return HTMLResponse(
-        "<h1>Server not configured for login</h1>"
-        "<p>This server requires <code>VAULT_OAUTH_PASSWORD</code> to be set before it can "
-        "authorize access to your vault. Set it and restart.</p>",
+        "OAuth login is not configured; set VAULT_OAUTH_PASSWORD.",
         status_code=503,
     )
 
 
-async def oauth_metadata(request: Request) -> JSONResponse:
-    """RFC 8414 OAuth authorization server metadata."""
-    base_url = config.advertised_base_url(str(request.base_url))
-    return JSONResponse({
-        "issuer": base_url,
-        "authorization_endpoint": f"{base_url}/oauth/authorize",
-        "token_endpoint": f"{base_url}/oauth/token",
-        "registration_endpoint": f"{base_url}/oauth/register",
-        "grant_types_supported": ["authorization_code"],
-        "response_types_supported": ["code"],
-        "code_challenge_methods_supported": ["S256"],
-        "token_endpoint_auth_methods_supported": ["client_secret_post", "none"],
-    })
-
-
-async def oauth_protected_resource(request: Request) -> JSONResponse:
-    """RFC 9728 OAuth protected-resource metadata. Claude/ChatGPT request this path
-    during discovery; it must be reachable without a bearer token (#20). With the MCP
-    endpoint served at "/" (#19), the protected resource is the base URL itself."""
-    base_url = config.advertised_base_url(str(request.base_url))
-    return JSONResponse({
-        "resource": base_url,
-        "authorization_servers": [base_url],
-        "bearer_methods_supported": ["header"],
-    })
-
-
 async def oauth_authorize(request: Request):
-    """OAuth 2.0 authorization endpoint with an interactive login gate.
-
-    GET  -> validate the request, then render a login form (or auto-approve only
-            under the explicit localhost escape hatch).
-    POST -> verify submitted credentials, then issue an authorization code.
-    """
-    if request.method == "POST":
-        form = await request.form()
-        getp = form.get
-    else:
-        getp = request.query_params.get
-
-    response_type = getp("response_type", "") or ""
-    client_id = getp("client_id", "") or ""
-    redirect_uri = getp("redirect_uri", "") or ""
-    state = getp("state", "") or ""
-    code_challenge = getp("code_challenge", "") or ""
-    code_challenge_method = getp("code_challenge_method", "S256") or "S256"
-
-    # --- Validate the OAuth request shape (independent of authentication) ---
-    if response_type != "code":
-        return JSONResponse({"error": "unsupported_response_type"}, status_code=400)
-    if not client_id or not _client_known(client_id):
-        return JSONResponse(
-            {"error": "invalid_client", "error_description": "Unknown client; register via /oauth/register first."},
-            status_code=400,
-        )
-    if not _redirect_uri_ok(client_id, redirect_uri):
-        return JSONResponse(
-            {"error": "invalid_request", "error_description": "Invalid or unregistered redirect_uri."},
-            status_code=400,
-        )
-    if not code_challenge or code_challenge_method != "S256":
-        return JSONResponse(
-            {"error": "invalid_request", "error_description": "PKCE S256 (code_challenge) is required."},
-            status_code=400,
-        )
-
-    oauth_params = {
-        "response_type": response_type,
-        "client_id": client_id,
-        "redirect_uri": redirect_uri,
-        "state": state,
-        "code_challenge": code_challenge,
-        "code_challenge_method": code_challenge_method,
-    }
-
-    # --- Authentication gate ---
-    # Fail CLOSED: with no login credential configured there is no safe way to
-    # authenticate the human, so we refuse to issue codes. There is deliberately
-    # no "auto-approve" escape hatch — an unauthenticated authorize endpoint is
-    # exactly the vulnerability this fix closes (issues #8 / #29).
+    """Validate a request, authenticate the human, and issue a durable code."""
+    form = await request.form() if request.method == "POST" else None
+    params = _request_parameters(request, form)
+    invalid = _validate_authorization_request(request, params)
+    if invalid is not None:
+        return invalid
     if not _login_configured():
-        logger.error("Refusing to authorize: VAULT_OAUTH_PASSWORD is not set.")
-        return _misconfigured_page()
+        logger.error("OAuth authorization refused: login is not configured")
+        return _login_misconfigured()
+    if request.method == "GET":
+        return _login_form(params)
 
-    if request.method != "POST":
-        # No credentials yet -- show the login form.
-        return _login_form(oauth_params)
+    assert form is not None
+    username = str(form.get("username", "") or "")
+    password = str(form.get("password", "") or "")
+    if not _check_credentials(username, password):
+        logger.warning("OAuth login failed")
+        return _login_form(
+            params, error="Invalid username or password", status_code=401
+        )
 
-    # POST: verify the submitted credentials.
-    if not _check_credentials(form.get("username", ""), form.get("password", "")):
-        logger.warning("OAuth login failed.")
-        return _login_form(oauth_params, error="Incorrect username or password.")
+    state = get_oauth_state()
+    client = state.get_client(params["client_id"])
+    assert client is not None
+    requires_reauthorization = client.policy == REAUTHORIZATION_REQUIRED
+    code = state.issue_authorization_code(
+        client_id=client.client_id,
+        redirect_uri=params["redirect_uri"],
+        code_challenge=params["code_challenge"],
+        resource=params["resource"],
+        fresh_reauthorization=requires_reauthorization,
+    )
+    query = {"code": code}
+    if params["state"]:
+        query["state"] = params["state"]
+    separator = "&" if "?" in params["redirect_uri"] else "?"
+    location = f"{params['redirect_uri']}{separator}{urllib.parse.urlencode(query)}"
+    logger.info("OAuth authorization code issued")
+    return RedirectResponse(location, status_code=302)
 
-    return _issue_code_redirect(client_id, redirect_uri, state, code_challenge, code_challenge_method)
+
+def _token_response(issued) -> JSONResponse:
+    expires_in = max(0, int(issued.token.expires_at - issued.token.issued_at))
+    return JSONResponse(
+        {
+            "access_token": issued.access_token,
+            "token_type": "bearer",
+            "expires_in": expires_in,
+        }
+    )
+
+
+def _oauth_error(
+    error: str,
+    description: str,
+    *,
+    status_code: int = 400,
+) -> JSONResponse:
+    return JSONResponse(
+        {"error": error, "error_description": description},
+        status_code=status_code,
+    )
+
+
+async def _handle_authorization_code(
+    request: Request, form: Mapping[str, Any]
+) -> JSONResponse:
+    fields = {
+        name: str(form.get(name, "") or "")
+        for name in (
+            "code",
+            "client_id",
+            "client_secret",
+            "redirect_uri",
+            "code_verifier",
+            "resource",
+        )
+    }
+    if not all(fields.values()):
+        return _oauth_error(
+            "invalid_request",
+            "code, client_id, client_secret, redirect_uri, code_verifier, "
+            "and resource are required",
+        )
+    try:
+        issued = get_oauth_state().redeem_authorization_code(**fields)
+    except InvalidClient:
+        return _oauth_error(
+            "invalid_client", "client authentication failed", status_code=401
+        )
+    except InvalidTarget:
+        return _oauth_error("invalid_target", "resource does not match authorization")
+    except InvalidGrant:
+        return _oauth_error("invalid_grant", "authorization code is invalid")
+    return _token_response(issued)
+
+
+async def _handle_client_credentials(
+    request: Request, form: Mapping[str, Any]
+) -> JSONResponse:
+    client_id = str(form.get("client_id", "") or "")
+    client_secret = str(form.get("client_secret", "") or "")
+    resource = str(form.get("resource", "") or "")
+    canonical_resource = _canonical_resource(request)
+    if resource != canonical_resource:
+        return _oauth_error("invalid_target", "resource must match this server")
+    state = get_oauth_state()
+    client = state.get_client(client_id)
+    if (
+        client is None
+        or not client.is_static
+        or not state.verify_client_secret(client_id, client_secret)
+    ):
+        return _oauth_error(
+            "invalid_client", "client authentication failed", status_code=401
+        )
+    try:
+        issued = state.issue_access_token(
+            client_id=client_id,
+            resource=resource,
+        )
+    except InvalidClient:
+        return _oauth_error(
+            "invalid_client", "client authentication failed", status_code=401
+        )
+    return _token_response(issued)
 
 
 async def oauth_token(request: Request) -> JSONResponse:
-    """OAuth 2.0 token endpoint -- authorization code grant with PKCE."""
-    try:
-        form = await request.form()
-    except Exception:
-        return JSONResponse({"error": "invalid_request"}, status_code=400)
-
-    grant_type = form.get("grant_type", "")
-    client_id = form.get("client_id", "")
-    client_secret = form.get("client_secret", "")
-
+    """Exchange a code or static client credentials for an opaque token."""
+    form = await request.form()
+    grant_type = str(form.get("grant_type", "") or "")
     if grant_type == "authorization_code":
-        return await _handle_authorization_code(form)
-    elif grant_type == "client_credentials":
-        return await _handle_client_credentials(client_id, client_secret)
-    else:
-        return JSONResponse({"error": "unsupported_grant_type"}, status_code=400)
+        return await _handle_authorization_code(request, form)
+    if grant_type == "client_credentials":
+        return await _handle_client_credentials(request, form)
+    return _oauth_error("unsupported_grant_type", "unsupported grant_type")
 
 
-async def _handle_authorization_code(form) -> JSONResponse:
-    """Exchange an authorization code for a bearer token. PKCE + redirect_uri are
-    both mandatory (no optional-verification escape hatches)."""
-    code = form.get("code", "")
-    redirect_uri = form.get("redirect_uri", "")
-    code_verifier = form.get("code_verifier", "")
-
-    _cleanup_codes()
-
-    if not code or code not in _auth_codes:
-        return JSONResponse({"error": "invalid_grant", "error_description": "Invalid or expired code"}, status_code=400)
-
-    code_data = _auth_codes.pop(code)  # single-use
-
-    # RFC 6749 4.1.3: the code must be redeemed by the client it was issued to (#4).
-    request_client_id = form.get("client_id", "")
-    if not hmac.compare_digest(request_client_id or "", code_data.get("client_id") or ""):
-        return JSONResponse({"error": "invalid_grant", "error_description": "client_id mismatch"}, status_code=400)
-
-    # redirect_uri must be present and match what was bound to the code.
-    if not redirect_uri or redirect_uri != code_data["redirect_uri"]:
-        return JSONResponse({"error": "invalid_grant", "error_description": "redirect_uri mismatch"}, status_code=400)
-
-    # PKCE is mandatory: a challenge was required at /authorize, so a verifier is required here.
-    if not code_data.get("code_challenge"):
-        return JSONResponse({"error": "invalid_grant", "error_description": "missing PKCE challenge"}, status_code=400)
-    if not code_verifier:
-        return JSONResponse({"error": "invalid_grant", "error_description": "code_verifier required"}, status_code=400)
-
-    digest = hashlib.sha256(code_verifier.encode("ascii")).digest()
-    computed_challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
-    if not hmac.compare_digest(computed_challenge, code_data["code_challenge"]):
-        return JSONResponse({"error": "invalid_grant", "error_description": "PKCE verification failed"}, status_code=400)
-
-    logger.info("OAuth token issued via authorization_code grant.")
-    return JSONResponse({
-        "access_token": config.VAULT_MCP_TOKEN,
-        "token_type": "bearer",
-        "expires_in": 86400,
-    })
-
-
-async def _handle_client_credentials(client_id: str, client_secret: str) -> JSONResponse:
-    """Headless grant for an operator-configured client (machine-to-machine).
-
-    Validated against the configured VAULT_OAUTH_CLIENT_ID/SECRET. Note: /oauth/register
-    no longer hands these out, so this path requires the operator's real secret.
-    """
-    if not config.VAULT_OAUTH_CLIENT_SECRET:
-        return JSONResponse({"error": "server_error"}, status_code=500)
-
-    id_match = hmac.compare_digest(client_id, config.VAULT_OAUTH_CLIENT_ID)
-    secret_match = hmac.compare_digest(client_secret, config.VAULT_OAUTH_CLIENT_SECRET)
-    if not (id_match and secret_match):
-        logger.warning("OAuth client_credentials failed.")
-        return JSONResponse({"error": "invalid_client"}, status_code=401)
-
-    logger.info("OAuth token issued via client_credentials grant.")
-    return JSONResponse({
-        "access_token": config.VAULT_MCP_TOKEN,
-        "token_type": "bearer",
-        "expires_in": 86400,
-    })
+def _valid_redirect_uri(uri: str) -> bool:
+    try:
+        parsed = urllib.parse.urlsplit(uri)
+    except ValueError:
+        return False
+    if parsed.scheme == "https":
+        return bool(parsed.netloc)
+    if parsed.scheme != "http":
+        return False
+    return parsed.hostname in {"localhost", "127.0.0.1", "::1"}
 
 
 async def oauth_register(request: Request) -> JSONResponse:
-    """Dynamic client registration (RFC 7591).
-
-    Non-authorizing: stores a client record and returns a freshly generated
-    per-client secret. NEVER returns the server's configured secret or the vault
-    bearer token. Registering a client confers no access on its own -- the human
-    must still log in at /oauth/authorize.
-    """
+    """Register a confidential authorization-code client."""
     try:
         body = await request.json()
-    except Exception:
-        body = {}
+    except (ValueError, TypeError):
+        return _oauth_error("invalid_client_metadata", "invalid JSON body")
+    if not isinstance(body, dict):
+        return _oauth_error(
+            "invalid_client_metadata", "registration body must be an object"
+        )
+    raw_redirects = body.get("redirect_uris", [])
+    if not isinstance(raw_redirects, list):
+        return _oauth_error("invalid_client_metadata", "redirect_uris must be an array")
+    redirect_uris = list(
+        dict.fromkeys(
+            uri
+            for uri in raw_redirects
+            if isinstance(uri, str) and _valid_redirect_uri(uri)
+        )
+    )
+    client_name = body.get("client_name", "Obsidian Vault MCP Client")
+    if not isinstance(client_name, str):
+        return _oauth_error("invalid_client_metadata", "client_name must be a string")
+    registered = get_oauth_state().register_client(
+        redirect_uris, client_name=client_name
+    )
+    return JSONResponse(
+        {
+            "client_id": registered.client.client_id,
+            "client_secret": registered.client_secret,
+            "client_name": registered.client.client_name,
+            "grant_types": ["authorization_code"],
+            "response_types": ["code"],
+            "redirect_uris": list(registered.client.redirect_uris),
+            "token_endpoint_auth_method": "client_secret_post",
+        },
+        status_code=201,
+    )
 
-    # Only accept valid https / loopback redirect URIs.
-    requested = body.get("redirect_uris", []) or []
-    redirect_uris = []
-    for uri in requested:
-        if not isinstance(uri, str):
-            continue
-        parsed = urlparse(uri)
-        is_loopback = parsed.scheme == "http" and (parsed.hostname in {"127.0.0.1", "localhost", "::1"})
-        if parsed.scheme == "https" or is_loopback:
-            redirect_uris.append(uri)
 
-    client_id = f"vault-mcp-{secrets.token_hex(8)}"
-    client_secret = secrets.token_hex(32)  # per-client, NOT config.VAULT_OAUTH_CLIENT_SECRET
-    _clients[client_id] = {
-        "client_secret": client_secret,
-        "redirect_uris": redirect_uris,
-        "created_at": time.time(),
-    }
-    _save_clients()  # survive restarts; otherwise this registration is lost on reboot
-
-    return JSONResponse({
-        "client_id": client_id,
-        "client_secret": client_secret,
-        "client_name": body.get("client_name", "Obsidian Vault MCP Client"),
-        "grant_types": ["authorization_code"],
-        "response_types": ["code"],
-        "redirect_uris": redirect_uris,
-        "token_endpoint_auth_method": "client_secret_post",
-    }, status_code=201)
-
-
-# Starlette routes to mount on the app
 oauth_routes = [
-    Route("/.well-known/oauth-authorization-server", oauth_metadata, methods=["GET"]),
-    Route("/.well-known/oauth-protected-resource", oauth_protected_resource, methods=["GET"]),
+    Route(
+        "/.well-known/oauth-authorization-server",
+        oauth_metadata,
+        methods=["GET"],
+    ),
+    Route(
+        "/.well-known/oauth-protected-resource",
+        oauth_protected_resource,
+        methods=["GET"],
+    ),
     Route("/oauth/authorize", oauth_authorize, methods=["GET", "POST"]),
     Route("/oauth/token", oauth_token, methods=["POST"]),
     Route("/oauth/register", oauth_register, methods=["POST"]),

--- a/src/obsidian_vault_mcp/oauth.py
+++ b/src/obsidian_vault_mcp/oauth.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import hmac
 import html
 import logging
@@ -28,12 +29,19 @@ logger = logging.getLogger(__name__)
 _oauth_state: OAuthState | None = None
 
 
+def _text_matches(candidate: str, expected: str) -> bool:
+    """Compare arbitrary Unicode text through fixed-length byte digests."""
+    candidate_digest = hashlib.sha256(candidate.encode("utf-8")).digest()
+    expected_digest = hashlib.sha256(expected.encode("utf-8")).digest()
+    return hmac.compare_digest(candidate_digest, expected_digest)
+
+
 def _static_client_authenticator(client_id: str, client_secret: str) -> bool:
     return bool(
         config.VAULT_OAUTH_CLIENT_ID
         and config.VAULT_OAUTH_CLIENT_SECRET
-        and hmac.compare_digest(client_id, config.VAULT_OAUTH_CLIENT_ID)
-        and hmac.compare_digest(client_secret, config.VAULT_OAUTH_CLIENT_SECRET)
+        and _text_matches(client_id, config.VAULT_OAUTH_CLIENT_ID)
+        and _text_matches(client_secret, config.VAULT_OAUTH_CLIENT_SECRET)
     )
 
 
@@ -44,7 +52,7 @@ def initialize_oauth_state() -> OAuthState:
     if _oauth_state is not None and _oauth_state.path != configured_path:
         close_oauth_state()
     if _oauth_state is None:
-        _oauth_state = OAuthState(
+        state = OAuthState(
             configured_path,
             vault_path=config.VAULT_PATH,
             legacy_path=config.OAUTH_CLIENTS_PATH,
@@ -52,13 +60,19 @@ def initialize_oauth_state() -> OAuthState:
             access_token_ttl_seconds=(config.oauth_access_token_ttl_seconds()),
             static_client_authenticator=_static_client_authenticator,
         )
-    if config.VAULT_OAUTH_CLIENT_ID:
-        _oauth_state.ensure_static_client(
-            config.VAULT_OAUTH_CLIENT_ID,
-            config.VAULT_OAUTH_REDIRECT_URIS,
-            policy=LEGACY_FULL,
-            capabilities=(),
-        )
+        try:
+            state.migrate_legacy()
+            if config.VAULT_OAUTH_CLIENT_ID:
+                state.ensure_static_client(
+                    config.VAULT_OAUTH_CLIENT_ID,
+                    config.VAULT_OAUTH_REDIRECT_URIS,
+                    policy=LEGACY_FULL,
+                    capabilities=(),
+                )
+        except BaseException:
+            state.close()
+            raise
+        _oauth_state = state
     return _oauth_state
 
 
@@ -175,14 +189,15 @@ def _check_credentials(username: str, password: str) -> bool:
     expected_username = config.VAULT_OAUTH_USERNAME or "obsidian"
     return bool(
         _login_configured()
-        and hmac.compare_digest(username, expected_username)
-        and hmac.compare_digest(password, config.VAULT_OAUTH_PASSWORD)
+        and _text_matches(username, expected_username)
+        and _text_matches(password, config.VAULT_OAUTH_PASSWORD)
     )
 
 
 def _login_form(
     params: Mapping[str, str],
     *,
+    client_name: str,
     error: str | None = None,
     status_code: int = 200,
 ) -> HTMLResponse:
@@ -192,12 +207,16 @@ def _login_form(
         for name, value in params.items()
     )
     error_html = f'<p role="alert">{html.escape(error)}</p>' if error else ""
+    client_name_html = html.escape(client_name)
+    redirect_uri_html = html.escape(params["redirect_uri"])
     content = f"""<!doctype html>
 <html lang="en">
 <head><meta charset="utf-8"><title>Authorize Obsidian Vault MCP</title></head>
 <body>
   <main>
     <h1>Authorize Obsidian Vault MCP</h1>
+    <p>Client: <strong>{client_name_html}</strong></p>
+    <p>Redirect URI: <code>{redirect_uri_html}</code></p>
     {error_html}
     <form method="post" action="/oauth/authorize">
       {hidden}
@@ -228,8 +247,11 @@ async def oauth_authorize(request: Request):
     if not _login_configured():
         logger.error("OAuth authorization refused: login is not configured")
         return _login_misconfigured()
+    state = get_oauth_state()
+    client = state.get_client(params["client_id"])
+    assert client is not None
     if request.method == "GET":
-        return _login_form(params)
+        return _login_form(params, client_name=client.client_name)
 
     assert form is not None
     username = str(form.get("username", "") or "")
@@ -237,12 +259,12 @@ async def oauth_authorize(request: Request):
     if not _check_credentials(username, password):
         logger.warning("OAuth login failed")
         return _login_form(
-            params, error="Invalid username or password", status_code=401
+            params,
+            client_name=client.client_name,
+            error="Invalid username or password",
+            status_code=401,
         )
 
-    state = get_oauth_state()
-    client = state.get_client(params["client_id"])
-    assert client is not None
     requires_reauthorization = client.policy == REAUTHORIZATION_REQUIRED
     code = state.issue_authorization_code(
         client_id=client.client_id,
@@ -383,13 +405,15 @@ async def oauth_register(request: Request) -> JSONResponse:
     raw_redirects = body.get("redirect_uris", [])
     if not isinstance(raw_redirects, list):
         return _oauth_error("invalid_client_metadata", "redirect_uris must be an array")
-    redirect_uris = list(
-        dict.fromkeys(
-            uri
-            for uri in raw_redirects
-            if isinstance(uri, str) and _valid_redirect_uri(uri)
+    if not raw_redirects or any(
+        not isinstance(uri, str) or not _valid_redirect_uri(uri)
+        for uri in raw_redirects
+    ):
+        return _oauth_error(
+            "invalid_redirect_uri",
+            "redirect_uris must contain only HTTPS or loopback HTTP URIs",
         )
-    )
+    redirect_uris = list(dict.fromkeys(raw_redirects))
     client_name = body.get("client_name", "Obsidian Vault MCP Client")
     if not isinstance(client_name, str):
         return _oauth_error("invalid_client_metadata", "client_name must be a string")

--- a/src/obsidian_vault_mcp/oauth_admin.py
+++ b/src/obsidian_vault_mcp/oauth_admin.py
@@ -1,0 +1,160 @@
+"""Local metadata-only operations for durable OAuth state."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from pathlib import Path
+from typing import TextIO
+
+from . import config
+from .oauth_state import OAuthState, OAuthStateError
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="vault-mcp-oauth",
+        description="Inspect, revoke, and back up local OAuth metadata.",
+    )
+    parser.add_argument(
+        "--state-path", type=Path, default=config.VAULT_OAUTH_STATE_PATH
+    )
+    parser.add_argument("--vault-path", type=Path, default=config.VAULT_PATH)
+    parser.add_argument("--legacy-path", type=Path, default=config.OAUTH_CLIENTS_PATH)
+    parser.add_argument(
+        "--approved-legacy-client-id",
+        action="append",
+        dest="approved_legacy_client_ids",
+        default=list(config.VAULT_OAUTH_APPROVED_LEGACY_CLIENT_IDS),
+    )
+    parser.add_argument(
+        "--access-token-ttl-seconds",
+        type=int,
+        default=config.oauth_access_token_ttl_seconds(),
+    )
+    resources = parser.add_subparsers(dest="resource", required=True)
+
+    clients = resources.add_parser("clients", help="Client metadata operations")
+    client_actions = clients.add_subparsers(dest="action", required=True)
+    client_actions.add_parser("list", help="List client metadata")
+    revoke_client = client_actions.add_parser(
+        "revoke", help="Revoke a client and all of its state"
+    )
+    revoke_client.add_argument("client_id")
+
+    tokens = resources.add_parser("tokens", help="Token metadata operations")
+    token_actions = tokens.add_subparsers(dest="action", required=True)
+    list_tokens = token_actions.add_parser("list", help="List token metadata")
+    list_tokens.add_argument("--client-id")
+    list_tokens.add_argument(
+        "--active-only", action="store_true", help="Hide expired/revoked tokens"
+    )
+    revoke_token = token_actions.add_parser("revoke", help="Revoke one token")
+    revoke_token.add_argument("token_id")
+
+    backup = resources.add_parser("backup", help="Create an online SQLite backup")
+    backup.add_argument("destination", type=Path)
+    return parser
+
+
+def _client_payload(client) -> dict[str, object]:
+    return {
+        "client_id": client.client_id,
+        "client_name": client.client_name,
+        "created_at": client.created_at,
+        "is_static": client.is_static,
+        "last_authorized_at": client.last_authorized_at,
+        "policy": client.policy,
+        "redirect_uris": list(client.redirect_uris),
+        "revoked_at": client.revoked_at,
+    }
+
+
+def _token_payload(token) -> dict[str, object]:
+    return {
+        "capabilities": list(token.capabilities),
+        "client_id": token.client_id,
+        "expires_at": token.expires_at,
+        "issued_at": token.issued_at,
+        "policy": token.policy,
+        "resource": token.resource,
+        "revoked_at": token.revoked_at,
+        "token_id": token.token_id,
+    }
+
+
+def _emit(stream: TextIO, payload: object) -> None:
+    json.dump(payload, stream, sort_keys=True, separators=(",", ":"))
+    stream.write("\n")
+
+
+def main(
+    argv: list[str] | None = None,
+    *,
+    stdout: TextIO | None = None,
+    stderr: TextIO | None = None,
+) -> int:
+    """Execute one local operation and return a process-style status code."""
+    output = stdout or sys.stdout
+    errors = stderr or sys.stderr
+    try:
+        args = _parser().parse_args(argv)
+    except ValueError as exc:
+        _emit(errors, {"error": str(exc)})
+        return 1
+    state: OAuthState | None = None
+    try:
+        state = OAuthState(
+            args.state_path,
+            vault_path=args.vault_path,
+            legacy_path=args.legacy_path,
+            approved_legacy_client_ids=frozenset(args.approved_legacy_client_ids),
+            access_token_ttl_seconds=args.access_token_ttl_seconds,
+        )
+        if args.resource == "clients" and args.action == "list":
+            clients = [_client_payload(client) for client in state.list_clients()]
+            _emit(output, clients)
+            return 0
+        if args.resource == "clients" and args.action == "revoke":
+            revoked = state.revoke_client(args.client_id)
+            _emit(
+                output,
+                {"client_id": args.client_id, "revoked": revoked},
+            )
+            return 0 if revoked else 1
+        if args.resource == "tokens" and args.action == "list":
+            tokens = state.list_tokens(include_inactive=not args.active_only)
+            if args.client_id is not None:
+                tokens = tuple(
+                    token for token in tokens if token.client_id == args.client_id
+                )
+            _emit(output, [_token_payload(token) for token in tokens])
+            return 0
+        if args.resource == "tokens" and args.action == "revoke":
+            revoked = state.revoke_token(args.token_id)
+            _emit(
+                output,
+                {"revoked": revoked, "token_id": args.token_id},
+            )
+            return 0 if revoked else 1
+        if args.resource == "backup":
+            destination = state.backup(args.destination)
+            _emit(output, {"backup": str(destination)})
+            return 0
+        raise AssertionError("unhandled OAuth admin command")
+    except (OSError, ValueError, OAuthStateError, sqlite3.Error) as exc:
+        _emit(errors, {"error": str(exc)})
+        return 1
+    finally:
+        if state is not None:
+            state.close()
+
+
+def _entrypoint() -> None:
+    raise SystemExit(main())
+
+
+if __name__ == "__main__":
+    _entrypoint()

--- a/src/obsidian_vault_mcp/oauth_state.py
+++ b/src/obsidian_vault_mcp/oauth_state.py
@@ -1,0 +1,1210 @@
+"""Transactional, secret-free-at-rest OAuth lifecycle state."""
+
+from __future__ import annotations
+
+import base64
+import contextlib
+import hashlib
+import hmac
+import json
+import os
+import secrets
+import sqlite3
+import stat
+import threading
+import time
+from collections.abc import Callable, Iterable, Iterator, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = 1
+AUTHORIZATION_CODE_TTL_SECONDS = 300
+MAX_ACCESS_TOKEN_TTL_SECONDS = 30 * 24 * 60 * 60
+
+VAULT_READONLY_V1 = "vault_readonly_v1"
+LEGACY_FULL = "legacy_full"
+REAUTHORIZATION_REQUIRED = "reauthorization_required"
+VAULT_READONLY_CAPABILITIES = (
+    "vault_batch_read",
+    "vault_list",
+    "vault_read",
+    "vault_search",
+    "vault_search_frontmatter",
+)
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS clients (
+    client_id TEXT PRIMARY KEY,
+    secret_verifier BLOB,
+    policy TEXT NOT NULL,
+    is_static INTEGER NOT NULL CHECK (is_static IN (0, 1)),
+    client_name TEXT NOT NULL,
+    created_at REAL NOT NULL,
+    last_authorized_at REAL,
+    revoked_at REAL
+);
+CREATE TABLE IF NOT EXISTS client_redirect_uris (
+    client_id TEXT NOT NULL REFERENCES clients(client_id) ON DELETE CASCADE,
+    redirect_uri TEXT NOT NULL,
+    PRIMARY KEY (client_id, redirect_uri)
+);
+CREATE TABLE IF NOT EXISTS authorization_codes (
+    code_verifier BLOB PRIMARY KEY,
+    client_id TEXT NOT NULL REFERENCES clients(client_id) ON DELETE CASCADE,
+    redirect_uri TEXT NOT NULL,
+    code_challenge TEXT NOT NULL,
+    resource TEXT NOT NULL,
+    policy TEXT NOT NULL,
+    capabilities_json TEXT NOT NULL,
+    created_at REAL NOT NULL,
+    expires_at REAL NOT NULL,
+    consumed_at REAL,
+    revoked_at REAL
+);
+CREATE TABLE IF NOT EXISTS access_tokens (
+    token_id TEXT PRIMARY KEY,
+    secret_verifier BLOB NOT NULL,
+    client_id TEXT NOT NULL REFERENCES clients(client_id) ON DELETE CASCADE,
+    policy TEXT NOT NULL,
+    resource TEXT NOT NULL,
+    issued_at REAL NOT NULL,
+    expires_at REAL NOT NULL,
+    revoked_at REAL
+);
+CREATE TABLE IF NOT EXISTS access_token_capabilities (
+    token_id TEXT NOT NULL REFERENCES access_tokens(token_id) ON DELETE CASCADE,
+    capability TEXT NOT NULL,
+    PRIMARY KEY (token_id, capability)
+);
+CREATE TABLE IF NOT EXISTS migration_metadata (
+    name TEXT PRIMARY KEY,
+    source_digest TEXT NOT NULL,
+    imported_count INTEGER NOT NULL,
+    completed_at REAL NOT NULL,
+    cleanup_pending INTEGER NOT NULL CHECK (cleanup_pending IN (0, 1))
+);
+"""
+
+
+class OAuthStateError(RuntimeError):
+    """Base class for OAuth state errors safe to map to protocol failures."""
+
+
+class UnsafeStatePath(OAuthStateError):
+    """A state, migration, or backup path violates local security rules."""
+
+
+class InvalidClient(OAuthStateError):
+    """Client authentication or client state is invalid."""
+
+
+class InvalidGrant(OAuthStateError):
+    """Authorization-code state is invalid."""
+
+
+class InvalidTarget(OAuthStateError):
+    """The resource target differs from the authorized resource."""
+
+
+@dataclass(frozen=True)
+class ClientMetadata:
+    client_id: str
+    redirect_uris: tuple[str, ...]
+    policy: str
+    client_name: str
+    created_at: float
+    last_authorized_at: float | None
+    revoked_at: float | None
+    is_static: bool
+
+    @property
+    def capabilities(self) -> tuple[str, ...]:
+        if self.policy == VAULT_READONLY_V1:
+            return VAULT_READONLY_CAPABILITIES
+        return ()
+
+
+@dataclass(frozen=True)
+class RegisteredClient:
+    client: ClientMetadata
+    client_secret: str
+
+
+@dataclass(frozen=True)
+class TokenMetadata:
+    token_id: str
+    client_id: str
+    policy: str
+    capabilities: tuple[str, ...]
+    resource: str
+    issued_at: float
+    expires_at: float
+    revoked_at: float | None
+
+
+@dataclass(frozen=True)
+class IssuedAccessToken:
+    access_token: str
+    token: TokenMetadata
+
+
+@dataclass(frozen=True)
+class MigrationRecord:
+    client_id: str
+    client_secret: str
+    redirect_uris: tuple[str, ...]
+    client_name: str
+    created_at: float
+
+
+class OAuthState:
+    """SQLite-backed OAuth state with atomic lifecycle transitions."""
+
+    def __init__(
+        self,
+        path: str | Path,
+        *,
+        vault_path: str | Path,
+        legacy_path: str | Path | None = None,
+        approved_legacy_client_ids: frozenset[str] = frozenset(),
+        access_token_ttl_seconds: int = 86_400,
+        clock: Callable[[], float] | None = None,
+        static_client_authenticator: Callable[[str, str], bool] | None = None,
+    ) -> None:
+        if not 1 <= access_token_ttl_seconds <= MAX_ACCESS_TOKEN_TTL_SECONDS:
+            raise ValueError("access_token_ttl_seconds must be between 1 and 2592000")
+        self.path = Path(path).expanduser().absolute()
+        self.vault_path = Path(vault_path).expanduser().absolute()
+        self.legacy_path = (
+            Path(legacy_path).expanduser().absolute()
+            if legacy_path is not None
+            else None
+        )
+        self.approved_legacy_client_ids = approved_legacy_client_ids
+        self.access_token_ttl_seconds = access_token_ttl_seconds
+        self._clock = clock or time.time
+        self._static_client_authenticator = static_client_authenticator
+        self._lock = threading.RLock()
+        self._closed = False
+
+        self._assert_outside_vault(self.path)
+        self._prepare_secure_directory(self.path.parent)
+        self._validate_state_targets()
+        self._create_database_file()
+        self._connection = sqlite3.connect(
+            self.path,
+            timeout=30,
+            isolation_level=None,
+            check_same_thread=False,
+        )
+        self._connection.row_factory = sqlite3.Row
+        try:
+            self._configure_connection()
+            self._initialize_schema()
+            self._migrate_legacy_once()
+            self._secure_state_files()
+        except BaseException:
+            self._connection.close()
+            self._closed = True
+            raise
+
+    @property
+    def schema_version(self) -> int:
+        with self._lock:
+            return int(self._connection.execute("PRAGMA user_version").fetchone()[0])
+
+    def table_names(self) -> set[str]:
+        with self._lock:
+            rows = self._connection.execute(
+                "SELECT name FROM sqlite_master "
+                "WHERE type = 'table' AND name NOT LIKE 'sqlite_%'"
+            ).fetchall()
+        return {str(row[0]) for row in rows}
+
+    def close(self) -> None:
+        with self._lock:
+            if not self._closed:
+                self._connection.close()
+                self._closed = True
+
+    def __enter__(self) -> OAuthState:
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        self.close()
+
+    def register_client(
+        self,
+        redirect_uris: Sequence[str],
+        *,
+        client_name: str = "Obsidian Vault MCP Client",
+    ) -> RegisteredClient:
+        redirects = self._normalize_redirects(redirect_uris)
+        now = self._clock()
+        with self._transaction() as connection:
+            while True:
+                client_id = f"vault-mcp-{secrets.token_hex(8)}"
+                exists = connection.execute(
+                    "SELECT 1 FROM clients WHERE client_id = ?", (client_id,)
+                ).fetchone()
+                if exists is None:
+                    break
+            client_secret = secrets.token_hex(32)
+            connection.execute(
+                "INSERT INTO clients "
+                "(client_id, secret_verifier, policy, is_static, client_name, "
+                "created_at) VALUES (?, ?, ?, 0, ?, ?)",
+                (
+                    client_id,
+                    _secret_verifier("client", client_secret),
+                    VAULT_READONLY_V1,
+                    client_name,
+                    now,
+                ),
+            )
+            connection.executemany(
+                "INSERT INTO client_redirect_uris (client_id, redirect_uri) "
+                "VALUES (?, ?)",
+                ((client_id, uri) for uri in redirects),
+            )
+        client = self.get_client(client_id)
+        assert client is not None
+        return RegisteredClient(client=client, client_secret=client_secret)
+
+    def ensure_static_client(
+        self,
+        client_id: str,
+        redirect_uris: Sequence[str],
+        *,
+        policy: str,
+        capabilities: Sequence[str],
+        client_name: str = "Obsidian Vault MCP Static Client",
+    ) -> ClientMetadata:
+        del capabilities
+        if not client_id:
+            raise ValueError("static client_id must not be empty")
+        self._validate_policy(policy)
+        redirects = self._normalize_redirects(redirect_uris)
+        now = self._clock()
+        with self._transaction() as connection:
+            existing = connection.execute(
+                "SELECT * FROM clients WHERE client_id = ?", (client_id,)
+            ).fetchone()
+            if existing is None:
+                connection.execute(
+                    "INSERT INTO clients "
+                    "(client_id, secret_verifier, policy, is_static, "
+                    "client_name, created_at) VALUES (?, NULL, ?, 1, ?, ?)",
+                    (client_id, policy, client_name, now),
+                )
+                connection.executemany(
+                    "INSERT INTO client_redirect_uris "
+                    "(client_id, redirect_uri) VALUES (?, ?)",
+                    ((client_id, uri) for uri in redirects),
+                )
+            elif not bool(existing["is_static"]):
+                raise ValueError(
+                    f"configured static client_id {client_id!r} is already dynamic"
+                )
+            else:
+                connection.execute(
+                    "UPDATE clients SET policy = ?, client_name = ? "
+                    "WHERE client_id = ?",
+                    (policy, client_name, client_id),
+                )
+                connection.execute(
+                    "DELETE FROM client_redirect_uris WHERE client_id = ?",
+                    (client_id,),
+                )
+                connection.executemany(
+                    "INSERT INTO client_redirect_uris "
+                    "(client_id, redirect_uri) VALUES (?, ?)",
+                    ((client_id, uri) for uri in redirects),
+                )
+        client = self.get_client(client_id)
+        assert client is not None
+        return client
+
+    def get_client(self, client_id: str) -> ClientMetadata | None:
+        with self._lock:
+            row = self._connection.execute(
+                "SELECT * FROM clients WHERE client_id = ?", (client_id,)
+            ).fetchone()
+            if row is None:
+                return None
+            redirects = self._redirects_for(self._connection, client_id)
+        return _client_from_row(row, redirects)
+
+    def list_clients(self) -> tuple[ClientMetadata, ...]:
+        with self._lock:
+            rows = self._connection.execute(
+                "SELECT * FROM clients ORDER BY created_at, client_id"
+            ).fetchall()
+            return tuple(
+                _client_from_row(
+                    row, self._redirects_for(self._connection, row["client_id"])
+                )
+                for row in rows
+            )
+
+    def verify_client_secret(self, client_id: str, client_secret: str) -> bool:
+        if not client_secret:
+            return False
+        with self._lock:
+            row = self._connection.execute(
+                "SELECT secret_verifier, is_static, revoked_at FROM clients "
+                "WHERE client_id = ?",
+                (client_id,),
+            ).fetchone()
+        if row is None or row["revoked_at"] is not None:
+            return False
+        if bool(row["is_static"]):
+            authenticator = self._static_client_authenticator
+            return bool(
+                authenticator is not None and authenticator(client_id, client_secret)
+            )
+        verifier = row["secret_verifier"]
+        return bool(
+            verifier is not None
+            and hmac.compare_digest(
+                bytes(verifier), _secret_verifier("client", client_secret)
+            )
+        )
+
+    def client_redirect_uri_allowed(self, client_id: str, uri: str) -> bool:
+        with self._lock:
+            row = self._connection.execute(
+                "SELECT 1 FROM clients AS c "
+                "JOIN client_redirect_uris AS r USING (client_id) "
+                "WHERE c.client_id = ? AND c.revoked_at IS NULL "
+                "AND r.redirect_uri = ?",
+                (client_id, uri),
+            ).fetchone()
+        return row is not None
+
+    def can_issue_authorization_code(self, client_id: str) -> bool:
+        client = self.get_client(client_id)
+        return bool(
+            client is not None
+            and client.revoked_at is None
+            and client.policy != REAUTHORIZATION_REQUIRED
+        )
+
+    def issue_authorization_code(
+        self,
+        *,
+        client_id: str,
+        redirect_uri: str,
+        code_challenge: str,
+        resource: str,
+        fresh_reauthorization: bool = False,
+    ) -> str:
+        if not code_challenge:
+            raise InvalidGrant("missing PKCE challenge")
+        now = self._clock()
+        code = secrets.token_urlsafe(32)
+        with self._transaction() as connection:
+            client = connection.execute(
+                "SELECT policy, revoked_at FROM clients WHERE client_id = ?",
+                (client_id,),
+            ).fetchone()
+            if client is None or client["revoked_at"] is not None:
+                raise InvalidClient("unknown or revoked client")
+            policy = str(client["policy"])
+            if policy == REAUTHORIZATION_REQUIRED:
+                if not fresh_reauthorization:
+                    raise InvalidClient("client requires fresh reauthorization")
+                policy = VAULT_READONLY_V1
+                connection.execute(
+                    "UPDATE clients SET policy = ?, last_authorized_at = ? "
+                    "WHERE client_id = ?",
+                    (policy, now, client_id),
+                )
+            capabilities = _capabilities_for_policy(policy)
+            allowed = connection.execute(
+                "SELECT 1 FROM client_redirect_uris "
+                "WHERE client_id = ? AND redirect_uri = ?",
+                (client_id, redirect_uri),
+            ).fetchone()
+            if allowed is None:
+                raise InvalidGrant("redirect URI is not registered")
+            connection.execute(
+                "INSERT INTO authorization_codes "
+                "(code_verifier, client_id, redirect_uri, code_challenge, "
+                "resource, policy, capabilities_json, created_at, expires_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    _secret_verifier("authorization-code", code),
+                    client_id,
+                    redirect_uri,
+                    code_challenge,
+                    resource,
+                    policy,
+                    json.dumps(capabilities, separators=(",", ":")),
+                    now,
+                    now + AUTHORIZATION_CODE_TTL_SECONDS,
+                ),
+            )
+        return code
+
+    def authorization_code_active(self, code: str) -> bool:
+        now = self._clock()
+        with self._lock:
+            row = self._connection.execute(
+                "SELECT expires_at, consumed_at, revoked_at "
+                "FROM authorization_codes WHERE code_verifier = ?",
+                (_secret_verifier("authorization-code", code),),
+            ).fetchone()
+        return bool(
+            row is not None
+            and row["consumed_at"] is None
+            and row["revoked_at"] is None
+            and now < float(row["expires_at"])
+        )
+
+    def redeem_authorization_code(
+        self,
+        *,
+        code: str,
+        client_id: str,
+        client_secret: str,
+        redirect_uri: str,
+        code_verifier: str,
+        resource: str,
+    ) -> IssuedAccessToken:
+        now = self._clock()
+        with self._transaction() as connection:
+            self._authenticate_client_in_transaction(
+                connection, client_id, client_secret
+            )
+            row = connection.execute(
+                "SELECT * FROM authorization_codes WHERE code_verifier = ?",
+                (_secret_verifier("authorization-code", code),),
+            ).fetchone()
+            if row is None:
+                raise InvalidGrant("unknown authorization code")
+            if row["client_id"] != client_id:
+                raise InvalidGrant("authorization code client mismatch")
+            if row["redirect_uri"] != redirect_uri:
+                raise InvalidGrant("authorization code redirect mismatch")
+            if row["resource"] != resource:
+                raise InvalidTarget("authorization code resource mismatch")
+            if now >= float(row["expires_at"]):
+                raise InvalidGrant("authorization code expired")
+            computed_challenge = (
+                base64.urlsafe_b64encode(
+                    hashlib.sha256(code_verifier.encode()).digest()
+                )
+                .rstrip(b"=")
+                .decode()
+            )
+            if not hmac.compare_digest(computed_challenge, row["code_challenge"]):
+                raise InvalidGrant("PKCE verification failed")
+
+            capabilities = tuple(json.loads(row["capabilities_json"]))
+            issued = self._insert_access_token(
+                connection,
+                client_id=client_id,
+                policy=row["policy"],
+                capabilities=capabilities,
+                resource=resource,
+                now=now,
+            )
+            updated = connection.execute(
+                "UPDATE authorization_codes SET consumed_at = ? "
+                "WHERE code_verifier = ? AND consumed_at IS NULL "
+                "AND revoked_at IS NULL",
+                (now, row["code_verifier"]),
+            )
+            if updated.rowcount != 1:
+                raise InvalidGrant("authorization code was already consumed")
+            connection.execute(
+                "UPDATE clients SET last_authorized_at = ? WHERE client_id = ?",
+                (now, client_id),
+            )
+            return issued
+
+    def issue_access_token(
+        self,
+        *,
+        client_id: str,
+        resource: str,
+    ) -> IssuedAccessToken:
+        now = self._clock()
+        with self._transaction() as connection:
+            row = connection.execute(
+                "SELECT revoked_at, policy FROM clients WHERE client_id = ?",
+                (client_id,),
+            ).fetchone()
+            if (
+                row is None
+                or row["revoked_at"] is not None
+                or row["policy"] == REAUTHORIZATION_REQUIRED
+            ):
+                raise InvalidClient("unknown, revoked, or unauthorized client")
+            policy = str(row["policy"])
+            return self._insert_access_token(
+                connection,
+                client_id=client_id,
+                policy=policy,
+                capabilities=_capabilities_for_policy(policy),
+                resource=resource,
+                now=now,
+            )
+
+    def lookup_access_token(self, access_token: str) -> TokenMetadata | None:
+        parsed = _parse_access_token(access_token)
+        if parsed is None:
+            return None
+        token_id, secret = parsed
+        now = self._clock()
+        with self._lock:
+            row = self._connection.execute(
+                "SELECT t.*, c.revoked_at AS client_revoked_at "
+                "FROM access_tokens AS t "
+                "JOIN clients AS c USING (client_id) "
+                "WHERE token_id = ?",
+                (token_id,),
+            ).fetchone()
+            if row is None:
+                return None
+            if (
+                row["revoked_at"] is not None
+                or row["client_revoked_at"] is not None
+                or now >= float(row["expires_at"])
+                or not hmac.compare_digest(
+                    bytes(row["secret_verifier"]),
+                    _secret_verifier("access-token", secret),
+                )
+            ):
+                return None
+            capabilities = self._token_capabilities(self._connection, token_id)
+        return _token_from_row(row, capabilities)
+
+    def list_tokens(
+        self,
+        *,
+        include_inactive: bool = True,
+    ) -> tuple[TokenMetadata, ...]:
+        now = self._clock()
+        with self._lock:
+            rows = self._connection.execute(
+                "SELECT t.*, c.revoked_at AS client_revoked_at "
+                "FROM access_tokens AS t JOIN clients AS c USING (client_id) "
+                "ORDER BY t.issued_at, t.token_id"
+            ).fetchall()
+            tokens = []
+            for row in rows:
+                if not include_inactive and (
+                    row["revoked_at"] is not None
+                    or row["client_revoked_at"] is not None
+                    or now >= float(row["expires_at"])
+                ):
+                    continue
+                tokens.append(
+                    _token_from_row(
+                        row,
+                        self._token_capabilities(self._connection, row["token_id"]),
+                    )
+                )
+        return tuple(tokens)
+
+    def revoke_token(self, token_id: str) -> bool:
+        now = self._clock()
+        with self._transaction() as connection:
+            result = connection.execute(
+                "UPDATE access_tokens SET revoked_at = ? "
+                "WHERE token_id = ? AND revoked_at IS NULL",
+                (now, token_id),
+            )
+        return result.rowcount == 1
+
+    def revoke_client(self, client_id: str) -> bool:
+        now = self._clock()
+        with self._transaction() as connection:
+            result = connection.execute(
+                "UPDATE clients SET revoked_at = ? "
+                "WHERE client_id = ? AND revoked_at IS NULL",
+                (now, client_id),
+            )
+            if result.rowcount != 1:
+                return False
+            connection.execute(
+                "UPDATE authorization_codes SET revoked_at = ? "
+                "WHERE client_id = ? AND revoked_at IS NULL "
+                "AND consumed_at IS NULL",
+                (now, client_id),
+            )
+            connection.execute(
+                "UPDATE access_tokens SET revoked_at = ? "
+                "WHERE client_id = ? AND revoked_at IS NULL",
+                (now, client_id),
+            )
+        return True
+
+    def backup(self, destination: str | Path) -> Path:
+        target = Path(destination).expanduser().absolute()
+        live_paths = {
+            self.path,
+            Path(f"{self.path}-wal"),
+            Path(f"{self.path}-shm"),
+        }
+        if target in live_paths:
+            raise UnsafeStatePath(
+                f"backup destination overlaps live OAuth state: {target}"
+            )
+        self._assert_outside_vault(target)
+        self._prepare_secure_directory(target.parent)
+        self._validate_secure_file(target, allow_missing=True)
+        for suffix in ("-wal", "-shm"):
+            sidecar = Path(f"{target}{suffix}")
+            if not os.path.lexists(sidecar):
+                continue
+            try:
+                self._validate_secure_file(sidecar, allow_missing=False)
+            except UnsafeStatePath as exc:
+                raise UnsafeStatePath(
+                    f"backup destination sidecar is unsafe: {sidecar}"
+                ) from exc
+            raise UnsafeStatePath(
+                f"backup destination sidecar already exists: {sidecar}"
+            )
+        temporary = target.with_name(
+            f".{target.name}.backup-{os.getpid()}-{secrets.token_hex(6)}"
+        )
+        self._create_secure_file(temporary)
+        backup_connection: sqlite3.Connection | None = None
+        try:
+            backup_connection = sqlite3.connect(temporary)
+            with self._lock:
+                self._connection.backup(backup_connection)
+            backup_connection.commit()
+            backup_connection.close()
+            backup_connection = None
+            os.chmod(temporary, 0o600, follow_symlinks=False)
+            with temporary.open("rb") as backup_file:
+                os.fsync(backup_file.fileno())
+            os.replace(temporary, target)
+            os.chmod(target, 0o600, follow_symlinks=False)
+            self._fsync_directory(target.parent)
+            return target
+        finally:
+            if backup_connection is not None:
+                backup_connection.close()
+            with contextlib.suppress(FileNotFoundError):
+                temporary.unlink()
+
+    def _configure_connection(self) -> None:
+        self._connection.execute("PRAGMA foreign_keys = ON")
+        self._connection.execute("PRAGMA busy_timeout = 30000")
+        self._connection.execute("PRAGMA synchronous = FULL")
+        deadline = time.monotonic() + 30
+        while True:
+            try:
+                mode = self._connection.execute("PRAGMA journal_mode = WAL").fetchone()[
+                    0
+                ]
+                break
+            except sqlite3.OperationalError as exc:
+                if (
+                    exc.sqlite_errorcode
+                    not in {sqlite3.SQLITE_BUSY, sqlite3.SQLITE_LOCKED}
+                    or time.monotonic() >= deadline
+                ):
+                    raise
+                # SQLite's busy handler does not cover every journal-mode race.
+                time.sleep(0.01)
+        if str(mode).lower() != "wal":
+            raise OAuthStateError("SQLite could not enable WAL mode")
+
+    def _migrate_legacy_once(self) -> None:
+        migration_name = "legacy_clients_json_v1"
+        source_bytes: bytes | None = None
+        source_digest = ""
+        records: tuple[MigrationRecord, ...] = ()
+        cleanup_pending = False
+
+        with self._transaction() as connection:
+            marker = connection.execute(
+                "SELECT * FROM migration_metadata WHERE name = ?",
+                (migration_name,),
+            ).fetchone()
+            if marker is not None:
+                cleanup_pending = bool(marker["cleanup_pending"])
+                source_digest = str(marker["source_digest"])
+            elif self.legacy_path is None or not os.path.lexists(self.legacy_path):
+                if self.approved_legacy_client_ids:
+                    raise ValueError(
+                        "approved legacy client IDs are absent from migration source"
+                    )
+                connection.execute(
+                    "INSERT INTO migration_metadata "
+                    "(name, source_digest, imported_count, completed_at, "
+                    "cleanup_pending) VALUES (?, '', 0, ?, 0)",
+                    (migration_name, self._clock()),
+                )
+                return
+            else:
+                self._assert_outside_vault(self.legacy_path)
+                self._validate_secure_file(self.legacy_path, allow_missing=False)
+                source_bytes = self.legacy_path.read_bytes()
+                source_digest = hashlib.sha256(source_bytes).hexdigest()
+                records = self._parse_legacy_records(source_bytes)
+                imported_ids = {record.client_id for record in records}
+                missing = self.approved_legacy_client_ids - imported_ids
+                if missing:
+                    joined = ", ".join(sorted(missing))
+                    raise ValueError(
+                        f"approved legacy client IDs absent from source: {joined}"
+                    )
+                for record in records:
+                    policy = (
+                        LEGACY_FULL
+                        if record.client_id in self.approved_legacy_client_ids
+                        else REAUTHORIZATION_REQUIRED
+                    )
+                    connection.execute(
+                        "INSERT INTO clients "
+                        "(client_id, secret_verifier, policy, is_static, "
+                        "client_name, created_at) VALUES (?, ?, ?, 0, ?, ?)",
+                        (
+                            record.client_id,
+                            _secret_verifier("client", record.client_secret),
+                            policy,
+                            record.client_name,
+                            record.created_at,
+                        ),
+                    )
+                    connection.executemany(
+                        "INSERT INTO client_redirect_uris "
+                        "(client_id, redirect_uri) VALUES (?, ?)",
+                        (
+                            (record.client_id, redirect_uri)
+                            for redirect_uri in record.redirect_uris
+                        ),
+                    )
+                connection.execute(
+                    "INSERT INTO migration_metadata "
+                    "(name, source_digest, imported_count, completed_at, "
+                    "cleanup_pending) VALUES (?, ?, ?, ?, 1)",
+                    (
+                        migration_name,
+                        source_digest,
+                        len(records),
+                        self._clock(),
+                    ),
+                )
+                cleanup_pending = True
+
+        if not cleanup_pending:
+            return
+        legacy_path = self.legacy_path
+        if legacy_path is None:
+            raise OAuthStateError(
+                "legacy OAuth cleanup is pending but source path is unavailable"
+            )
+        with self._transaction() as connection:
+            marker = connection.execute(
+                "SELECT source_digest, cleanup_pending "
+                "FROM migration_metadata WHERE name = ?",
+                (migration_name,),
+            ).fetchone()
+            if marker is None or not bool(marker["cleanup_pending"]):
+                return
+            expected_digest = str(marker["source_digest"])
+            if os.path.lexists(legacy_path):
+                self._validate_secure_file(legacy_path, allow_missing=False)
+                current_digest = hashlib.sha256(legacy_path.read_bytes()).hexdigest()
+                if current_digest != expected_digest:
+                    raise OAuthStateError(
+                        "legacy OAuth source changed after durable migration"
+                    )
+                try:
+                    legacy_path.unlink()
+                except FileNotFoundError:
+                    pass
+            self._fsync_directory(legacy_path.parent)
+            connection.execute(
+                "UPDATE migration_metadata SET cleanup_pending = 0 WHERE name = ?",
+                (migration_name,),
+            )
+
+    def _parse_legacy_records(self, source_bytes: bytes) -> tuple[MigrationRecord, ...]:
+        def reject_duplicates(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+            result: dict[str, Any] = {}
+            for key, value in pairs:
+                if key in result:
+                    raise ValueError(f"duplicate key in legacy OAuth source: {key}")
+                result[key] = value
+            return result
+
+        try:
+            payload = json.loads(
+                source_bytes.decode("utf-8"),
+                object_pairs_hook=reject_duplicates,
+            )
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise ValueError("malformed legacy OAuth source") from exc
+        if not isinstance(payload, dict):
+            raise ValueError("legacy OAuth source must contain an object")
+
+        records: list[MigrationRecord] = []
+        seen_redirects: set[str] = set()
+        for client_id, raw in payload.items():
+            if not isinstance(client_id, str) or not client_id:
+                raise ValueError("legacy client ID must be a non-empty string")
+            if not isinstance(raw, dict):
+                raise ValueError(f"legacy client {client_id!r} must be an object")
+            client_secret = raw.get("client_secret")
+            redirects = raw.get("redirect_uris")
+            if not isinstance(client_secret, str) or not client_secret:
+                raise ValueError(
+                    f"legacy client {client_id!r} has no valid client_secret"
+                )
+            if (
+                not isinstance(redirects, list)
+                or not redirects
+                or not all(isinstance(uri, str) and uri for uri in redirects)
+            ):
+                raise ValueError(
+                    f"legacy client {client_id!r} has invalid redirect_uris"
+                )
+            normalized_redirects = tuple(dict.fromkeys(redirects))
+            if len(normalized_redirects) != len(redirects):
+                raise ValueError(
+                    f"legacy client {client_id!r} has duplicate redirect URIs"
+                )
+            duplicates = set(normalized_redirects) & seen_redirects
+            if duplicates:
+                raise ValueError("legacy OAuth source contains duplicate redirect URIs")
+            seen_redirects.update(normalized_redirects)
+            created_at = raw.get("created_at", self._clock())
+            if not isinstance(created_at, (int, float)):
+                raise ValueError(f"legacy client {client_id!r} has invalid created_at")
+            client_name = raw.get("client_name", "Obsidian Vault MCP Migrated Client")
+            if not isinstance(client_name, str):
+                raise ValueError(f"legacy client {client_id!r} has invalid client_name")
+            records.append(
+                MigrationRecord(
+                    client_id=client_id,
+                    client_secret=client_secret,
+                    redirect_uris=normalized_redirects,
+                    client_name=client_name,
+                    created_at=float(created_at),
+                )
+            )
+        return tuple(records)
+
+    def _authenticate_client_in_transaction(
+        self,
+        connection: sqlite3.Connection,
+        client_id: str,
+        client_secret: str,
+    ) -> None:
+        row = connection.execute(
+            "SELECT secret_verifier, is_static, revoked_at FROM clients "
+            "WHERE client_id = ?",
+            (client_id,),
+        ).fetchone()
+        if row is None or row["revoked_at"] is not None or not client_secret:
+            raise InvalidClient("client authentication failed")
+        if bool(row["is_static"]):
+            authenticator = self._static_client_authenticator
+            valid = bool(
+                authenticator is not None and authenticator(client_id, client_secret)
+            )
+        else:
+            verifier = row["secret_verifier"]
+            valid = bool(
+                verifier is not None
+                and hmac.compare_digest(
+                    bytes(verifier),
+                    _secret_verifier("client", client_secret),
+                )
+            )
+        if not valid:
+            raise InvalidClient("client authentication failed")
+
+    def _insert_access_token(
+        self,
+        connection: sqlite3.Connection,
+        *,
+        client_id: str,
+        policy: str,
+        capabilities: Sequence[str],
+        resource: str,
+        now: float,
+    ) -> IssuedAccessToken:
+        normalized_capabilities = _normalize_capabilities(capabilities)
+        while True:
+            token_id = secrets.token_urlsafe(18)
+            exists = connection.execute(
+                "SELECT 1 FROM access_tokens WHERE token_id = ?", (token_id,)
+            ).fetchone()
+            if exists is None:
+                break
+        token_secret = secrets.token_urlsafe(32)
+        expires_at = now + self.access_token_ttl_seconds
+        connection.execute(
+            "INSERT INTO access_tokens "
+            "(token_id, secret_verifier, client_id, policy, resource, "
+            "issued_at, expires_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                token_id,
+                _secret_verifier("access-token", token_secret),
+                client_id,
+                policy,
+                resource,
+                now,
+                expires_at,
+            ),
+        )
+        connection.executemany(
+            "INSERT INTO access_token_capabilities (token_id, capability) "
+            "VALUES (?, ?)",
+            ((token_id, capability) for capability in normalized_capabilities),
+        )
+        token = TokenMetadata(
+            token_id=token_id,
+            client_id=client_id,
+            policy=policy,
+            capabilities=normalized_capabilities,
+            resource=resource,
+            issued_at=now,
+            expires_at=expires_at,
+            revoked_at=None,
+        )
+        return IssuedAccessToken(
+            access_token=f"v1.{token_id}.{token_secret}", token=token
+        )
+
+    @contextlib.contextmanager
+    def _transaction(self) -> Iterator[sqlite3.Connection]:
+        with self._lock:
+            self._connection.execute("BEGIN IMMEDIATE")
+            try:
+                yield self._connection
+            except BaseException:
+                self._connection.rollback()
+                raise
+            else:
+                self._connection.commit()
+
+    def _initialize_schema(self) -> None:
+        with self._lock:
+            version = int(self._connection.execute("PRAGMA user_version").fetchone()[0])
+            if version not in (0, SCHEMA_VERSION):
+                raise OAuthStateError(
+                    f"unsupported OAuth state schema version {version}"
+                )
+            script = (
+                "BEGIN IMMEDIATE;\n"
+                f"{_SCHEMA}\n"
+                f"PRAGMA user_version = {SCHEMA_VERSION};\n"
+                "COMMIT;\n"
+            )
+            try:
+                self._connection.executescript(script)
+            except BaseException:
+                self._connection.rollback()
+                raise
+
+    def _redirects_for(
+        self, connection: sqlite3.Connection, client_id: str
+    ) -> tuple[str, ...]:
+        rows = connection.execute(
+            "SELECT redirect_uri FROM client_redirect_uris "
+            "WHERE client_id = ? ORDER BY redirect_uri",
+            (client_id,),
+        ).fetchall()
+        return tuple(str(row[0]) for row in rows)
+
+    def _token_capabilities(
+        self, connection: sqlite3.Connection, token_id: str
+    ) -> tuple[str, ...]:
+        rows = connection.execute(
+            "SELECT capability FROM access_token_capabilities "
+            "WHERE token_id = ? ORDER BY capability",
+            (token_id,),
+        ).fetchall()
+        return tuple(str(row[0]) for row in rows)
+
+    def _validate_state_targets(self) -> None:
+        self._validate_secure_file(self.path, allow_missing=True)
+        for suffix in ("-wal", "-shm"):
+            self._validate_secure_file(Path(f"{self.path}{suffix}"), allow_missing=True)
+
+    def _create_database_file(self) -> None:
+        if not os.path.lexists(self.path):
+            try:
+                self._create_secure_file(self.path)
+            except FileExistsError:
+                # Another process won initialization; validate its result below.
+                pass
+        self._validate_secure_file(self.path, allow_missing=False)
+
+    @staticmethod
+    def _fsync_directory(directory: Path) -> None:
+        directory_fd = os.open(directory, os.O_RDONLY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+
+    def _secure_state_files(self) -> None:
+        os.chmod(self.path, 0o600, follow_symlinks=False)
+        for suffix in ("-wal", "-shm"):
+            sidecar = Path(f"{self.path}{suffix}")
+            if os.path.lexists(sidecar):
+                self._validate_secure_file(sidecar, allow_missing=False)
+                os.chmod(sidecar, 0o600, follow_symlinks=False)
+
+    def _prepare_secure_directory(self, directory: Path) -> None:
+        directory = directory.absolute()
+        if os.path.lexists(directory):
+            metadata = directory.lstat()
+            if stat.S_ISLNK(metadata.st_mode):
+                raise UnsafeStatePath(f"state directory is a symlink: {directory}")
+            if not stat.S_ISDIR(metadata.st_mode):
+                raise UnsafeStatePath(
+                    f"state directory is not a directory: {directory}"
+                )
+        else:
+            parent = directory.parent
+            if parent.resolve(strict=False) != parent.absolute():
+                raise UnsafeStatePath(
+                    f"state directory parent traverses a symlink: {parent}"
+                )
+            directory.mkdir(mode=0o700, parents=True, exist_ok=True)
+        metadata = directory.lstat()
+        self._validate_owner_and_mode(metadata, directory, is_directory=True)
+        os.chmod(directory, 0o700, follow_symlinks=False)
+
+    def _validate_secure_file(self, path: Path, *, allow_missing: bool) -> None:
+        if not os.path.lexists(path):
+            if allow_missing:
+                return
+            raise UnsafeStatePath(f"required state file is missing: {path}")
+        metadata = path.lstat()
+        if stat.S_ISLNK(metadata.st_mode):
+            raise UnsafeStatePath(f"state file is a symlink: {path}")
+        if not stat.S_ISREG(metadata.st_mode):
+            raise UnsafeStatePath(f"state path is not a regular file: {path}")
+        self._validate_owner_and_mode(metadata, path, is_directory=False)
+
+    def _validate_owner_and_mode(
+        self, metadata: os.stat_result, path: Path, *, is_directory: bool
+    ) -> None:
+        if metadata.st_uid != os.getuid():
+            raise UnsafeStatePath(f"state path has unsafe owner: {path}")
+        mode = stat.S_IMODE(metadata.st_mode)
+        if mode & 0o077:
+            kind = "directory" if is_directory else "file"
+            raise UnsafeStatePath(f"state {kind} has unsafe mode {mode:o}: {path}")
+
+    def _assert_outside_vault(self, path: Path) -> None:
+        resolved_path = path.resolve(strict=False)
+        resolved_vault = self.vault_path.resolve(strict=False)
+        try:
+            common = Path(os.path.commonpath((resolved_path, resolved_vault)))
+        except ValueError:
+            return
+        if common == resolved_vault:
+            raise UnsafeStatePath(f"OAuth state must remain outside the vault: {path}")
+
+    @staticmethod
+    def _create_secure_file(path: Path) -> None:
+        flags = os.O_CREAT | os.O_EXCL | os.O_RDWR
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        descriptor = os.open(path, flags, 0o600)
+        try:
+            os.fchmod(descriptor, 0o600)
+        finally:
+            os.close(descriptor)
+
+    @staticmethod
+    def _normalize_redirects(redirect_uris: Sequence[str]) -> tuple[str, ...]:
+        redirects = tuple(dict.fromkeys(redirect_uris))
+        if not all(isinstance(uri, str) and uri for uri in redirects):
+            raise ValueError("redirect URIs must be non-empty strings")
+        return redirects
+
+    @staticmethod
+    def _validate_policy(policy: str) -> None:
+        if policy not in {
+            VAULT_READONLY_V1,
+            LEGACY_FULL,
+            REAUTHORIZATION_REQUIRED,
+        }:
+            raise ValueError(f"unknown OAuth policy: {policy}")
+
+
+def _secret_verifier(kind: str, secret: str) -> bytes:
+    digest = hashlib.sha256()
+    digest.update(b"obsidian-vault-mcp/oauth-state/v1\0")
+    digest.update(kind.encode("ascii"))
+    digest.update(b"\0")
+    digest.update(secret.encode("utf-8"))
+    return digest.digest()
+
+
+def _normalize_capabilities(capabilities: Iterable[str]) -> tuple[str, ...]:
+    result = tuple(sorted(set(capabilities)))
+    if not all(isinstance(capability, str) and capability for capability in result):
+        raise ValueError("capabilities must be non-empty strings")
+    return result
+
+
+def _parse_access_token(access_token: str) -> tuple[str, str] | None:
+    if not isinstance(access_token, str):
+        return None
+    parts = access_token.split(".")
+    if len(parts) != 3 or parts[0] != "v1" or not parts[1] or not parts[2]:
+        return None
+    return parts[1], parts[2]
+
+
+def _capabilities_for_policy(policy: str) -> tuple[str, ...]:
+    if policy == VAULT_READONLY_V1:
+        return VAULT_READONLY_CAPABILITIES
+    if policy in {LEGACY_FULL, REAUTHORIZATION_REQUIRED}:
+        return ()
+    raise ValueError(f"unknown OAuth policy: {policy}")
+
+
+def _client_from_row(
+    row: sqlite3.Row, redirect_uris: tuple[str, ...]
+) -> ClientMetadata:
+    return ClientMetadata(
+        client_id=str(row["client_id"]),
+        redirect_uris=redirect_uris,
+        policy=str(row["policy"]),
+        client_name=str(row["client_name"]),
+        created_at=float(row["created_at"]),
+        last_authorized_at=(
+            float(row["last_authorized_at"])
+            if row["last_authorized_at"] is not None
+            else None
+        ),
+        revoked_at=(
+            float(row["revoked_at"]) if row["revoked_at"] is not None else None
+        ),
+        is_static=bool(row["is_static"]),
+    )
+
+
+def _token_from_row(row: sqlite3.Row, capabilities: tuple[str, ...]) -> TokenMetadata:
+    return TokenMetadata(
+        token_id=str(row["token_id"]),
+        client_id=str(row["client_id"]),
+        policy=str(row["policy"]),
+        capabilities=capabilities,
+        resource=str(row["resource"]),
+        issued_at=float(row["issued_at"]),
+        expires_at=float(row["expires_at"]),
+        revoked_at=(
+            float(row["revoked_at"]) if row["revoked_at"] is not None else None
+        ),
+    )

--- a/src/obsidian_vault_mcp/oauth_state.py
+++ b/src/obsidian_vault_mcp/oauth_state.py
@@ -202,12 +202,16 @@ class OAuthState:
         try:
             self._configure_connection()
             self._initialize_schema()
-            self._migrate_legacy_once()
             self._secure_state_files()
         except BaseException:
             self._connection.close()
             self._closed = True
             raise
+
+    def migrate_legacy(self) -> None:
+        """Import and remove the configured legacy JSON source exactly once."""
+        self._migrate_legacy_once()
+
 
     @property
     def schema_version(self) -> int:

--- a/src/obsidian_vault_mcp/server.py
+++ b/src/obsidian_vault_mcp/server.py
@@ -14,7 +14,7 @@ import urllib.parse
 import urllib.request
 from contextlib import asynccontextmanager
 
-from mcp.server.fastmcp import FastMCP
+from .authorization import PolicyFastMCP, ToolRegistrar
 from mcp.server.transport_security import TransportSecuritySettings
 
 from .config import (
@@ -110,7 +110,7 @@ async def lifespan(server):
 
 
 # Create the MCP server
-mcp = FastMCP(
+mcp = PolicyFastMCP(
     "obsidian_web_mcp",
     stateless_http=True,
     json_response=True,
@@ -131,6 +131,7 @@ mcp = FastMCP(
         ],
     ),
 )
+tool_registrar = ToolRegistrar(mcp)
 
 
 # --- Register all tools ---
@@ -288,7 +289,7 @@ def _run_audited_batch(operation: str, func, context: dict) -> str:
     return result
 
 
-@mcp.tool(
+@tool_registrar.tool(
     name="vault_read",
     description="Read a file from the Obsidian vault, returning content, metadata, and parsed YAML frontmatter.",
     annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True, "openWorldHint": False},
@@ -299,7 +300,7 @@ def vault_read(path: str) -> str:
     return _run_audited("vault_read", lambda: _vault_read(inp.path), path=inp.path)
 
 
-@mcp.tool(
+@tool_registrar.tool(
     name="vault_batch_read",
     description="Read multiple files from the vault in one call. Handles missing files gracefully.",
     annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True, "openWorldHint": False},
@@ -310,7 +311,7 @@ def vault_batch_read(paths: list[str], include_content: bool = True) -> str:
     return _run_audited("vault_batch_read", lambda: _vault_batch_read(inp.paths, inp.include_content))
 
 
-@mcp.tool(
+@tool_registrar.tool(
     name="vault_write",
     description="Write a file to the Obsidian vault. Supports frontmatter merging with existing files. Creates parent directories by default.",
     annotations={"readOnlyHint": False, "destructiveHint": True, "idempotentHint": False, "openWorldHint": False},
@@ -325,7 +326,7 @@ def vault_write(path: str, content: str, create_dirs: bool = True, merge_frontma
     )
 
 
-@mcp.tool(
+@tool_registrar.tool(
     name="vault_write_binary",
     description="Write an allowed binary file (image or PDF) to the Obsidian vault from base64-encoded content. Enforces a media-type/extension allowlist and a size cap; writes atomically.",
     annotations={"readOnlyHint": False, "destructiveHint": True, "idempotentHint": False, "openWorldHint": False},
@@ -336,7 +337,7 @@ def vault_write_binary(path: str, data: str, media_type: str, overwrite: bool = 
     return _vault_write_binary(inp.path, inp.data, inp.media_type, inp.overwrite, inp.create_dirs)
 
 
-@mcp.tool(
+@tool_registrar.tool(
     name="vault_edit",
     description=(
         "Patch an existing vault file with exact text replacements. Use this for token-efficient partial edits "
@@ -357,7 +358,7 @@ def vault_edit(path: str, edits: list[dict], dry_run: bool = False) -> str:
     )
 
 
-@mcp.tool(
+@tool_registrar.tool(
     name="vault_append",
     description=(
         "Append content to a vault file without sending the existing file body. Use this for token-efficient "
@@ -375,7 +376,7 @@ def vault_append(path: str, content: str, separator: str = "\n\n", create_dirs: 
     )
 
 
-@mcp.tool(
+@tool_registrar.tool(
     name="vault_batch_frontmatter_update",
     description="Update YAML frontmatter fields on multiple files without changing body content. Each update merges new fields into existing frontmatter.",
     annotations={"readOnlyHint": False, "destructiveHint": False, "idempotentHint": True, "openWorldHint": False},
@@ -390,7 +391,7 @@ def vault_batch_frontmatter_update(updates: list[dict]) -> str:
     )
 
 
-@mcp.tool(
+@tool_registrar.tool(
     name="vault_search",
     description="Search for text across vault files. Uses ripgrep if available, falls back to Python. Returns matching lines with context and frontmatter excerpts.",
     annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True, "openWorldHint": False},
@@ -410,7 +411,7 @@ def vault_search(
     )
 
 
-@mcp.tool(
+@tool_registrar.tool(
     name="vault_search_frontmatter",
     description="Search vault files by YAML frontmatter field values. Queries an in-memory index for fast results. Supports exact match, contains, and field-exists queries.",
     annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True, "openWorldHint": False},
@@ -430,7 +431,7 @@ def vault_search_frontmatter(
     )
 
 
-@mcp.tool(
+@tool_registrar.tool(
     name="vault_list",
     description="List directory contents in the vault. Supports recursion depth, file/dir filtering, and glob patterns. Excludes .obsidian, .trash, .git directories.",
     annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True, "openWorldHint": False},
@@ -451,7 +452,7 @@ def vault_list(
     )
 
 
-@mcp.tool(
+@tool_registrar.tool(
     name="vault_move",
     description="Move a file or directory within the vault. Validates both source and destination paths.",
     annotations={"readOnlyHint": False, "destructiveHint": True, "idempotentHint": False, "openWorldHint": False},
@@ -467,7 +468,7 @@ def vault_move(source: str, destination: str, create_dirs: bool = True) -> str:
     )
 
 
-@mcp.tool(
+@tool_registrar.tool(
     name="vault_delete",
     description="Delete a file by moving it to .trash/ in the vault root. Requires confirm=true as a safety gate. Does NOT hard delete.",
     annotations={"readOnlyHint": False, "destructiveHint": True, "idempotentHint": False, "openWorldHint": False},
@@ -482,7 +483,7 @@ def vault_delete(path: str, confirm: bool = False) -> str:
     )
 
 
-@mcp.tool(
+@tool_registrar.tool(
     name="vault_canvas_read",
     description="Read an Obsidian .canvas file and return its parsed nodes and edges.",
     annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True, "openWorldHint": False},
@@ -493,7 +494,7 @@ def vault_canvas_read(path: str) -> str:
     return _run_audited("vault_canvas_read", lambda: _vault_canvas_read(inp.path), path=inp.path)
 
 
-@mcp.tool(
+@tool_registrar.tool(
     name="vault_canvas_add_node",
     description=(
         "Append a node to an Obsidian .canvas file, creating the file if it does not exist. Requires type, x, y, "
@@ -511,7 +512,7 @@ def vault_canvas_add_node(path: str, node: dict) -> str:
     )
 
 
-@mcp.tool(
+@tool_registrar.tool(
     name="vault_canvas_add_edge",
     description=(
         "Append an edge to an existing Obsidian .canvas file. Requires fromNode, toNode, and fromSide/toSide "
@@ -530,7 +531,7 @@ def vault_canvas_add_edge(path: str, edge: dict) -> str:
     )
 
 
-@mcp.tool(
+@tool_registrar.tool(
     name="vault_daily_note_path",
     description="Return today's daily-note path (server local date), derived from VAULT_DAILY_NOTES_FOLDER and VAULT_DAILY_NOTES_FORMAT. Does not read or create the file.",
     annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True, "openWorldHint": False},
@@ -540,7 +541,7 @@ def vault_daily_note_path() -> str:
     return _vault_daily_note_path()
 
 
-@mcp.tool(
+@tool_registrar.tool(
     name="vault_daily_note_read",
     description="Read today's daily note. Returns an error payload (does not create the note) when it does not exist.",
     annotations={"readOnlyHint": True, "destructiveHint": False, "idempotentHint": True, "openWorldHint": False},
@@ -550,7 +551,7 @@ def vault_daily_note_read() -> str:
     return _run_audited("vault_daily_note_read", _vault_daily_note_read)
 
 
-@mcp.tool(
+@tool_registrar.tool(
     name="vault_daily_note_append",
     description="Append content to today's daily note, creating it from VAULT_DAILY_NOTES_TEMPLATE when missing. Token-efficient daily logging without resending the note body.",
     annotations={"readOnlyHint": False, "destructiveHint": True, "idempotentHint": False, "openWorldHint": False},
@@ -565,7 +566,7 @@ def vault_daily_note_append(content: str) -> str:
     )
 
 
-@mcp.tool(
+@tool_registrar.tool(
     name="vault_analytics_summary",
     description=(
         "Return a compact analytics summary for vault hygiene, including frontmatter, link, tag, and encoding "
@@ -587,7 +588,7 @@ def vault_analytics_summary(
     return _vault_analytics_summary(inp.path_prefix or "", inp.required_frontmatter, inp.max_examples)
 
 
-@mcp.tool(
+@tool_registrar.tool(
     name="vault_analytics_findings",
     description=(
         "Return detailed findings for one vault analytics category: frontmatter_missing, "
@@ -724,6 +725,14 @@ def build_app(extensions=()):
                     f"extension route {getattr(r, 'path', r)!r} covers auth-exempt "
                     f"{m} {p!r}; it would be served without bearer authentication"
                 )
+        # Restricted principals are allowed through the middleware only at the MCP
+        # transport path. An earlier extension route there would inherit that
+        # allowance without passing through PolicyFastMCP.
+        if _covers(r, "POST", VAULT_MCP_PATH) is not Match.NONE:
+            raise ValueError(
+                f"extension route {getattr(r, 'path', r)!r} covers MCP transport "
+                f"path {VAULT_MCP_PATH!r}; it would bypass MCP authorization"
+            )
     app.add_middleware(BearerAuthMiddleware)
     return app
 
@@ -787,7 +796,7 @@ def serve(extensions=()):
     # each extension prepare before the frontmatter index starts (e.g. attach a
     # change listener so no change is missed between build and listener attach).
     for ext in extensions:
-        ext.register_tools(mcp)
+        ext.register_tools(tool_registrar)
         ext.before_indexes_start(frontmatter_index)
 
     # Build the frontmatter index ONCE, before serving. With stateless_http the

--- a/src/obsidian_vault_mcp/server.py
+++ b/src/obsidian_vault_mcp/server.py
@@ -672,11 +672,11 @@ def build_app(extensions=()):
     # TRUST MODEL: extensions are fully-trusted, in-process code the operator passes
     # to serve(). They can do anything the server can (read VAULT_MCP_TOKEN, touch the
     # vault, mutate any route). This is NOT a sandbox and CANNOT stop a hostile
-    # extension. The check below is a best-effort FOOTGUN guard for honest authors: it
-    # fails closed when a newly-added route would land on an auth-exempt path (which
-    # the bearer middleware skips before routing) and would thus be served
-    # unauthenticated. It does not (and cannot) defend against an extension that
-    # mutates an existing route in place, opens a raw socket, etc.
+    # extension. The check below is a startup FOOTGUN guard for honest authors: it
+    # fails closed when a newly-added route cannot be inspected or would land on an
+    # auth-exempt path (which the bearer middleware skips before routing) and would
+    # thus be served unauthenticated. It does not (and cannot) defend against an
+    # extension that mutates an existing route in place, opens a raw socket, etc.
     from starlette.routing import Match, Mount, WebSocketRoute
 
     from .auth import _AUTH_EXEMPT_METHOD_PATHS, _AUTH_EXEMPT_PATHS
@@ -688,18 +688,17 @@ def build_app(extensions=()):
     ext_routes = [r for r in app.routes if id(r) not in before_ids]
 
     def _covers(route, method, path):
-        """Match enum for route vs (method, path); NONE if the probe can't run."""
+        """Return how a route covers a method/path probe, rejecting unknown behavior."""
         try:
             match, _ = route.matches(
                 {"type": "http", "method": method, "path": path, "headers": []}
             )
-            return match
-        except Exception:
-            logger.warning(
-                "extension route %r could not be auth-checked; allowing "
-                "(trusted-extension model)", getattr(route, "path", route)
-            )
-            return Match.NONE
+        except Exception as exc:
+            route_path = getattr(route, "path", route)
+            raise ValueError(
+                f"extension route {route_path!r} could not be safely inspected"
+            ) from exc
+        return match
 
     for r in ext_routes:
         # Footguns: a Mount can shadow an exempt prefix; a WebSocketRoute isn't covered

--- a/src/obsidian_vault_mcp/server.py
+++ b/src/obsidian_vault_mcp/server.py
@@ -821,12 +821,20 @@ def serve(extensions=()):
         ).start()
         logger.info("Heartbeat enabled (interval: %ds)", heartbeat_interval)
 
-    # Build the Starlette app with auth middleware and OAuth endpoints
+    # Open and validate OAuth state before accepting any request. Filesystem,
+    # migration, and schema failures are fatal; never fall back to ephemeral state.
     try:
+        from .oauth import close_oauth_state, initialize_oauth_state
+
+        initialize_oauth_state()
+        atexit.register(close_oauth_state)
         app = build_app(extensions)
-        logger.info(f"Starting server on {VAULT_MCP_HOST}:{VAULT_MCP_PORT} with bearer auth + OAuth")
+        logger.info(
+            f"Starting server on {VAULT_MCP_HOST}:{VAULT_MCP_PORT} "
+            "with bearer auth + OAuth"
+        )
     except Exception as e:
-        # Fail CLOSED: never fall back to an unauthenticated server.
+        # Fail CLOSED: never fall back to an unauthenticated or ephemeral server.
         logger.error(f"Could not build the authenticated app: {e}")
         sys.exit(1)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,5 @@
 """Test fixtures for the Obsidian vault MCP server."""
 
-import os
-import tempfile
 from pathlib import Path
 
 import pytest
@@ -39,6 +37,13 @@ def vault_dir(tmp_path, monkeypatch):
 
     # Reload config to pick up new env var
     import obsidian_vault_mcp.config as config
+    from obsidian_vault_mcp import oauth
+
+    oauth.close_oauth_state()
     config.VAULT_PATH = Path(str(vault))
+    config.VAULT_OAUTH_STATE_PATH = tmp_path / "oauth-state" / "oauth.sqlite3"
+    config.OAUTH_CLIENTS_PATH = tmp_path / "legacy" / "oauth_clients.json"
+    config.VAULT_OAUTH_APPROVED_LEGACY_CLIENT_IDS = frozenset()
 
     yield vault
+    oauth.close_oauth_state()

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -12,8 +12,16 @@ import pytest
 
 from obsidian_vault_mcp import audit, config, context, server
 
-PRINCIPAL = "test-bearer-token-abc123"
-EXPECTED_HASH = __import__("hashlib").sha256(PRINCIPAL.encode("utf-8")).hexdigest()
+RAW_TOKEN = "test-bearer-token-abc123"
+EXPECTED_HASH = __import__("hashlib").sha256(RAW_TOKEN.encode("utf-8")).hexdigest()
+PRINCIPAL = context.AuthenticatedPrincipal(
+    principal_id="oauth:pytest",
+    credential_id=EXPECTED_HASH,
+    client_id="pytest",
+    policy="vault_readonly_v1",
+    capabilities=frozenset({"vault_read"}),
+    full_access=False,
+)
 
 
 @pytest.fixture
@@ -22,7 +30,7 @@ def audit_log(vault_dir, tmp_path, monkeypatch):
     log_path = tmp_path / "audit" / "mutations.jsonl"
     monkeypatch.setattr(config, "VAULT_AUDIT_LOG_PATH", str(log_path))
     monkeypatch.setattr(config, "VAULT_AUDIT_LOG_INCLUDE_READS", False)
-    token = context.set_request_context(principal=PRINCIPAL, request_id="req-1", client="pytest")
+    token = context.set_request_context(principal=PRINCIPAL, request_id="req-1")
     yield log_path
     context.reset_request_context(token)
 
@@ -44,6 +52,14 @@ def test_audit_off_by_default(vault_dir, monkeypatch, tmp_path):
     assert audit.should_audit_operation("vault_write") is False
 
 
+def test_audit_record_without_authenticated_request_has_no_identity():
+    record = audit.build_audit_record(operation="test", target_path=None)
+    assert record["token_id_hash"] is None
+    assert record["principal_id"] is None
+    assert record["client_id"] is None
+    assert record["auth_policy"] is None
+
+
 # --- mutations ---
 
 def test_mutation_writes_record_with_required_fields(audit_log):
@@ -52,9 +68,9 @@ def test_mutation_writes_record_with_required_fields(audit_log):
     assert len(records) == 1
     rec = records[0]
     for field in (
-        "timestamp", "token_id_hash", "client_id", "operation", "target_path",
-        "size_before", "size_after", "checksum_before", "checksum_after",
-        "request_id", "operation_status", "error",
+        "timestamp", "token_id_hash", "principal_id", "client_id", "auth_policy",
+        "operation", "target_path", "size_before", "size_after", "checksum_before",
+        "checksum_after", "request_id", "operation_status", "error",
     ):
         assert field in rec
     assert rec["operation"] == "vault_write"
@@ -68,9 +84,11 @@ def test_mutation_writes_record_with_required_fields(audit_log):
 def test_raw_token_never_written_only_hash(audit_log):
     server.vault_write("audited.md", "secret content")
     raw = audit_log.read_text(encoding="utf-8")
-    assert PRINCIPAL not in raw
+    assert RAW_TOKEN not in raw
     assert _records(audit_log)[0]["token_id_hash"] == EXPECTED_HASH
     assert _records(audit_log)[0]["client_id"] == "pytest"
+    assert _records(audit_log)[0]["principal_id"] == "oauth:pytest"
+    assert _records(audit_log)[0]["auth_policy"] == "vault_readonly_v1"
 
 
 def test_overwrite_captures_before_and_after(audit_log):
@@ -125,7 +143,7 @@ def test_audit_write_failure_does_not_break_tool(vault_dir, monkeypatch):
     bad = vault_dir / "test-note.md" / "audit.jsonl"
     monkeypatch.setattr(config, "VAULT_AUDIT_LOG_PATH", str(bad))
     assert audit.audit_path_writable() is False
-    token = context.set_request_context(principal=PRINCIPAL, request_id="r", client="c")
+    token = context.set_request_context(principal=PRINCIPAL, request_id="r")
     try:
         result = json.loads(server.vault_write("still-works.md", "body"))
         assert result["created"] is True        # the write itself succeeded despite audit failing

--- a/tests/test_audit_propagation.py
+++ b/tests/test_audit_propagation.py
@@ -19,35 +19,67 @@ from obsidian_vault_mcp.context import current_request_context
 def test_principal_propagates_to_sync_handler(monkeypatch):
     monkeypatch.setattr(auth_module, "VAULT_MCP_TOKEN", "secret-token")
 
-    def sync_probe(request):  # sync on purpose: mirrors how FastMCP runs vault_* tools
+    def sync_probe(request):  # sync on purpose: mirrors FastMCP worker dispatch
         ctx = current_request_context()
-        return JSONResponse({"principal": ctx.get("principal"), "client": ctx.get("client"),
-                             "request_id": ctx.get("request_id")})
+        assert ctx is not None
+        return JSONResponse(
+            {
+                "principal_id": ctx.principal.principal_id,
+                "credential_id": ctx.principal.credential_id,
+                "client_id": ctx.principal.client_id,
+                "policy": ctx.principal.policy,
+                "capabilities": sorted(ctx.principal.capabilities),
+                "full_access": ctx.principal.full_access,
+                "request_id": ctx.request_id,
+            }
+        )
 
     app = Starlette(routes=[Route("/probe", sync_probe)])
     app.add_middleware(auth_module.BearerAuthMiddleware)
     client = TestClient(app)
 
-    r = client.get("/probe", headers={"Authorization": "Bearer secret-token",
-                                      "User-Agent": "probe/1"})
-    assert r.status_code == 200, r.text
-    body = r.json()
-    assert body["principal"] == "secret-token"   # null here => token_id_hash null in prod
-    assert body["client"] == "probe/1"
+    response = client.get(
+        "/probe",
+        headers={
+            "Authorization": "Bearer secret-token",
+            "User-Agent": "probe/1",
+        },
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["principal_id"] == "master"
+    assert body["client_id"] is None
+    assert body["policy"] == "legacy_full"
+    assert body["capabilities"] == []
+    assert body["full_access"] is True
+    assert body["credential_id"] != "secret-token"
+    assert len(body["credential_id"]) == 64
     assert body["request_id"]
+    assert "secret-token" not in response.text
+
+    second = client.get(
+        "/probe",
+        headers={"Authorization": "Bearer secret-token"},
+    )
+    assert second.status_code == 200, second.text
+    second_body = second.json()
+    assert second_body["credential_id"] == body["credential_id"]
+    assert second_body["request_id"] != body["request_id"]
 
 
 def test_context_clean_outside_request():
-    assert current_request_context() == {}
+    assert current_request_context() is None
 
 
 def test_health_is_liveness_only(vault_dir, monkeypatch):
     # Unauthenticated /health must not leak the audit log path or write counters.
-    monkeypatch.setattr(config, "VAULT_AUDIT_LOG_PATH", str(vault_dir.parent / "audit.jsonl"))
+    monkeypatch.setattr(
+        config, "VAULT_AUDIT_LOG_PATH", str(vault_dir.parent / "audit.jsonl")
+    )
     app = server.build_app()
     client = TestClient(app)
     r = client.get("/health")
     assert r.status_code == 200, r.text
     body = r.json()
     assert body["status"] == "ok"
-    assert body["audit"] == {"enabled": True}    # only the bool, nothing else
+    assert body["audit"] == {"enabled": True}  # only the bool, nothing else

--- a/tests/test_authorization.py
+++ b/tests/test_authorization.py
@@ -1,0 +1,490 @@
+"""Protocol-level tests for per-client MCP authorization."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+import json
+import secrets
+from collections.abc import Iterator
+from urllib.parse import parse_qs, urlsplit
+
+import pytest
+from mcp.server.fastmcp.exceptions import ToolError
+from mcp.types import (
+    CallToolResult,
+    ListPromptsResult,
+    ListResourcesResult,
+    ListToolsResult,
+)
+from starlette.responses import JSONResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from obsidian_vault_mcp import auth, config, context, oauth, server
+from obsidian_vault_mcp.authorization import PolicyFastMCP, ToolRegistrar
+from obsidian_vault_mcp.extensions import Extension
+from obsidian_vault_mcp.oauth_state import (
+    LEGACY_FULL,
+    VAULT_READONLY_CAPABILITIES,
+)
+
+MASTER_TOKEN = "master-bearer-must-not-be-issued"
+LOGIN_USERNAME = "policy-user"
+LOGIN_PASSWORD = "policy-password"
+RESOURCE = "http://localhost:8420"
+READ_ONLY = set(VAULT_READONLY_CAPABILITIES)
+_EXTENSION_TOOL = "stage3_extension_probe"
+_EXTENSION_CALLS: list[str] = []
+
+
+class _RouteExtension(Extension):
+    def register_routes(self, app) -> None:
+        async def private_probe(_request):
+            return JSONResponse({"ok": True})
+
+        app.routes.insert(0, Route("/__private", private_probe, methods=["GET"]))
+
+
+def test_policy_registrar_is_narrow_and_fail_closed():
+    policy_server = PolicyFastMCP("authorization-unit")
+    registrar = ToolRegistrar(policy_server)
+    calls: list[str] = []
+
+    @registrar.tool(name="unit_extension_tool")
+    def unit_extension_tool() -> str:
+        calls.append("called")
+        return "called"
+
+    assert not hasattr(registrar, "resource")
+    assert not hasattr(registrar, "prompt")
+    assert (
+        policy_server.required_capability("unit_extension_tool")
+        == "unit_extension_tool"
+    )
+    assert asyncio.run(policy_server.list_tools()) == []
+    with pytest.raises(ToolError, match="Forbidden"):
+        asyncio.run(policy_server.call_tool("unit_extension_tool", {}))
+
+    denied_token = context.set_request_context(
+        principal=context.AuthenticatedPrincipal(
+            principal_id="oauth:denied",
+            credential_id="a" * 64,
+            client_id="denied",
+            policy="vault_readonly_v1",
+            capabilities=frozenset({"vault_read"}),
+            full_access=False,
+        ),
+        request_id="denied",
+    )
+    try:
+        assert asyncio.run(policy_server.list_tools()) == []
+        with pytest.raises(ToolError, match="Forbidden"):
+            asyncio.run(policy_server.call_tool("unit_extension_tool", {}))
+    finally:
+        context.reset_request_context(denied_token)
+
+    allowed_token = context.set_request_context(
+        principal=context.AuthenticatedPrincipal(
+            principal_id="oauth:allowed",
+            credential_id="b" * 64,
+            client_id="allowed",
+            policy="test",
+            capabilities=frozenset({"unit_extension_tool"}),
+            full_access=False,
+        ),
+        request_id="allowed",
+    )
+    try:
+        tools = asyncio.run(policy_server.list_tools())
+        assert [tool.name for tool in tools] == ["unit_extension_tool"]
+        asyncio.run(policy_server.call_tool("unit_extension_tool", {}))
+        assert calls == ["called"]
+    finally:
+        context.reset_request_context(allowed_token)
+
+    master_token = context.set_request_context(
+        principal=context.AuthenticatedPrincipal(
+            principal_id="master",
+            credential_id="c" * 64,
+            client_id=None,
+            policy=LEGACY_FULL,
+            capabilities=frozenset(),
+            full_access=True,
+        ),
+        request_id="master",
+    )
+    try:
+        assert [tool.name for tool in asyncio.run(policy_server.list_tools())] == [
+            "unit_extension_tool"
+        ]
+    finally:
+        context.reset_request_context(master_token)
+
+
+def _pkce() -> tuple[str, str]:
+    verifier = secrets.token_urlsafe(48)
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+    return verifier, challenge
+
+
+def _rpc(
+    client: TestClient,
+    token: str,
+    method: str,
+    params: dict[str, object],
+) -> dict[str, object]:
+    request_id = secrets.randbelow(2**31)
+    response = client.post(
+        config.VAULT_MCP_PATH,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/json, text/event-stream",
+        },
+        json={
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": method,
+            "params": params,
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["id"] == request_id
+    assert "error" not in body
+    return body["result"]
+
+
+def _rpc_error(
+    client: TestClient,
+    token: str,
+    method: str,
+    params: dict[str, object],
+) -> dict[str, object]:
+    request_id = secrets.randbelow(2**31)
+    response = client.post(
+        config.VAULT_MCP_PATH,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/json, text/event-stream",
+        },
+        json={
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": method,
+            "params": params,
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["id"] == request_id
+    assert "error" in body
+    return body["error"]
+
+
+def _initialize(client: TestClient, token: str) -> None:
+    _rpc(
+        client,
+        token,
+        "initialize",
+        {
+            "protocolVersion": "2025-06-18",
+            "capabilities": {},
+            "clientInfo": {"name": "authorization-test", "version": "1"},
+        },
+    )
+
+
+def _list_tools(client: TestClient, token: str) -> set[str]:
+    _initialize(client, token)
+    result = ListToolsResult.model_validate(_rpc(client, token, "tools/list", {}))
+    return {tool.name for tool in result.tools}
+
+
+def _call_tool(
+    client: TestClient,
+    token: str,
+    name: str,
+    arguments: dict[str, object],
+) -> CallToolResult:
+    _initialize(client, token)
+    return CallToolResult.model_validate(
+        _rpc(
+            client,
+            token,
+            "tools/call",
+            {"name": name, "arguments": arguments},
+        )
+    )
+
+
+def _issue_dynamic_token(client: TestClient, name: str) -> tuple[str, str]:
+    redirect_uri = f"https://client.example.test/callback/{name}"
+    registration = client.post(
+        "/oauth/register",
+        json={"client_name": name, "redirect_uris": [redirect_uri]},
+    )
+    assert registration.status_code == 201
+    registered = registration.json()
+    verifier, challenge = _pkce()
+    authorization = client.post(
+        "/oauth/authorize",
+        data={
+            "response_type": "code",
+            "client_id": registered["client_id"],
+            "redirect_uri": redirect_uri,
+            "state": f"state-{name}",
+            "code_challenge": challenge,
+            "code_challenge_method": "S256",
+            "resource": RESOURCE,
+            "username": LOGIN_USERNAME,
+            "password": LOGIN_PASSWORD,
+        },
+        follow_redirects=False,
+    )
+    assert authorization.status_code == 302
+    code = parse_qs(urlsplit(authorization.headers["location"]).query)["code"][0]
+    token_response = client.post(
+        "/oauth/token",
+        data={
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": redirect_uri,
+            "client_id": registered["client_id"],
+            "client_secret": registered["client_secret"],
+            "code_verifier": verifier,
+            "resource": RESOURCE,
+        },
+    )
+    assert token_response.status_code == 200
+    return registered["client_id"], token_response.json()["access_token"]
+
+
+def _register_extension_tool() -> None:
+    if server.mcp._tool_manager.get_tool(_EXTENSION_TOOL) is not None:
+        return
+
+    registrar = getattr(server, "tool_registrar", server.mcp)
+
+    @registrar.tool(name=_EXTENSION_TOOL)
+    def extension_probe() -> str:
+        _EXTENSION_CALLS.append("called")
+        return "extension-called"
+
+
+@pytest.fixture(scope="module")
+def policy_client(tmp_path_factory) -> Iterator[TestClient]:
+    patch = pytest.MonkeyPatch()
+    root = tmp_path_factory.mktemp("authorization")
+    vault_path = root / "vault"
+    vault_path.mkdir(mode=0o700)
+    oauth.close_oauth_state()
+    patch.setattr(config, "VAULT_PATH", vault_path)
+    patch.setattr(server, "VAULT_PATH", vault_path)
+    patch.setattr(config, "VAULT_MCP_TOKEN", MASTER_TOKEN)
+    patch.setattr(auth, "VAULT_MCP_TOKEN", MASTER_TOKEN)
+    patch.setattr(config, "VAULT_OAUTH_USERNAME", LOGIN_USERNAME)
+    patch.setattr(config, "VAULT_OAUTH_PASSWORD", LOGIN_PASSWORD)
+    patch.setattr(config, "VAULT_MCP_PUBLIC_URL", RESOURCE)
+    patch.setattr(
+        config,
+        "VAULT_OAUTH_STATE_PATH",
+        root / "oauth-state" / "oauth.sqlite3",
+    )
+    patch.setattr(config, "OAUTH_CLIENTS_PATH", root / "legacy" / "clients.json")
+    patch.setattr(config, "VAULT_OAUTH_APPROVED_LEGACY_CLIENT_IDS", frozenset())
+    _register_extension_tool()
+    _EXTENSION_CALLS.clear()
+    app = server.build_app((_RouteExtension(),))
+    app.state.authorization_vault_path = vault_path
+    with TestClient(app, base_url=RESOURCE) as client:
+        yield client
+    oauth.close_oauth_state()
+    patch.undo()
+
+
+def test_dynamic_client_discovers_exact_read_only_catalog(policy_client):
+    _client_id, token = _issue_dynamic_token(policy_client, "catalog")
+    assert _list_tools(policy_client, token) == READ_ONLY
+
+
+def test_read_only_capabilities_name_registered_tools():
+    registered = {tool.name for tool in server.mcp._tool_manager.list_tools()}
+    assert READ_ONLY <= registered
+    assert {server.mcp.required_capability(name) for name in READ_ONLY} == READ_ONLY
+
+
+def test_dynamic_client_cannot_reach_mutation(policy_client):
+    _client_id, token = _issue_dynamic_token(policy_client, "mutation")
+    result = _call_tool(
+        policy_client,
+        token,
+        "vault_write",
+        {"path": "forbidden.md", "content": "must not exist"},
+    )
+    assert result.isError is True
+    assert "Forbidden" in result.content[0].text
+    vault_path = policy_client.app.state.authorization_vault_path
+    assert not vault_path.joinpath("forbidden.md").exists()
+
+
+def test_oauth_audit_attribution_is_stable_and_secret_free(
+    policy_client,
+    monkeypatch,
+):
+    client_id, token = _issue_dynamic_token(policy_client, "audit")
+    vault_path = policy_client.app.state.authorization_vault_path
+    vault_path.joinpath("audited-read.md").write_text(
+        "visible",
+        encoding="utf-8",
+    )
+    audit_path = vault_path.parent / "audit-attribution.jsonl"
+    monkeypatch.setattr(config, "VAULT_AUDIT_LOG_PATH", str(audit_path))
+    monkeypatch.setattr(config, "VAULT_AUDIT_LOG_INCLUDE_READS", True)
+
+    for _ in range(2):
+        result = _call_tool(
+            policy_client,
+            token,
+            "vault_read",
+            {"path": "audited-read.md"},
+        )
+        assert result.isError is not True
+
+    raw_audit = audit_path.read_text(encoding="utf-8")
+    records = [json.loads(line) for line in raw_audit.splitlines() if line]
+    assert len(records) == 2
+    assert records[0]["request_id"] != records[1]["request_id"]
+    assert token not in raw_audit
+    for record in records:
+        assert record["client_id"] == client_id
+        assert (
+            record["token_id_hash"] == hashlib.sha256(token.encode("utf-8")).hexdigest()
+        )
+        assert record["principal_id"] == f"oauth:{client_id}"
+        assert record["auth_policy"] == "vault_readonly_v1"
+
+
+def test_new_extension_tool_is_denied_by_default(policy_client):
+    _client_id, token = _issue_dynamic_token(policy_client, "extension")
+    assert _EXTENSION_TOOL not in _list_tools(policy_client, token)
+    result = _call_tool(policy_client, token, _EXTENSION_TOOL, {})
+    assert result.isError is True
+    assert _EXTENSION_CALLS == []
+
+
+def test_master_retains_full_tool_access(policy_client):
+    names = _list_tools(policy_client, MASTER_TOKEN)
+    assert "vault_write" in names
+    assert _EXTENSION_TOOL in names
+    result = _call_tool(policy_client, MASTER_TOKEN, _EXTENSION_TOOL, {})
+    assert result.isError is not True
+    assert _EXTENSION_CALLS == ["called"]
+
+
+def test_legacy_full_oauth_token_retains_full_tool_access(policy_client):
+    state = oauth.get_oauth_state()
+    state.ensure_static_client(
+        "approved-static",
+        ("https://approved.example.test/callback",),
+        policy=LEGACY_FULL,
+        capabilities=(),
+    )
+    issued = state.issue_access_token(
+        client_id="approved-static",
+        resource="http://localhost:8420",
+    )
+    names = _list_tools(policy_client, issued.access_token)
+    assert "vault_write" in names
+    assert _EXTENSION_TOOL in names
+
+
+def test_read_only_principal_has_no_resources_or_prompts(policy_client):
+    _client_id, token = _issue_dynamic_token(policy_client, "surfaces")
+    _initialize(policy_client, token)
+    resources = ListResourcesResult.model_validate(
+        _rpc(policy_client, token, "resources/list", {})
+    )
+    prompts = ListPromptsResult.model_validate(
+        _rpc(policy_client, token, "prompts/list", {})
+    )
+    assert resources.resources == []
+    assert prompts.prompts == []
+    resource_error = _rpc_error(
+        policy_client,
+        token,
+        "resources/read",
+        {"uri": "vault://private"},
+    )
+    prompt_error = _rpc_error(
+        policy_client,
+        token,
+        "prompts/get",
+        {"name": "private"},
+    )
+    assert "Forbidden" in str(resource_error)
+    assert "Forbidden" in str(prompt_error)
+
+
+@pytest.mark.parametrize("token", ["wrong", "v1.unknown.invalid"])
+def test_invalid_bearer_returns_401(policy_client, token):
+    response = policy_client.post(
+        config.VAULT_MCP_PATH,
+        headers={"Authorization": f"Bearer {token}"},
+        json={"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}},
+    )
+    assert response.status_code == 401
+    assert 'error="invalid_token"' in response.headers["WWW-Authenticate"]
+
+
+def test_revoked_oauth_token_returns_401(policy_client):
+    _client_id, token = _issue_dynamic_token(policy_client, "revoked")
+    metadata = oauth.get_oauth_state().lookup_access_token(token)
+    assert metadata is not None
+    assert oauth.get_oauth_state().revoke_token(metadata.token_id)
+    response = policy_client.post(
+        config.VAULT_MCP_PATH,
+        headers={"Authorization": f"Bearer {token}"},
+        json={"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}},
+    )
+    assert response.status_code == 401
+
+
+def test_wrong_resource_oauth_token_returns_401(policy_client):
+    client_id, _valid_token = _issue_dynamic_token(
+        policy_client,
+        "wrong-resource",
+    )
+    state = oauth.get_oauth_state()
+    issued = state.issue_access_token(
+        client_id=client_id,
+        resource="https://different-resource.example.test",
+    )
+    response = policy_client.post(
+        config.VAULT_MCP_PATH,
+        headers={"Authorization": f"Bearer {issued.access_token}"},
+        json={"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}},
+    )
+    assert response.status_code == 401
+
+
+def test_read_only_token_gets_403_on_protected_non_mcp_route(policy_client):
+    _client_id, token = _issue_dynamic_token(policy_client, "route")
+    response = policy_client.get(
+        "/__private",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == 403
+    assert response.json() == {"error": "Insufficient scope"}
+    assert 'error="insufficient_scope"' in response.headers["WWW-Authenticate"]
+
+
+def test_master_can_reach_protected_non_mcp_route(policy_client):
+    response = policy_client.get(
+        "/__private",
+        headers={"Authorization": f"Bearer {MASTER_TOKEN}"},
+    )
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}

--- a/tests/test_authorization.py
+++ b/tests/test_authorization.py
@@ -481,6 +481,38 @@ def test_read_only_token_gets_403_on_protected_non_mcp_route(policy_client):
     assert 'error="insufficient_scope"' in response.headers["WWW-Authenticate"]
 
 
+def test_dynamic_bearer_authentication_does_not_mutate_static_client(
+    policy_client,
+    monkeypatch,
+):
+    monkeypatch.setattr(config, "VAULT_OAUTH_CLIENT_ID", "configured-static")
+    monkeypatch.setattr(config, "VAULT_OAUTH_CLIENT_SECRET", "configured-secret")
+    monkeypatch.setattr(
+        config,
+        "VAULT_OAUTH_REDIRECT_URIS",
+        ["https://static.example.test/callback"],
+    )
+    _client_id, token = _issue_dynamic_token(policy_client, "read-only-auth")
+    state = oauth.get_oauth_state()
+    statements: list[str] = []
+    state._connection.set_trace_callback(statements.append)
+    try:
+        response = policy_client.get(
+            "/__private",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    finally:
+        state._connection.set_trace_callback(None)
+
+    assert response.status_code == 403
+    mutations = [
+        statement
+        for statement in statements
+        if statement.lstrip().partition(" ")[0].upper() in {"DELETE", "INSERT", "UPDATE"}
+    ]
+    assert mutations == []
+
+
 def test_master_can_reach_protected_non_mcp_route(policy_client):
     response = policy_client.get(
         "/__private",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,7 @@
 """Tests for environment-driven configuration (VAULT_MCP_ALLOWED_HOSTS)."""
 
 import importlib
-
+from pathlib import Path
 import pytest
 
 import obsidian_vault_mcp.config as config_module
@@ -9,10 +9,56 @@ import obsidian_vault_mcp.config as config_module
 
 @pytest.fixture(autouse=True)
 def _restore_config(monkeypatch):
-    """Reload config after each test so the module-level parse doesn't leak."""
     yield
-    monkeypatch.delenv("VAULT_MCP_ALLOWED_HOSTS", raising=False)
+    for name in (
+        "VAULT_MCP_ALLOWED_HOSTS",
+        "VAULT_OAUTH_STATE_PATH",
+        "VAULT_OAUTH_APPROVED_LEGACY_CLIENT_IDS",
+        "VAULT_OAUTH_ACCESS_TOKEN_TTL_SECONDS",
+    ):
+        monkeypatch.delenv(name, raising=False)
     importlib.reload(config_module)
+
+
+def test_oauth_state_defaults_are_lazy_and_bounded(monkeypatch):
+    monkeypatch.delenv("VAULT_OAUTH_STATE_PATH", raising=False)
+    monkeypatch.delenv("VAULT_OAUTH_APPROVED_LEGACY_CLIENT_IDS", raising=False)
+    monkeypatch.delenv("VAULT_OAUTH_ACCESS_TOKEN_TTL_SECONDS", raising=False)
+
+    cfg = importlib.reload(config_module)
+
+    assert cfg.VAULT_OAUTH_STATE_PATH == (
+        Path.home() / ".local/share/vault-mcp/oauth_state.sqlite3"
+    )
+    assert cfg.VAULT_OAUTH_APPROVED_LEGACY_CLIENT_IDS == frozenset()
+    assert cfg.oauth_access_token_ttl_seconds() == 86_400
+
+
+def test_oauth_state_environment_is_parsed_strictly(monkeypatch, tmp_path):
+    state_path = tmp_path / "state" / "oauth.sqlite3"
+    monkeypatch.setenv("VAULT_OAUTH_STATE_PATH", str(state_path))
+    monkeypatch.setenv(
+        "VAULT_OAUTH_APPROVED_LEGACY_CLIENT_IDS",
+        " approved-a, approved-b, approved-a ",
+    )
+    monkeypatch.setenv("VAULT_OAUTH_ACCESS_TOKEN_TTL_SECONDS", "2592000")
+
+    cfg = importlib.reload(config_module)
+
+    assert cfg.VAULT_OAUTH_STATE_PATH == state_path
+    assert cfg.VAULT_OAUTH_APPROVED_LEGACY_CLIENT_IDS == frozenset(
+        {"approved-a", "approved-b"}
+    )
+    assert cfg.oauth_access_token_ttl_seconds() == 2_592_000
+
+
+@pytest.mark.parametrize("value", ["", "0", "-1", "abc", "2592001"])
+def test_invalid_oauth_access_token_ttl_fails_startup_validation(monkeypatch, value):
+    monkeypatch.setenv("VAULT_OAUTH_ACCESS_TOKEN_TTL_SECONDS", value)
+    cfg = importlib.reload(config_module)
+
+    with pytest.raises(ValueError, match="VAULT_OAUTH_ACCESS_TOKEN_TTL_SECONDS"):
+        cfg.validate_config()
 
 
 def test_allowed_hosts_defaults_empty(monkeypatch):
@@ -22,10 +68,15 @@ def test_allowed_hosts_defaults_empty(monkeypatch):
 
 
 def test_allowed_hosts_parsed_stripped_and_compacted(monkeypatch):
-    monkeypatch.setenv("VAULT_MCP_ALLOWED_HOSTS", "vault-mcp.example.com, second.example.com ,")
+    monkeypatch.setenv(
+        "VAULT_MCP_ALLOWED_HOSTS", "vault-mcp.example.com, second.example.com ,"
+    )
     cfg = importlib.reload(config_module)
     # Whitespace trimmed; empty fragments (trailing comma) dropped.
-    assert cfg.VAULT_MCP_ALLOWED_HOSTS == ["vault-mcp.example.com", "second.example.com"]
+    assert cfg.VAULT_MCP_ALLOWED_HOSTS == [
+        "vault-mcp.example.com",
+        "second.example.com",
+    ]
 
 
 def test_server_appends_to_loopback_defaults(monkeypatch):

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -164,6 +164,20 @@ def test_extension_wildcard_route_covering_exempt_path_is_rejected(vault_dir):
         server.build_app([_ext_adding(Route("/{rest:path}", _leak, methods=["GET"]))])
 
 
+def test_extension_route_that_cannot_be_inspected_is_rejected(vault_dir):
+    """Inspection failure must not let an extension shadow an exempt route."""
+
+    class DeferredRoute(Route):
+        def matches(self, scope):
+            if "query_string" not in scope:
+                raise RuntimeError("route requires a complete request scope")
+            return super().matches(scope)
+
+    route = DeferredRoute("/health", _leak, methods=["GET"])
+    with pytest.raises(ValueError, match="inspect"):
+        server.build_app([_ext_adding(route)])
+
+
 def test_extension_mount_is_rejected(vault_dir):
     """Mounts are too broad to reason about — rejected outright."""
     from starlette.routing import Mount

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -20,8 +20,10 @@ class SpyExtension(extensions.Extension):
 
     def __init__(self):
         self.calls = []
+        self.registrar = None
 
-    def register_tools(self, mcp):
+    def register_tools(self, registrar):
+        self.registrar = registrar
         self.calls.append("register_tools")
 
     def before_indexes_start(self, frontmatter_index):
@@ -69,6 +71,21 @@ def test_extension_route_is_bearer_protected(vault_dir, monkeypatch):
     assert ok.status_code == 200 and ok.json() == {"ok": True}
 
 
+def test_extension_route_cannot_shadow_mcp_transport(vault_dir):
+    class McpShadowExtension(extensions.Extension):
+        def register_routes(self, app):
+            async def shadow(_request):
+                return JSONResponse({"unsafe": True})
+
+            app.routes.insert(
+                0,
+                Route(server.VAULT_MCP_PATH, shadow, methods=["GET"]),
+            )
+
+    with pytest.raises(ValueError, match="MCP transport"):
+        server.build_app([McpShadowExtension()])
+
+
 def test_serve_invokes_lifecycle_hooks_in_order(vault_dir, monkeypatch):
     """serve() must call the hooks in the documented order and register shutdown."""
     import uvicorn
@@ -92,6 +109,9 @@ def test_serve_invokes_lifecycle_hooks_in_order(vault_dir, monkeypatch):
         "register_routes",
     ]
     assert ext.shutdown in registered
+    assert ext.registrar is server.tool_registrar
+    assert not hasattr(ext.registrar, "resource")
+    assert not hasattr(ext.registrar, "prompt")
 
 
 def test_serve_accepts_a_generator_of_extensions(vault_dir, monkeypatch):

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -362,6 +362,36 @@ def test_client_credentials_rejects_wrong_secret_and_resource(client):
     assert wrong_resource.json()["error"] == "invalid_target"
 
 
+def test_client_credentials_accepts_configured_unicode_secret(client, monkeypatch):
+    monkeypatch.setattr(config, "VAULT_OAUTH_CLIENT_SECRET", "секрет")
+    with TestClient(client.app, raise_server_exceptions=False) as tolerant_client:
+        response = tolerant_client.post(
+            "/oauth/token",
+            data={
+                "grant_type": "client_credentials",
+                "client_id": STATIC_CLIENT_ID,
+                "client_secret": "секрет",
+                "resource": RESOURCE,
+            },
+        )
+
+    assert response.status_code == 200
+
+
+def test_authorize_rejects_wrong_unicode_credentials_without_server_error(client):
+    client_id, _, redirect_uri = _register(client)
+    params = _authz_params(client_id, redirect_uri)
+    with TestClient(client.app, raise_server_exceptions=False) as tolerant_client:
+        response = tolerant_client.post(
+            "/oauth/authorize",
+            data={**params, "username": "пользователь", "password": "пароль"},
+            follow_redirects=False,
+        )
+
+    assert response.status_code == 401
+    assert "Invalid username or password" in response.text
+
+
 def test_authorize_requires_interactive_login(client):
     client_id, _, redirect_uri = _register(client)
     params = _authz_params(client_id, redirect_uri)
@@ -377,6 +407,33 @@ def test_authorize_requires_interactive_login(client):
     assert "<form" in get_response.text
     assert wrong_response.status_code == 401
     assert "location" not in wrong_response.headers
+
+
+def test_consent_form_identifies_client_and_redirect_without_rendering_markup(client):
+    redirect_uri = (
+        "https://client.example.test/callback?next=<unsafe>&mode=consent"
+    )
+    registration = client.post(
+        "/oauth/register",
+        json={
+            "client_name": "<img src=x onerror=alert(1)>",
+            "redirect_uris": [redirect_uri],
+        },
+    )
+    assert registration.status_code == 201
+
+    response = client.get(
+        "/oauth/authorize",
+        params=_authz_params(registration.json()["client_id"], redirect_uri),
+    )
+
+    assert response.status_code == 200
+    assert "<img src=x" not in response.text
+    assert "&lt;img src=x onerror=alert(1)&gt;" in response.text
+    assert (
+        "<code>https://client.example.test/callback?"
+        "next=&lt;unsafe&gt;&amp;mode=consent</code>"
+    ) in response.text
 
 
 def test_missing_login_configuration_fails_closed(client, monkeypatch):
@@ -477,33 +534,33 @@ def test_authorization_request_validation(client, changes, error):
     assert response.json()["error"] == error
 
 
-def test_registration_filters_unsafe_redirects(client):
+@pytest.mark.parametrize(
+    "redirect_uris",
+    [
+        [],
+        [123],
+        ["http://evil.example.test/callback"],
+        [
+            "https://safe.example.test/callback",
+            "http://evil.example.test/callback",
+        ],
+    ],
+)
+def test_registration_rejects_empty_or_invalid_redirect_metadata(
+    client,
+    redirect_uris,
+):
+    state = oauth.get_oauth_state()
+    clients_before = state.list_clients()
+
     response = client.post(
         "/oauth/register",
-        json={
-            "redirect_uris": [
-                "http://evil.example.test/callback",
-                "http://localhost:1234/callback",
-                "https://safe.example.test/callback",
-            ]
-        },
+        json={"redirect_uris": redirect_uris},
     )
 
-    assert response.status_code == 201
-    assert response.json()["redirect_uris"] == [
-        "http://localhost:1234/callback",
-        "https://safe.example.test/callback",
-    ]
-
-
-def test_registration_with_no_safe_redirect_cannot_authorize(client):
-    client_id, _, _ = _register(client, "http://evil.example.test/callback")
-    params = _authz_params(client_id, "http://evil.example.test/callback")
-
-    response = client.get("/oauth/authorize", params=params)
-
     assert response.status_code == 400
-    assert response.json()["error"] == "invalid_request"
+    assert response.json()["error"] == "invalid_redirect_uri"
+    assert state.list_clients() == clients_before
 
 
 def test_oauth_metadata_advertises_confidential_code_flow(client):

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -1,59 +1,110 @@
-"""Tests for the OAuth authorization flow and its login gate (issues #8 / #29).
+"""Tests for the vault MCP server's OAuth 2.0 endpoints."""
 
-These drive the OAuth routes directly (no FastMCP needed) via Starlette's
-TestClient. The headline test is `test_exploit_is_closed`: the exact
-unauthenticated attack from the bug reports must no longer yield a token.
-"""
+from __future__ import annotations
 
 import base64
 import hashlib
+import json
+import sqlite3
+import urllib.parse
+from pathlib import Path
 
 import pytest
 from starlette.applications import Starlette
 from starlette.testclient import TestClient
 
 from obsidian_vault_mcp import config, oauth
+from obsidian_vault_mcp.oauth_state import (
+    REAUTHORIZATION_REQUIRED,
+    VAULT_READONLY_V1,
+)
 
-TOKEN = "test-vault-token-do-not-leak"
+MASTER_TOKEN = "master-bearer-must-not-be-issued"
+STATIC_CLIENT_ID = "test-static-client"
+STATIC_CLIENT_SECRET = "test-static-secret"
+LOGIN_USERNAME = "test-user"
+LOGIN_PASSWORD = "test-pass"
+RESOURCE = "https://vault.example.test"
+STATIC_REDIRECT = "https://operator.example.test/callback"
+DYNAMIC_REDIRECT = "https://client.example.test/callback"
 
 
 @pytest.fixture(autouse=True)
-def reset_state(monkeypatch, tmp_path):
-    """Fresh in-memory stores + known config for every test."""
-    oauth._clients.clear()
-    oauth._auth_codes.clear()
-    monkeypatch.setattr(config, "VAULT_MCP_TOKEN", TOKEN)
-    monkeypatch.setattr(config, "VAULT_OAUTH_USERNAME", "obsidian")
-    monkeypatch.setattr(config, "VAULT_OAUTH_PASSWORD", "")  # unset by default
-    monkeypatch.setattr(config, "VAULT_OAUTH_CLIENT_ID", "vault-mcp-client")
-    monkeypatch.setattr(config, "VAULT_OAUTH_CLIENT_SECRET", "configured-server-secret")
-    monkeypatch.setattr(config, "VAULT_OAUTH_REDIRECT_URIS", [])
-    # Persist the client registry to a throwaway path so tests never touch the real
-    # on-disk registry.
-    monkeypatch.setattr(config, "OAUTH_CLIENTS_PATH", tmp_path / "oauth_clients.json")
+def reset_state(monkeypatch, tmp_path: Path):
+    oauth.close_oauth_state()
+    vault_path = tmp_path / "vault"
+    vault_path.mkdir(mode=0o700)
+    monkeypatch.setattr(config, "VAULT_PATH", vault_path)
+    monkeypatch.setattr(config, "VAULT_MCP_TOKEN", MASTER_TOKEN)
+    monkeypatch.setattr(config, "VAULT_OAUTH_USERNAME", LOGIN_USERNAME)
+    monkeypatch.setattr(config, "VAULT_OAUTH_PASSWORD", LOGIN_PASSWORD)
+    monkeypatch.setattr(config, "VAULT_OAUTH_CLIENT_ID", STATIC_CLIENT_ID)
+    monkeypatch.setattr(config, "VAULT_OAUTH_CLIENT_SECRET", STATIC_CLIENT_SECRET)
+    monkeypatch.setattr(config, "VAULT_OAUTH_REDIRECT_URIS", [STATIC_REDIRECT])
+    monkeypatch.setattr(config, "VAULT_MCP_PUBLIC_URL", RESOURCE)
+    monkeypatch.setattr(
+        config, "VAULT_OAUTH_STATE_PATH", tmp_path / "state" / "oauth.sqlite3"
+    )
+    monkeypatch.setattr(
+        config, "OAUTH_CLIENTS_PATH", tmp_path / "legacy" / "clients.json"
+    )
+    monkeypatch.setattr(config, "VAULT_OAUTH_APPROVED_LEGACY_CLIENT_IDS", frozenset())
+    monkeypatch.setattr(config, "oauth_access_token_ttl_seconds", lambda: 3_600)
     yield
+    oauth.close_oauth_state()
 
 
 @pytest.fixture
-def client():
+def client() -> TestClient:
     app = Starlette(routes=oauth.oauth_routes)
     return TestClient(app)
 
 
-def _pkce():
-    verifier = "verifier-abc123_this-is-long-enough-for-pkce-xyz"
+def _pkce() -> tuple[str, str]:
+    verifier = "test-pkce-verifier-that-is-long-enough"
     digest = hashlib.sha256(verifier.encode()).digest()
     challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode()
     return verifier, challenge
 
 
-def _register(client, redirect_uri="https://app.example/cb"):
-    r = client.post("/oauth/register", json={"client_name": "t", "redirect_uris": [redirect_uri]})
-    assert r.status_code == 201
-    return r.json()["client_id"], redirect_uri
+def _register(
+    client: TestClient, redirect_uri: str = DYNAMIC_REDIRECT
+) -> tuple[str, str, str]:
+    response = client.post(
+        "/oauth/register",
+        json={
+            "client_name": "Test Client",
+            "redirect_uris": [redirect_uri],
+        },
+    )
+    assert response.status_code == 201
+    body = response.json()
+    return body["client_id"], body["client_secret"], redirect_uri
 
 
-def _authz_params(client_id, redirect_uri, challenge):
+def _write_pending_legacy_client() -> tuple[str, str, str]:
+    client_id = "pending-legacy-client"
+    client_secret = "pending-legacy-secret"
+    redirect_uri = "https://pending.example.test/callback"
+    source = config.OAUTH_CLIENTS_PATH
+    source.parent.mkdir(mode=0o700, parents=True)
+    source.write_text(
+        json.dumps(
+            {
+                client_id: {
+                    "client_secret": client_secret,
+                    "redirect_uris": [redirect_uri],
+                    "created_at": 1.0,
+                }
+            }
+        )
+    )
+    source.chmod(0o600)
+    return client_id, client_secret, redirect_uri
+
+
+def _authz_params(client_id: str, redirect_uri: str) -> dict[str, str]:
+    _, challenge = _pkce()
     return {
         "response_type": "code",
         "client_id": client_id,
@@ -61,253 +112,420 @@ def _authz_params(client_id, redirect_uri, challenge):
         "state": "xyz",
         "code_challenge": challenge,
         "code_challenge_method": "S256",
+        "resource": RESOURCE,
     }
 
 
-# --- The reported vulnerability ------------------------------------------------
-
-def test_exploit_is_closed(client):
-    """Default config (no password): an anonymous caller must NOT get a token."""
-    client_id, redirect = _register(client)
-    _, challenge = _pkce()
-    # Step 1: hit /authorize like the attacker did -- expect NO code, no redirect.
-    r = client.get("/oauth/authorize", params=_authz_params(client_id, redirect, challenge),
-                   follow_redirects=False)
-    assert r.status_code == 503  # fails closed
-    assert "location" not in {k.lower() for k in r.headers}
-
-
-def test_register_does_not_leak_configured_secret(client):
-    r = client.post("/oauth/register", json={"redirect_uris": ["https://app.example/cb"]})
-    assert r.status_code == 201
-    body = r.json()
-    assert body["client_secret"] != config.VAULT_OAUTH_CLIENT_SECRET
-    assert body["client_secret"] != config.VAULT_MCP_TOKEN
-    assert len(body["client_secret"]) == 64  # freshly generated per-client
-
-
-# --- The login gate ------------------------------------------------------------
-
-def test_authorize_shows_login_form_when_password_set(client, monkeypatch):
-    monkeypatch.setattr(config, "VAULT_OAUTH_PASSWORD", "hunter2")
-    client_id, redirect = _register(client)
-    _, challenge = _pkce()
-    r = client.get("/oauth/authorize", params=_authz_params(client_id, redirect, challenge),
-                   follow_redirects=False)
-    assert r.status_code == 200
-    assert 'name="password"' in r.text
-    assert "code=" not in (r.headers.get("location") or "")
+def _authorize(
+    client: TestClient,
+    client_id: str,
+    redirect_uri: str,
+) -> str:
+    params = _authz_params(client_id, redirect_uri)
+    response = client.post(
+        "/oauth/authorize",
+        data={
+            **params,
+            "username": LOGIN_USERNAME,
+            "password": LOGIN_PASSWORD,
+        },
+        follow_redirects=False,
+    )
+    assert response.status_code == 302
+    query = urllib.parse.parse_qs(
+        urllib.parse.urlsplit(response.headers["location"]).query
+    )
+    assert query["state"] == ["xyz"]
+    return query["code"][0]
 
 
-def test_authorize_rejects_wrong_password(client, monkeypatch):
-    monkeypatch.setattr(config, "VAULT_OAUTH_PASSWORD", "hunter2")
-    client_id, redirect = _register(client)
-    _, challenge = _pkce()
-    data = _authz_params(client_id, redirect, challenge)
-    data.update({"username": "obsidian", "password": "wrong"})
-    r = client.post("/oauth/authorize", data=data, follow_redirects=False)
-    assert r.status_code == 401
-    assert "location" not in {k.lower() for k in r.headers}
+def _exchange(
+    client: TestClient,
+    *,
+    code: str,
+    client_id: str,
+    client_secret: str,
+    redirect_uri: str,
+    verifier: str | None = None,
+    resource: str = RESOURCE,
+):
+    if verifier is None:
+        verifier, _ = _pkce()
+    return client.post(
+        "/oauth/token",
+        data={
+            "grant_type": "authorization_code",
+            "code": code,
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "redirect_uri": redirect_uri,
+            "code_verifier": verifier,
+            "resource": resource,
+        },
+    )
 
 
-def test_full_flow_with_correct_password(client, monkeypatch):
-    monkeypatch.setattr(config, "VAULT_OAUTH_PASSWORD", "hunter2")
-    client_id, redirect = _register(client)
-    verifier, challenge = _pkce()
-    data = _authz_params(client_id, redirect, challenge)
-    data.update({"username": "obsidian", "password": "hunter2"})
+def test_registration_returns_per_client_secret_and_persists(client):
+    client_id, client_secret, redirect_uri = _register(client)
 
-    r = client.post("/oauth/authorize", data=data, follow_redirects=False)
-    assert r.status_code == 302
-    loc = r.headers["location"]
-    assert loc.startswith(redirect)
-    code = loc.split("code=")[1].split("&")[0]
+    assert client_id.startswith("vault-mcp-")
+    assert len(client_secret) == 64
+    assert client_secret not in {STATIC_CLIENT_SECRET, MASTER_TOKEN}
+    assert oauth.get_oauth_state().client_redirect_uri_allowed(client_id, redirect_uri)
 
-    # Exchange the code (with the PKCE verifier) for a token.
-    tok = client.post("/oauth/token", data={
-        "grant_type": "authorization_code", "code": code, "client_id": client_id,
-        "redirect_uri": redirect, "code_verifier": verifier,
-    })
-    assert tok.status_code == 200
-    assert tok.json()["access_token"] == TOKEN
+    oauth.close_oauth_state()
+    reopened = oauth.get_oauth_state()
+    assert reopened.verify_client_secret(client_id, client_secret)
+    assert reopened.client_redirect_uri_allowed(client_id, redirect_uri)
 
 
-def test_token_requires_pkce_verifier(client, monkeypatch):
-    monkeypatch.setattr(config, "VAULT_OAUTH_PASSWORD", "hunter2")
-    client_id, redirect = _register(client)
-    verifier, challenge = _pkce()
-    data = _authz_params(client_id, redirect, challenge)
-    data.update({"username": "obsidian", "password": "hunter2"})
-    r = client.post("/oauth/authorize", data=data, follow_redirects=False)
-    code = r.headers["location"].split("code=")[1].split("&")[0]
+def test_two_dynamic_clients_receive_independent_access_tokens(client):
+    first_id, first_secret, first_redirect = _register(client)
+    second_id, second_secret, second_redirect = _register(
+        client, "https://second.example.test/callback"
+    )
+    first_code = _authorize(client, first_id, first_redirect)
+    second_code = _authorize(client, second_id, second_redirect)
 
-    # Same code, but NO verifier -> rejected.
-    tok = client.post("/oauth/token", data={
-        "grant_type": "authorization_code", "code": code, "client_id": client_id,
-        "redirect_uri": redirect,
-    })
-    assert tok.status_code == 400
+    first = _exchange(
+        client,
+        code=first_code,
+        client_id=first_id,
+        client_secret=first_secret,
+        redirect_uri=first_redirect,
+    )
+    second = _exchange(
+        client,
+        code=second_code,
+        client_id=second_id,
+        client_secret=second_secret,
+        redirect_uri=second_redirect,
+    )
 
-
-# --- Request validation --------------------------------------------------------
-
-def test_unknown_client_rejected(client, monkeypatch):
-    monkeypatch.setattr(config, "VAULT_OAUTH_PASSWORD", "hunter2")
-    _, challenge = _pkce()
-    r = client.get("/oauth/authorize",
-                   params=_authz_params("bogus-client", "https://app.example/cb", challenge),
-                   follow_redirects=False)
-    assert r.status_code == 400
-    assert r.json()["error"] == "invalid_client"
-
-
-def test_pkce_required_at_authorize(client, monkeypatch):
-    monkeypatch.setattr(config, "VAULT_OAUTH_PASSWORD", "hunter2")
-    client_id, redirect = _register(client)
-    params = _authz_params(client_id, redirect, "")  # empty challenge
-    r = client.get("/oauth/authorize", params=params, follow_redirects=False)
-    assert r.status_code == 400
+    assert first.status_code == 200
+    assert second.status_code == 200
+    first_token = first.json()["access_token"]
+    second_token = second.json()["access_token"]
+    assert first_token != second_token
+    assert MASTER_TOKEN not in {first_token, second_token}
+    assert first.json()["expires_in"] == 3_600
+    assert "refresh_token" not in first.json()
 
 
-def test_open_redirect_rejected(client, monkeypatch):
-    monkeypatch.setattr(config, "VAULT_OAUTH_PASSWORD", "hunter2")
-    client_id, _ = _register(client, redirect_uri="https://app.example/cb")
-    _, challenge = _pkce()
-    # http non-loopback scheme -> rejected
-    r1 = client.get("/oauth/authorize",
-                    params=_authz_params(client_id, "http://evil.example/x", challenge),
-                    follow_redirects=False)
-    assert r1.status_code == 400
-    # https but not the registered URI -> rejected
-    r2 = client.get("/oauth/authorize",
-                    params=_authz_params(client_id, "https://evil.example/cb", challenge),
-                    follow_redirects=False)
-    assert r2.status_code == 400
+def test_authorization_code_survives_state_reopen(client):
+    client_id, client_secret, redirect_uri = _register(client)
+    code = _authorize(client, client_id, redirect_uri)
+
+    oauth.close_oauth_state()
+    response = _exchange(
+        client,
+        code=code,
+        client_id=client_id,
+        client_secret=client_secret,
+        redirect_uri=redirect_uri,
+    )
+
+    assert response.status_code == 200
+    assert response.json()["access_token"].startswith("v1.")
 
 
-# --- Fail-closed: no password means no authorization, by any method -----------
+def test_wrong_client_secret_does_not_consume_code(client):
+    client_id, client_secret, redirect_uri = _register(client)
+    code = _authorize(client, client_id, redirect_uri)
 
-def test_no_password_fails_closed_even_via_post(client):
-    """There is no auto-approve escape hatch: without a configured password,
-    neither GET nor POST to /authorize can yield a code."""
-    client_id, redirect = _register(client)
-    _, challenge = _pkce()
-    data = _authz_params(client_id, redirect, challenge)
-    data.update({"username": "obsidian", "password": "anything"})
-    r = client.post("/oauth/authorize", data=data, follow_redirects=False)
-    assert r.status_code == 503
-    assert "location" not in {k.lower() for k in r.headers}
+    denied = _exchange(
+        client,
+        code=code,
+        client_id=client_id,
+        client_secret="wrong",
+        redirect_uri=redirect_uri,
+    )
+    accepted = _exchange(
+        client,
+        code=code,
+        client_id=client_id,
+        client_secret=client_secret,
+        redirect_uri=redirect_uri,
+    )
 
-
-# --- #4: client identity at token exchange + redirect allowlist ---------------
-
-def _login_and_get_code(client, client_id, redirect, challenge):
-    data = _authz_params(client_id, redirect, challenge)
-    data.update({"username": "obsidian", "password": "hunter2"})
-    r = client.post("/oauth/authorize", data=data, follow_redirects=False)
-    assert r.status_code == 302
-    return r.headers["location"].split("code=")[1].split("&")[0]
-
-
-def test_token_rejects_client_id_mismatch(client, monkeypatch):
-    """A code issued to client A cannot be redeemed by client B (RFC 6749 4.1.3)."""
-    monkeypatch.setattr(config, "VAULT_OAUTH_PASSWORD", "hunter2")
-    client_id, redirect = _register(client)
-    other_id, _ = _register(client, redirect_uri="https://other.example/cb")
-    verifier, challenge = _pkce()
-    code = _login_and_get_code(client, client_id, redirect, challenge)
-    tok = client.post("/oauth/token", data={
-        "grant_type": "authorization_code", "code": code, "client_id": other_id,
-        "redirect_uri": redirect, "code_verifier": verifier,
-    })
-    assert tok.status_code == 400
-    assert tok.json()["error"] == "invalid_grant"
+    assert denied.status_code == 401
+    assert denied.json()["error"] == "invalid_client"
+    assert accepted.status_code == 200
 
 
-def test_operator_client_redirect_requires_allowlist(client, monkeypatch):
-    """The operator-configured client_id no longer accepts an arbitrary redirect_uri;
-    it must match VAULT_OAUTH_REDIRECT_URIS (#4a fallthrough closed)."""
-    monkeypatch.setattr(config, "VAULT_OAUTH_PASSWORD", "hunter2")
-    _, challenge = _pkce()
-    op = config.VAULT_OAUTH_CLIENT_ID  # not DCR-registered
+def test_invalid_exchange_inputs_do_not_consume_code(client):
+    client_id, client_secret, redirect_uri = _register(client)
+    code = _authorize(client, client_id, redirect_uri)
 
-    # No allowlist -> any redirect rejected.
-    r = client.get("/oauth/authorize",
-                   params=_authz_params(op, "https://anywhere.example/cb", challenge),
-                   follow_redirects=False)
-    assert r.status_code == 400
+    bad_pkce = _exchange(
+        client,
+        code=code,
+        client_id=client_id,
+        client_secret=client_secret,
+        redirect_uri=redirect_uri,
+        verifier="wrong",
+    )
+    bad_resource = _exchange(
+        client,
+        code=code,
+        client_id=client_id,
+        client_secret=client_secret,
+        redirect_uri=redirect_uri,
+        resource="https://wrong.example.test",
+    )
+    accepted = _exchange(
+        client,
+        code=code,
+        client_id=client_id,
+        client_secret=client_secret,
+        redirect_uri=redirect_uri,
+    )
 
-    # Allowlist set -> only the listed URI is accepted.
-    monkeypatch.setattr(config, "VAULT_OAUTH_REDIRECT_URIS", ["https://allowed.example/cb"])
-    r_bad = client.get("/oauth/authorize",
-                       params=_authz_params(op, "https://anywhere.example/cb", challenge),
-                       follow_redirects=False)
-    assert r_bad.status_code == 400
-    r_ok = client.get("/oauth/authorize",
-                      params=_authz_params(op, "https://allowed.example/cb", challenge),
-                      follow_redirects=False)
-    assert r_ok.status_code == 200  # login form for an allowed redirect
-
-
-def test_registered_client_empty_redirects_denied(client, monkeypatch):
-    """A DCR client that registered no usable (https/loopback) redirect_uris
-    cannot use the authorization-code flow (no fallthrough)."""
-    monkeypatch.setattr(config, "VAULT_OAUTH_PASSWORD", "hunter2")
-    r = client.post("/oauth/register", json={"redirect_uris": ["http://evil.example/cb"]})
-    cid = r.json()["client_id"]
-    assert r.json()["redirect_uris"] == []  # http non-loopback filtered out
-    _, challenge = _pkce()
-    r2 = client.get("/oauth/authorize",
-                    params=_authz_params(cid, "https://evil.example/cb", challenge),
-                    follow_redirects=False)
-    assert r2.status_code == 400
+    assert bad_pkce.status_code == 400
+    assert bad_pkce.json()["error"] == "invalid_grant"
+    assert bad_resource.status_code == 400
+    assert bad_resource.json()["error"] == "invalid_target"
+    assert accepted.status_code == 200
 
 
-# --- #20: RFC 9728 protected-resource metadata --------------------------------
+def test_static_authorization_code_uses_configured_secret(client):
+    code = _authorize(client, STATIC_CLIENT_ID, STATIC_REDIRECT)
 
-def test_oauth_protected_resource_metadata(client):
-    r = client.get("/.well-known/oauth-protected-resource")
-    assert r.status_code == 200
-    body = r.json()
-    assert body["resource"]
-    assert isinstance(body["authorization_servers"], list) and body["authorization_servers"]
-    assert body["bearer_methods_supported"] == ["header"]
+    denied = _exchange(
+        client,
+        code=code,
+        client_id=STATIC_CLIENT_ID,
+        client_secret="wrong",
+        redirect_uri=STATIC_REDIRECT,
+    )
+    accepted = _exchange(
+        client,
+        code=code,
+        client_id=STATIC_CLIENT_ID,
+        client_secret=STATIC_CLIENT_SECRET,
+        redirect_uri=STATIC_REDIRECT,
+    )
 
-
-def test_protected_resource_path_is_auth_exempt():
-    from obsidian_vault_mcp.auth import _AUTH_EXEMPT_PATHS
-    assert "/.well-known/oauth-protected-resource" in _AUTH_EXEMPT_PATHS
-
-
-# --- Registry persistence across restart --------------------------------------
-
-def test_registration_persists_across_restart(client):
-    """A DCR client survives a server restart (in-memory wipe) via the on-disk
-    registry. Without this, a restart leaves the connected client replaying a
-    client_id the server no longer knows -> 'Invalid or unregistered redirect_uri'."""
-    client_id, redirect = _register(client)
-    assert config.OAUTH_CLIENTS_PATH.exists()
-
-    # Simulate a restart: drop in-memory state, reload from disk.
-    oauth._clients.clear()
-    assert client_id not in oauth._clients
-    oauth._load_clients()
-
-    assert client_id in oauth._clients
-    # redirect_uri validation passes again post-reload, so /oauth/authorize won't 400.
-    assert oauth._redirect_uri_ok(client_id, redirect) is True
+    assert denied.status_code == 401
+    assert accepted.status_code == 200
+    assert accepted.json()["access_token"] != MASTER_TOKEN
 
 
-def test_registry_file_is_owner_only(client):
-    """The persisted registry holds per-client secrets; it must be 0600."""
-    _register(client)
-    mode = config.OAUTH_CLIENTS_PATH.stat().st_mode & 0o777
-    assert mode == 0o600
+def test_client_credentials_issues_independent_tokens_and_honors_revoke(client):
+    request = {
+        "grant_type": "client_credentials",
+        "client_id": STATIC_CLIENT_ID,
+        "client_secret": STATIC_CLIENT_SECRET,
+        "resource": RESOURCE,
+    }
+    first = client.post("/oauth/token", data=request)
+    second = client.post("/oauth/token", data=request)
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert first.json()["access_token"] != second.json()["access_token"]
+    assert MASTER_TOKEN not in {
+        first.json()["access_token"],
+        second.json()["access_token"],
+    }
+
+    assert oauth.get_oauth_state().revoke_client(STATIC_CLIENT_ID)
+    oauth.close_oauth_state()
+    denied = client.post("/oauth/token", data=request)
+    assert denied.status_code == 401
+    assert denied.json()["error"] == "invalid_client"
 
 
-def test_load_clients_tolerates_corrupt_file(client):
-    """A garbage registry file must not crash startup; load is best-effort."""
-    config.OAUTH_CLIENTS_PATH.write_text("{not valid json")
-    oauth._clients.clear()
-    oauth._load_clients()  # must not raise
-    assert oauth._clients == {}
+def test_client_credentials_rejects_wrong_secret_and_resource(client):
+    wrong_secret = client.post(
+        "/oauth/token",
+        data={
+            "grant_type": "client_credentials",
+            "client_id": STATIC_CLIENT_ID,
+            "client_secret": "wrong",
+            "resource": RESOURCE,
+        },
+    )
+    wrong_resource = client.post(
+        "/oauth/token",
+        data={
+            "grant_type": "client_credentials",
+            "client_id": STATIC_CLIENT_ID,
+            "client_secret": STATIC_CLIENT_SECRET,
+            "resource": "https://wrong.example.test",
+        },
+    )
+
+    assert wrong_secret.status_code == 401
+    assert wrong_secret.json()["error"] == "invalid_client"
+    assert wrong_resource.status_code == 400
+    assert wrong_resource.json()["error"] == "invalid_target"
+
+
+def test_authorize_requires_interactive_login(client):
+    client_id, _, redirect_uri = _register(client)
+    params = _authz_params(client_id, redirect_uri)
+
+    get_response = client.get("/oauth/authorize", params=params)
+    wrong_response = client.post(
+        "/oauth/authorize",
+        data={**params, "username": LOGIN_USERNAME, "password": "wrong"},
+        follow_redirects=False,
+    )
+
+    assert get_response.status_code == 200
+    assert "<form" in get_response.text
+    assert wrong_response.status_code == 401
+    assert "location" not in wrong_response.headers
+
+
+def test_missing_login_configuration_fails_closed(client, monkeypatch):
+    client_id, _, redirect_uri = _register(client)
+    params = _authz_params(client_id, redirect_uri)
+    monkeypatch.setattr(config, "VAULT_OAUTH_PASSWORD", "")
+
+    get_response = client.get("/oauth/authorize", params=params, follow_redirects=False)
+    post_response = client.post(
+        "/oauth/authorize",
+        data={**params, "username": LOGIN_USERNAME, "password": "anything"},
+        follow_redirects=False,
+    )
+
+    assert get_response.status_code == 503
+    assert post_response.status_code == 503
+    assert "location" not in get_response.headers
+    assert "location" not in post_response.headers
+
+
+def test_pending_import_requires_fresh_login_then_issues_exact_readonly_token(client):
+    client_id, client_secret, redirect_uri = _write_pending_legacy_client()
+    state = oauth.initialize_oauth_state()
+    params = _authz_params(client_id, redirect_uri)
+
+    denied = client.post(
+        "/oauth/authorize",
+        data={**params, "username": LOGIN_USERNAME, "password": "wrong"},
+        follow_redirects=False,
+    )
+    assert denied.status_code == 401
+    assert state.get_client(client_id).policy == REAUTHORIZATION_REQUIRED
+
+    code = _authorize(client, client_id, redirect_uri)
+    accepted = _exchange(
+        client,
+        code=code,
+        client_id=client_id,
+        client_secret=client_secret,
+        redirect_uri=redirect_uri,
+    )
+
+    assert accepted.status_code == 200
+    assert state.get_client(client_id).policy == VAULT_READONLY_V1
+    token_id = accepted.json()["access_token"].split(".")[1]
+    token = next(item for item in state.list_tokens() if item.token_id == token_id)
+    assert token.policy == VAULT_READONLY_V1
+    assert token.capabilities == (
+        "vault_batch_read",
+        "vault_list",
+        "vault_read",
+        "vault_search",
+        "vault_search_frontmatter",
+    )
+
+
+def test_reauthorization_rolls_back_if_code_insert_fails(client):
+    client_id, _, redirect_uri = _write_pending_legacy_client()
+    state = oauth.initialize_oauth_state()
+    state._connection.execute(
+        "CREATE TRIGGER fail_code_insert BEFORE INSERT ON authorization_codes "
+        "BEGIN SELECT RAISE(ABORT, 'synthetic code insert failure'); END"
+    )
+
+    with pytest.raises(sqlite3.IntegrityError, match="synthetic code insert failure"):
+        client.post(
+            "/oauth/authorize",
+            data={
+                **_authz_params(client_id, redirect_uri),
+                "username": LOGIN_USERNAME,
+                "password": LOGIN_PASSWORD,
+            },
+            follow_redirects=False,
+        )
+
+    assert state.get_client(client_id).policy == REAUTHORIZATION_REQUIRED
+
+
+@pytest.mark.parametrize(
+    "changes,error",
+    [
+        ({"response_type": "token"}, "unsupported_response_type"),
+        ({"client_id": "unknown-client"}, "invalid_client"),
+        ({"redirect_uri": "https://evil.example.test/callback"}, "invalid_request"),
+        ({"code_challenge": ""}, "invalid_request"),
+        ({"code_challenge_method": "plain"}, "invalid_request"),
+        ({"resource": "https://wrong.example.test"}, "invalid_target"),
+    ],
+)
+def test_authorization_request_validation(client, changes, error):
+    client_id, _, redirect_uri = _register(client)
+    params = _authz_params(client_id, redirect_uri)
+    params.update(changes)
+
+    response = client.get("/oauth/authorize", params=params)
+
+    assert response.status_code == 400
+    assert response.json()["error"] == error
+
+
+def test_registration_filters_unsafe_redirects(client):
+    response = client.post(
+        "/oauth/register",
+        json={
+            "redirect_uris": [
+                "http://evil.example.test/callback",
+                "http://localhost:1234/callback",
+                "https://safe.example.test/callback",
+            ]
+        },
+    )
+
+    assert response.status_code == 201
+    assert response.json()["redirect_uris"] == [
+        "http://localhost:1234/callback",
+        "https://safe.example.test/callback",
+    ]
+
+
+def test_registration_with_no_safe_redirect_cannot_authorize(client):
+    client_id, _, _ = _register(client, "http://evil.example.test/callback")
+    params = _authz_params(client_id, "http://evil.example.test/callback")
+
+    response = client.get("/oauth/authorize", params=params)
+
+    assert response.status_code == 400
+    assert response.json()["error"] == "invalid_request"
+
+
+def test_oauth_metadata_advertises_confidential_code_flow(client):
+    response = client.get("/.well-known/oauth-authorization-server")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["issuer"] == RESOURCE
+    assert body["resource"] == RESOURCE
+    assert body["token_endpoint_auth_methods_supported"] == ["client_secret_post"]
+    assert set(body["grant_types_supported"]) == {
+        "authorization_code",
+        "client_credentials",
+    }
+
+
+def test_protected_resource_metadata_uses_canonical_resource(client):
+    response = client.get("/.well-known/oauth-protected-resource")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "resource": RESOURCE,
+        "authorization_servers": [RESOURCE],
+        "bearer_methods_supported": ["header"],
+    }

--- a/tests/test_oauth_admin.py
+++ b/tests/test_oauth_admin.py
@@ -1,0 +1,151 @@
+"""Metadata-only local OAuth operator CLI contracts."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from io import StringIO
+from pathlib import Path
+
+from obsidian_vault_mcp import oauth_admin
+from obsidian_vault_mcp.oauth_state import (
+    VAULT_READONLY_CAPABILITIES,
+    VAULT_READONLY_V1,
+    OAuthState,
+)
+
+RESOURCE = "https://vault.example.test"
+REDIRECT = "https://client.example.test/callback"
+
+
+def _state(tmp_path: Path) -> OAuthState:
+    vault = tmp_path / "vault"
+    vault.mkdir(mode=0o700, exist_ok=True)
+    return OAuthState(
+        tmp_path / "state" / "oauth.sqlite3",
+        vault_path=vault,
+        legacy_path=tmp_path / "legacy" / "clients.json",
+        access_token_ttl_seconds=3_600,
+    )
+
+
+def _args(tmp_path: Path) -> list[str]:
+    return [
+        "--state-path",
+        str(tmp_path / "state" / "oauth.sqlite3"),
+        "--vault-path",
+        str(tmp_path / "vault"),
+        "--legacy-path",
+        str(tmp_path / "legacy" / "clients.json"),
+        "--access-token-ttl-seconds",
+        "3600",
+    ]
+
+
+def _run(tmp_path: Path, *command: str) -> tuple[int, object, str]:
+    stdout = StringIO()
+    stderr = StringIO()
+    result = oauth_admin.main(
+        [*_args(tmp_path), *command], stdout=stdout, stderr=stderr
+    )
+    payload = json.loads(stdout.getvalue()) if stdout.getvalue() else None
+    return result, payload, stderr.getvalue()
+
+
+def test_client_inventory_and_revoke_are_metadata_only(tmp_path):
+    state = _state(tmp_path)
+    registered = state.register_client([REDIRECT], client_name="CLI test")
+    client_id = registered.client.client_id
+    client_secret = registered.client_secret
+    state.close()
+
+    result, payload, stderr = _run(tmp_path, "clients", "list")
+
+    assert result == 0
+    assert stderr == ""
+    assert payload == [
+        {
+            "client_id": client_id,
+            "client_name": "CLI test",
+            "created_at": registered.client.created_at,
+            "is_static": False,
+            "last_authorized_at": None,
+            "policy": VAULT_READONLY_V1,
+            "redirect_uris": [REDIRECT],
+            "revoked_at": None,
+        }
+    ]
+    assert client_secret not in json.dumps(payload)
+
+    result, revoked, _ = _run(tmp_path, "clients", "revoke", client_id)
+    assert result == 0
+    assert revoked == {"client_id": client_id, "revoked": True}
+
+    reopened = _state(tmp_path)
+    assert reopened.get_client(client_id).revoked_at is not None
+    reopened.close()
+
+
+def test_token_inventory_filter_and_revoke_never_expose_bearer(tmp_path):
+    state = _state(tmp_path)
+    first = state.register_client([REDIRECT])
+    second = state.register_client(["https://second.example.test/cb"])
+    first_token = state.issue_access_token(
+        client_id=first.client.client_id,
+        resource=RESOURCE,
+    )
+    state.issue_access_token(
+        client_id=second.client.client_id,
+        resource=RESOURCE,
+    )
+    state.close()
+
+    result, payload, stderr = _run(
+        tmp_path,
+        "tokens",
+        "list",
+        "--client-id",
+        first.client.client_id,
+    )
+
+    assert result == 0
+    assert stderr == ""
+    assert len(payload) == 1
+    assert payload[0]["token_id"] == first_token.token.token_id
+    assert payload[0]["capabilities"] == list(VAULT_READONLY_CAPABILITIES)
+    serialized = json.dumps(payload)
+    assert first_token.access_token not in serialized
+    assert first_token.access_token.split(".")[-1] not in serialized
+
+    result, revoked, _ = _run(tmp_path, "tokens", "revoke", first_token.token.token_id)
+    assert result == 0
+    assert revoked == {
+        "revoked": True,
+        "token_id": first_token.token.token_id,
+    }
+
+
+def test_backup_is_online_reopenable_and_secret_free(tmp_path):
+    state = _state(tmp_path)
+    registered = state.register_client([REDIRECT])
+    issued = state.issue_access_token(
+        client_id=registered.client.client_id,
+        resource=RESOURCE,
+    )
+    state.close()
+    backup = tmp_path / "backup" / "oauth.sqlite3"
+
+    result, payload, stderr = _run(tmp_path, "backup", str(backup))
+
+    assert result == 0
+    assert stderr == ""
+    assert payload == {"backup": str(backup)}
+    with sqlite3.connect(backup) as connection:
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 1
+        assert connection.execute("SELECT count(*) FROM clients").fetchone()[0] == 1
+        assert (
+            connection.execute("SELECT count(*) FROM access_tokens").fetchone()[0] == 1
+        )
+    backup_bytes = backup.read_bytes()
+    assert registered.client_secret.encode() not in backup_bytes
+    assert issued.access_token.encode() not in backup_bytes

--- a/tests/test_oauth_admin.py
+++ b/tests/test_oauth_admin.py
@@ -149,3 +149,32 @@ def test_backup_is_online_reopenable_and_secret_free(tmp_path):
     backup_bytes = backup.read_bytes()
     assert registered.client_secret.encode() not in backup_bytes
     assert issued.access_token.encode() not in backup_bytes
+
+
+def test_metadata_command_does_not_consume_pending_legacy_migration(tmp_path):
+    vault = tmp_path / "vault"
+    vault.mkdir(mode=0o700)
+    legacy_path = tmp_path / "legacy" / "clients.json"
+    legacy_path.parent.mkdir(mode=0o700)
+    legacy_path.write_text(
+        json.dumps(
+            {
+                "pending-client": {
+                    "client_secret": "pending-secret",
+                    "redirect_uris": [REDIRECT],
+                }
+            }
+        )
+    )
+    legacy_path.chmod(0o600)
+
+    result, payload, stderr = _run(tmp_path, "clients", "list")
+
+    assert result == 0
+    assert stderr == ""
+    assert payload == []
+    assert legacy_path.exists()
+    with sqlite3.connect(tmp_path / "state" / "oauth.sqlite3") as connection:
+        assert connection.execute(
+            "SELECT count(*) FROM migration_metadata"
+        ).fetchone() == (0,)

--- a/tests/test_oauth_state.py
+++ b/tests/test_oauth_state.py
@@ -60,7 +60,7 @@ def _state(
 ) -> OAuthState:
     vault, state_path, legacy_path = state_paths
     clock = (lambda: now[0]) if now is not None else None
-    return OAuthState(
+    state = OAuthState(
         state_path,
         vault_path=vault,
         legacy_path=legacy_path,
@@ -71,6 +71,8 @@ def _state(
             client_id == "static-client" and secrets_equal(secret, static_secret)
         ),
     )
+    state.migrate_legacy()
+    return state
 
 
 def secrets_equal(left: str, right: str) -> bool:

--- a/tests/test_oauth_state.py
+++ b/tests/test_oauth_state.py
@@ -1,0 +1,687 @@
+"""Persistent OAuth credential lifecycle contracts."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import sqlite3
+import stat
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+from obsidian_vault_mcp.oauth_state import (
+    LEGACY_FULL,
+    REAUTHORIZATION_REQUIRED,
+    VAULT_READONLY_CAPABILITIES,
+    VAULT_READONLY_V1,
+    InvalidClient,
+    InvalidGrant,
+    InvalidTarget,
+    OAuthState,
+    UnsafeStatePath,
+)
+
+DYNAMIC_SECRET = "dynamic-client-secret-marker"
+STATIC_SECRET = "static-client-secret-marker"
+TOKEN_SECRET = "access-token-secret-marker"
+MASTER_SECRET = "master-bearer-marker"
+LOGIN_SECRET = "interactive-login-marker"
+RESOURCE = "https://vault.example.test"
+REDIRECT = "https://client.example.test/callback"
+VERIFIER = "pkce-verifier-marker"
+CHALLENGE = (
+    base64.urlsafe_b64encode(hashlib.sha256(VERIFIER.encode()).digest())
+    .rstrip(b"=")
+    .decode()
+)
+
+
+@pytest.fixture
+def state_paths(tmp_path: Path) -> tuple[Path, Path, Path]:
+    vault = tmp_path / "vault"
+    vault.mkdir(mode=0o700)
+    state_path = tmp_path / "state" / "oauth_state.sqlite3"
+    legacy_path = tmp_path / "legacy" / "oauth_clients.json"
+    return vault, state_path, legacy_path
+
+
+def _state(
+    state_paths: tuple[Path, Path, Path],
+    *,
+    now: list[float] | None = None,
+    approved: frozenset[str] = frozenset(),
+    static_secret: str = STATIC_SECRET,
+) -> OAuthState:
+    vault, state_path, legacy_path = state_paths
+    clock = (lambda: now[0]) if now is not None else None
+    return OAuthState(
+        state_path,
+        vault_path=vault,
+        legacy_path=legacy_path,
+        approved_legacy_client_ids=approved,
+        access_token_ttl_seconds=60,
+        clock=clock,
+        static_client_authenticator=lambda client_id, secret: (
+            client_id == "static-client" and secrets_equal(secret, static_secret)
+        ),
+    )
+
+
+def secrets_equal(left: str, right: str) -> bool:
+    """Keep static-secret expectations independent of production helpers."""
+    import hmac
+
+    return hmac.compare_digest(left, right)
+
+
+def _register(state: OAuthState) -> tuple[str, str]:
+    issued = state.register_client([REDIRECT])
+    return issued.client.client_id, issued.client_secret
+
+
+def _issue_code(state: OAuthState, client_id: str) -> str:
+    return state.issue_authorization_code(
+        client_id=client_id,
+        redirect_uri=REDIRECT,
+        code_challenge=CHALLENGE,
+        resource=RESOURCE,
+    )
+
+
+def _redeem(
+    state: OAuthState,
+    code: str,
+    client_id: str,
+    client_secret: str,
+):
+    return state.redeem_authorization_code(
+        code=code,
+        client_id=client_id,
+        client_secret=client_secret,
+        redirect_uri=REDIRECT,
+        code_verifier=VERIFIER,
+        resource=RESOURCE,
+    )
+
+
+def _write_legacy(path: Path, records: dict[str, dict]) -> None:
+    path.parent.mkdir(mode=0o700, exist_ok=True)
+    path.write_text(json.dumps(records))
+    path.chmod(0o600)
+
+
+def _db_text(path: Path) -> str:
+    chunks = [path.read_bytes()]
+    for suffix in ("-wal", "-shm"):
+        sidecar = Path(f"{path}{suffix}")
+        if sidecar.exists():
+            chunks.append(sidecar.read_bytes())
+    return b"".join(chunks).decode("utf-8", errors="ignore")
+
+
+def test_readonly_policy_has_exact_closed_capability_set():
+    assert VAULT_READONLY_CAPABILITIES == (
+        "vault_batch_read",
+        "vault_list",
+        "vault_read",
+        "vault_search",
+        "vault_search_frontmatter",
+    )
+
+
+def test_v1_schema_and_owner_only_files_survive_reopen(state_paths):
+    state = _state(state_paths)
+    _, state_path, _ = state_paths
+
+    assert state.schema_version == 1
+    assert stat.S_IMODE(state_path.parent.stat().st_mode) == 0o700
+    assert stat.S_IMODE(state_path.stat().st_mode) == 0o600
+    assert state.table_names() == {
+        "access_token_capabilities",
+        "access_tokens",
+        "authorization_codes",
+        "client_redirect_uris",
+        "clients",
+        "migration_metadata",
+    }
+
+    state.close()
+    reopened = _state(state_paths)
+    assert reopened.schema_version == 1
+    reopened.close()
+
+
+def test_simultaneous_initialization_is_idempotent(state_paths, monkeypatch):
+    _, _, legacy_path = state_paths
+    _write_legacy(
+        legacy_path,
+        {"client": {"client_secret": "secret", "redirect_uris": [REDIRECT]}},
+    )
+    original_unlink = Path.unlink
+
+    def slow_legacy_unlink(path: Path, *args, **kwargs):
+        if path == legacy_path:
+            time.sleep(0.05)
+        return original_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", slow_legacy_unlink)
+    barrier = threading.Barrier(2)
+
+    def open_once():
+        barrier.wait()
+        state = _state(state_paths)
+        try:
+            return state.schema_version, state.table_names(), len(state.list_clients())
+        finally:
+            state.close()
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(lambda _: open_once(), range(2)))
+
+    assert results[0] == results[1]
+    assert results[0][0] == 1
+    assert results[0][2] == 1
+    assert not legacy_path.exists()
+
+
+def test_state_path_must_be_outside_vault(tmp_path):
+    vault = tmp_path / "vault"
+    vault.mkdir(mode=0o700)
+
+    with pytest.raises(UnsafeStatePath, match="outside"):
+        OAuthState(vault / "oauth.sqlite3", vault_path=vault)
+
+
+@pytest.mark.parametrize("target", ["directory", "database", "wal", "shm"])
+def test_symlinked_state_targets_are_rejected_before_open(tmp_path, target):
+    vault = tmp_path / "vault"
+    vault.mkdir(mode=0o700)
+    state_dir = tmp_path / "state"
+    state_path = state_dir / "oauth.sqlite3"
+    planted = tmp_path / "planted"
+    planted.write_text("sentinel")
+
+    if target == "directory":
+        state_dir.symlink_to(tmp_path / "elsewhere", target_is_directory=True)
+    else:
+        state_dir.mkdir(mode=0o700)
+        suffix = "" if target == "database" else f"-{target}"
+        Path(f"{state_path}{suffix}").symlink_to(planted)
+
+    with pytest.raises(UnsafeStatePath, match="symlink"):
+        OAuthState(state_path, vault_path=vault)
+    assert planted.read_text() == "sentinel"
+
+
+def test_unsafe_mode_and_foreign_owner_are_rejected(state_paths, monkeypatch):
+    state = _state(state_paths)
+    _, state_path, _ = state_paths
+    state.close()
+
+    state_path.chmod(0o644)
+    with pytest.raises(UnsafeStatePath, match="mode"):
+        _state(state_paths)
+    state_path.chmod(0o600)
+
+    import obsidian_vault_mcp.oauth_state as oauth_state_module
+
+    actual_uid = os.getuid()
+    monkeypatch.setattr(oauth_state_module.os, "getuid", lambda: actual_uid + 1)
+    with pytest.raises(UnsafeStatePath, match="owner"):
+        _state(state_paths)
+
+
+def test_registration_stores_only_domain_separated_verifiers(state_paths):
+    state = _state(state_paths)
+    first = state.register_client([REDIRECT])
+    second = state.register_client(["https://second.example.test/callback"])
+    _, state_path, _ = state_paths
+
+    assert first.client.client_id != second.client.client_id
+    assert first.client_secret != second.client_secret
+    assert first.client_secret not in _db_text(state_path)
+    assert second.client_secret not in _db_text(state_path)
+    assert state.verify_client_secret(first.client.client_id, first.client_secret)
+    assert not state.verify_client_secret(first.client.client_id, "wrong")
+    assert state.client_redirect_uri_allowed(first.client.client_id, REDIRECT)
+    state.close()
+
+
+def test_token_wire_lookup_expiry_and_independent_revoke(state_paths):
+    now = [1_000.0]
+    state = _state(state_paths, now=now)
+    first_id, _ = _register(state)
+    second_id, _ = _register(state)
+
+    first = state.issue_access_token(
+        client_id=first_id,
+        resource=RESOURCE,
+    )
+    second = state.issue_access_token(
+        client_id=second_id,
+        resource=RESOURCE,
+    )
+
+    assert first.access_token.startswith("v1.")
+    assert first.access_token.count(".") == 2
+    assert first.access_token != second.access_token
+    assert state.lookup_access_token(first.access_token) == first.token
+    assert state.lookup_access_token(first.access_token + "wrong") is None
+    assert state.lookup_access_token("malformed") is None
+    assert state.lookup_access_token("v1.unknown.secret") is None
+
+    assert state.revoke_token(first.token.token_id)
+    assert state.lookup_access_token(first.access_token) is None
+    assert state.lookup_access_token(second.access_token) == second.token
+
+    now[0] = second.token.expires_at
+    assert state.lookup_access_token(second.access_token) is None
+    state.close()
+
+
+def test_authorization_code_expires_at_300_seconds_and_is_single_use(state_paths):
+    now = [5_000.0]
+    state = _state(state_paths, now=now)
+    client_id, secret = _register(state)
+    code = _issue_code(state, client_id)
+
+    now[0] += 300
+    with pytest.raises(InvalidGrant, match="expired"):
+        _redeem(state, code, client_id, secret)
+
+    now[0] = 6_000.0
+    fresh = _issue_code(state, client_id)
+    issued = _redeem(state, fresh, client_id, secret)
+    assert issued.token.client_id == client_id
+    with pytest.raises(InvalidGrant):
+        _redeem(state, fresh, client_id, secret)
+    state.close()
+
+
+def test_code_exchange_checks_client_secret_redirect_pkce_and_resource(state_paths):
+    state = _state(state_paths)
+    client_id, secret = _register(state)
+
+    checks = [
+        ({"client_secret": "wrong"}, InvalidClient),
+        ({"client_id": "wrong-client"}, InvalidClient),
+        ({"redirect_uri": "https://wrong.example.test/cb"}, InvalidGrant),
+        ({"code_verifier": "wrong"}, InvalidGrant),
+        ({"resource": "https://wrong.example.test"}, InvalidTarget),
+    ]
+    for changes, error in checks:
+        code = _issue_code(state, client_id)
+        params = {
+            "code": code,
+            "client_id": client_id,
+            "client_secret": secret,
+            "redirect_uri": REDIRECT,
+            "code_verifier": VERIFIER,
+            "resource": RESOURCE,
+        }
+        params.update(changes)
+        with pytest.raises(error):
+            state.redeem_authorization_code(**params)
+        assert state.authorization_code_active(code)
+
+    state.close()
+
+
+def test_simultaneous_redemption_issues_exactly_one_token(state_paths):
+    state = _state(state_paths)
+    client_id, secret = _register(state)
+    code = _issue_code(state, client_id)
+    state.close()
+    barrier = threading.Barrier(2)
+
+    def redeem_once():
+        local = _state(state_paths)
+        barrier.wait()
+        try:
+            return _redeem(local, code, client_id, secret).access_token
+        except InvalidGrant:
+            return None
+        finally:
+            local.close()
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(pool.map(lambda _: redeem_once(), range(2)))
+
+    assert sum(result is not None for result in results) == 1
+
+
+def test_revoke_racing_redemption_cannot_leave_active_token(state_paths):
+    state = _state(state_paths)
+    client_id, secret = _register(state)
+    code = _issue_code(state, client_id)
+    state.close()
+    barrier = threading.Barrier(2)
+
+    def redeem_once():
+        local = _state(state_paths)
+        barrier.wait()
+        try:
+            return _redeem(local, code, client_id, secret).access_token
+        except (InvalidClient, InvalidGrant):
+            return None
+        finally:
+            local.close()
+
+    def revoke_once():
+        local = _state(state_paths)
+        barrier.wait()
+        try:
+            assert local.revoke_client(client_id)
+        finally:
+            local.close()
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        token_future = pool.submit(redeem_once)
+        revoke_future = pool.submit(revoke_once)
+        token = token_future.result()
+        revoke_future.result()
+
+    reopened = _state(state_paths)
+    if token is not None:
+        assert reopened.lookup_access_token(token) is None
+    assert reopened.get_client(client_id).revoked_at is not None
+    reopened.close()
+
+
+def test_client_revoke_cascades_codes_and_tokens_across_reopen(state_paths):
+    state = _state(state_paths)
+    first_id, first_secret = _register(state)
+    second_id, second_secret = _register(state)
+    first_code = _issue_code(state, first_id)
+    first_token = _redeem(state, first_code, first_id, first_secret)
+    pending = _issue_code(state, first_id)
+    second_code = _issue_code(state, second_id)
+    second_token = _redeem(state, second_code, second_id, second_secret)
+
+    assert state.revoke_client(first_id)
+    state.close()
+    reopened = _state(state_paths)
+
+    assert reopened.lookup_access_token(first_token.access_token) is None
+    with pytest.raises((InvalidClient, InvalidGrant)):
+        _redeem(reopened, pending, first_id, first_secret)
+    assert reopened.lookup_access_token(second_token.access_token) == second_token.token
+    reopened.close()
+
+
+def test_legacy_migration_is_allowlisted_one_way_and_secret_free(state_paths):
+    _, state_path, legacy_path = state_paths
+    records = {
+        "approved-client": {
+            "client_secret": "approved-secret-marker",
+            "redirect_uris": ["https://approved.example.test/cb"],
+            "created_at": 1.0,
+        },
+        "pending-client": {
+            "client_secret": "pending-secret-marker",
+            "redirect_uris": ["https://pending.example.test/cb"],
+            "created_at": 2.0,
+        },
+    }
+    _write_legacy(legacy_path, records)
+
+    state = _state(state_paths, approved=frozenset({"approved-client"}))
+
+    assert not legacy_path.exists()
+    assert state.get_client("approved-client").policy == LEGACY_FULL
+    assert state.get_client("pending-client").policy == REAUTHORIZATION_REQUIRED
+    assert not state.can_issue_authorization_code("pending-client")
+    with pytest.raises(InvalidClient):
+        state.issue_authorization_code(
+            client_id="pending-client",
+            redirect_uri="https://pending.example.test/cb",
+            code_challenge=CHALLENGE,
+            resource=RESOURCE,
+        )
+    state.issue_authorization_code(
+        client_id="pending-client",
+        redirect_uri="https://pending.example.test/cb",
+        code_challenge=CHALLENGE,
+        resource=RESOURCE,
+        fresh_reauthorization=True,
+    )
+    transitioned = state.get_client("pending-client")
+    assert transitioned is not None
+    assert transitioned.policy == VAULT_READONLY_V1
+    assert transitioned.capabilities == VAULT_READONLY_CAPABILITIES
+    assert "approved-secret-marker" not in _db_text(state_path)
+    assert "pending-secret-marker" not in _db_text(state_path)
+    state.close()
+
+
+@pytest.mark.parametrize(
+    "records,approved",
+    [
+        ({"client": {"redirect_uris": [REDIRECT]}}, frozenset()),
+        ({"client": {"client_secret": "s", "redirect_uris": "bad"}}, frozenset()),
+        (
+            {
+                "a": {"client_secret": "a", "redirect_uris": [REDIRECT]},
+                "b": {"client_secret": "b", "redirect_uris": [REDIRECT]},
+            },
+            frozenset(),
+        ),
+        (
+            {"present": {"client_secret": "s", "redirect_uris": [REDIRECT]}},
+            frozenset({"absent"}),
+        ),
+    ],
+)
+def test_invalid_legacy_import_is_atomic(state_paths, records, approved):
+    _, state_path, legacy_path = state_paths
+    _write_legacy(legacy_path, records)
+
+    with pytest.raises(ValueError):
+        _state(state_paths, approved=approved)
+
+    assert legacy_path.exists()
+    if state_path.exists():
+        with sqlite3.connect(state_path) as connection:
+            assert connection.execute("SELECT count(*) FROM clients").fetchone()[0] == 0
+
+
+def test_unsafe_legacy_permissions_abort_import(state_paths):
+    _, state_path, legacy_path = state_paths
+    _write_legacy(
+        legacy_path,
+        {"client": {"client_secret": "secret", "redirect_uris": [REDIRECT]}},
+    )
+    legacy_path.chmod(0o644)
+
+    with pytest.raises(UnsafeStatePath, match="mode"):
+        _state(state_paths)
+    assert legacy_path.exists()
+    if state_path.exists():
+        with sqlite3.connect(state_path) as connection:
+            assert connection.execute("SELECT count(*) FROM clients").fetchone()[0] == 0
+
+
+def test_completed_migration_never_reimports_changed_source(state_paths):
+    _, _, legacy_path = state_paths
+    _write_legacy(
+        legacy_path,
+        {"first": {"client_secret": "one", "redirect_uris": [REDIRECT]}},
+    )
+    state = _state(state_paths)
+    state.close()
+
+    _write_legacy(
+        legacy_path,
+        {"second": {"client_secret": "two", "redirect_uris": [REDIRECT]}},
+    )
+    reopened = _state(state_paths)
+    assert reopened.get_client("first") is not None
+    assert reopened.get_client("second") is None
+    assert legacy_path.exists()
+    reopened.close()
+
+
+def test_unlink_failure_blocks_startup_then_retries_without_reimport(
+    state_paths, monkeypatch
+):
+    _, _, legacy_path = state_paths
+    _write_legacy(
+        legacy_path,
+        {"client": {"client_secret": "secret", "redirect_uris": [REDIRECT]}},
+    )
+    original_unlink = Path.unlink
+
+    def fail_legacy_unlink(path: Path, *args, **kwargs):
+        if path == legacy_path:
+            raise OSError("synthetic unlink failure")
+        return original_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", fail_legacy_unlink)
+    with pytest.raises(OSError, match="synthetic unlink failure"):
+        _state(state_paths)
+    assert legacy_path.exists()
+
+    monkeypatch.setattr(Path, "unlink", original_unlink)
+    reopened = _state(state_paths)
+    assert reopened.get_client("client") is not None
+    assert len(reopened.list_clients()) == 1
+    assert not legacy_path.exists()
+    reopened.close()
+
+
+def test_migration_cleanup_accepts_source_removed_by_concurrent_initializer(
+    state_paths, monkeypatch
+):
+    _, _, legacy_path = state_paths
+    _write_legacy(
+        legacy_path,
+        {"client": {"client_secret": "secret", "redirect_uris": [REDIRECT]}},
+    )
+    original_unlink = Path.unlink
+
+    def concurrent_unlink(path: Path, *args, **kwargs):
+        if path == legacy_path:
+            original_unlink(path, *args, **kwargs)
+            raise FileNotFoundError(path)
+        return original_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", concurrent_unlink)
+    state = _state(state_paths)
+    assert state.get_client("client") is not None
+    assert not legacy_path.exists()
+    state.close()
+
+
+def test_migration_unlink_is_durable_before_cleanup_marker_clears(
+    state_paths, monkeypatch
+):
+    _, state_path, legacy_path = state_paths
+    _write_legacy(
+        legacy_path,
+        {"client": {"client_secret": "secret", "redirect_uris": [REDIRECT]}},
+    )
+    original_fsync = os.fsync
+
+    def fail_directory_fsync(file_descriptor: int):
+        metadata = os.fstat(file_descriptor)
+        if stat.S_ISDIR(metadata.st_mode):
+            raise OSError("synthetic directory fsync failure")
+        return original_fsync(file_descriptor)
+
+    monkeypatch.setattr(os, "fsync", fail_directory_fsync)
+    with pytest.raises(OSError, match="synthetic directory fsync failure"):
+        _state(state_paths)
+    assert not legacy_path.exists()
+    with sqlite3.connect(state_path) as connection:
+        assert (
+            connection.execute(
+                "SELECT cleanup_pending FROM migration_metadata "
+                "WHERE name = 'legacy_clients_json_v1'"
+            ).fetchone()[0]
+            == 1
+        )
+
+    monkeypatch.setattr(os, "fsync", original_fsync)
+    reopened = _state(state_paths)
+    with sqlite3.connect(state_path) as connection:
+        assert (
+            connection.execute(
+                "SELECT cleanup_pending FROM migration_metadata "
+                "WHERE name = 'legacy_clients_json_v1'"
+            ).fetchone()[0]
+            == 0
+        )
+    reopened.close()
+
+
+def test_static_client_revoke_survives_restart(state_paths):
+    state = _state(state_paths)
+    client = state.ensure_static_client(
+        "static-client",
+        [REDIRECT],
+        policy=LEGACY_FULL,
+        capabilities=(),
+    )
+    assert client.is_static
+    assert state.verify_client_secret("static-client", STATIC_SECRET)
+    assert state.revoke_client("static-client")
+    state.close()
+
+    reopened = _state(state_paths)
+    assert reopened.get_client("static-client").revoked_at is not None
+    assert not reopened.verify_client_secret("static-client", STATIC_SECRET)
+    with pytest.raises(InvalidClient):
+        reopened.issue_access_token(
+            client_id="static-client",
+            resource=RESOURCE,
+        )
+    reopened.ensure_static_client(
+        "static-client",
+        [REDIRECT],
+        policy=LEGACY_FULL,
+        capabilities=(),
+    )
+    assert reopened.get_client("static-client").revoked_at is not None
+    reopened.close()
+
+
+def test_backup_rejects_unsafe_target_and_produces_reopenable_copy(state_paths):
+    state = _state(state_paths)
+    _register(state)
+    vault, _, _ = state_paths
+    backup = state.path.parent.parent / "backups" / "oauth.sqlite3"
+    with pytest.raises(UnsafeStatePath, match="live OAuth state"):
+        state.backup(state.path)
+
+    copied = state.backup(backup)
+    assert copied == backup
+    assert stat.S_IMODE(backup.parent.stat().st_mode) == 0o700
+    assert stat.S_IMODE(backup.stat().st_mode) == 0o600
+    with sqlite3.connect(backup) as connection:
+        assert connection.execute("PRAGMA user_version").fetchone()[0] == 1
+        assert connection.execute("SELECT count(*) FROM clients").fetchone()[0] == 1
+
+    planted = backup.parent / "planted"
+    planted.write_text("sentinel")
+    unsafe = backup.parent / "unsafe.sqlite3"
+    unsafe.symlink_to(planted)
+    with pytest.raises(UnsafeStatePath, match="symlink"):
+        state.backup(unsafe)
+    assert planted.read_text() == "sentinel"
+
+    sidecar_target = backup.parent / "sidecar.sqlite3"
+    unsafe_sidecar = Path(f"{sidecar_target}-wal")
+    unsafe_sidecar.symlink_to(planted)
+    with pytest.raises(UnsafeStatePath, match="sidecar"):
+        state.backup(sidecar_target)
+    assert planted.read_text() == "sentinel"
+
+    with pytest.raises(UnsafeStatePath, match="outside"):
+        state.backup(vault / "backup.sqlite3")
+    state.close()


### PR DESCRIPTION
## Summary

- replace the shared bearer issued to dynamic OAuth clients with independent opaque access tokens backed by a versioned SQLite lifecycle store;
- authenticate every MCP request as an immutable principal and enforce the principal's stored capabilities in both tool discovery and dispatch;
- add operator-only client inventory/revoke/backup commands, credential-safe audit attribution, migration safeguards, and fail-closed extension registration/routing guards.

This is one security boundary rather than two independent features: issuing per-client tokens without enforcing their stored policy would still leave every dynamic client with the full MCP surface.

## Security behavior

- Dynamic clients authenticate with their own registered secret and receive unrelated `v1.*` access tokens with bounded expiry, canonical resource binding and durable revocation metadata.
- Authorization codes are PKCE-bound, client-bound, redirect-bound, resource-bound, single-use and consumed atomically.
- The `vault_readonly_v1` policy exposes exactly `vault_batch_read`, `vault_list`, `vault_read`, `vault_search` and `vault_search_frontmatter`.
- Mutation tools, resources, resource templates, prompts and protected non-MCP routes are denied before side effects for restricted principals.
- Master bearer and explicitly approved imported clients retain the existing full-access behavior.
- Unknown policies, invalid capabilities, expired/revoked tokens and wrong-resource credentials fail closed.
- Audit records contain stable hashed credential/client attribution but never raw bearer tokens or client secrets.
- Interactive consent identifies the escaped client name and exact registered redirect URI before credentials are submitted.
- Dynamic registration rejects empty, malformed, unsafe, or mixed-validity redirect metadata without persisting a client.
- Extensions receive a tool-only policy registrar and cannot shadow the MCP transport or auth-exempt routes; routes that cannot be safely inspected fail closed at startup.

## Compatibility and operations

- Existing `oauth_clients.json` data is imported only through the explicit `vault-mcp-oauth migrate` operator action and legacy allowlist; ordinary startup and metadata commands do not consume migration state.
- SQLite state, sidecars and backups enforce owner-only modes and reject unsafe ownership or symlink layouts before opening.
- Bearer authentication is read-only after state initialization and does not rewrite the configured static client on each request.
- The existing master bearer remains available for operator compatibility.
- The MCP dependency is pinned to the source-reviewed `mcp[cli]==1.28.1` contract; a clean install no longer resolves MCP 2.0.
- README and `.env.example` document state path, TTL, migration allowlist and local-only administration without exposing runtime credentials.

## Verification

Latest local verification on Python 3.14 after review remediation:

- full suite: `440 passed, 1 warning in 4.22s`;
- focused remediation regressions: `10 passed, 1 warning in 0.57s`;
- security mutation checks: `4 passed, 1 warning in 0.72s`;
- `python -m compileall -q src tests` passed;
- Ruff passed on every changed file under the repository's existing `E402` import-order baseline;
- gitleaks scanned all 4 PR commits and found no leaks.

The remaining warning is inherited from Pydantic settings through the MCP dependency; all tests pass.

## Review history

Independent local review found one restricted-principal bypass: an extension route could shadow the MCP transport path and inherit the middleware allowance intended for MCP dispatch. A regression test now proves both full and partial route matches are rejected before middleware attachment.

A follow-up review was verified against the implementation before changes were applied. The resulting remediation makes migration explicit, removes authentication-path writes, handles arbitrary Unicode credentials, exposes consent identity safely, rejects invalid redirect registration atomically, and turns unknown extension-route inspection into a startup failure. Lifecycle pruning, public token identifiers, and stricter symlink canonicalization remain non-blocking design cleanup rather than merge blockers.

## Checklist

- [x] One self-contained change, based directly on current main
- [x] Full test suite passes locally (`pytest`)
- [x] New and abuse inputs are covered through real OAuth and MCP wiring
- [x] Auth routes and mount collisions are validated and fail closed
- [x] No new unchecked vault-path handling
- [x] No new request-controlled shell or outbound-request surface
- [x] No secrets, tokens or capability URLs in logs or committed evidence
- [x] New configuration is validated at startup and security defaults fail closed
- [x] No heavy or bridge dependency added
- [x] Existing atomic vault-write paths remain unchanged
- [x] README and `.env.example` document the new configuration and operations