### PR TITLE
fix(deps): cap MCP below breaking v2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Secure remote MCP server for Obsidian vaults -- access your notes
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "mcp[cli]>=1.9.0",
+    "mcp[cli]>=1.9.0,<2",
     "python-frontmatter>=1.1.0",
     "ruamel.yaml>=0.18",
     "pydantic>=2.0",


### PR DESCRIPTION
## Summary

- cap `mcp[cli]` below the incompatible 2.x major release;
- keep clean installs on the existing `mcp.server.fastmcp` contract.

Closes #71.

## Reproduction and verification

On a clean worktree from current `main`:

- before the change, `uv sync --extra dev` resolved `mcp==2.0.0` and pytest stopped during collection with 8 `ModuleNotFoundError: mcp.server.fastmcp` errors;
- after adding `<2`, the same command resolved `mcp==1.29.0` and `mcp.server.fastmcp` was importable;
- full suite: `373 passed, 2 warnings in 4.38s`;
- `python -m compileall -q src tests` passed;
- `git diff --check` passed.

The two warnings are inherited dependency deprecations from Pydantic settings and Starlette `TestClient`.

## Scope

One dependency constraint changes. No application, OAuth, vault, route, or deployment behavior changes.

## Checklist

- [x] One self-contained fix, based directly on current main
- [x] Full test suite passes locally (`pytest`)
- [x] No new routes, request inputs, subprocesses, outbound requests, logs, or writes
- [x] No new dependency; the existing dependency is bounded to its compatible major line