### PR TITLE
fix(oauth): protected-resource metadata must advertise the MCP endpoint URL, not the base URL

### DIFF
--- a/src/obsidian_vault_mcp/oauth.py
+++ b/src/obsidian_vault_mcp/oauth.py
@@ -248,11 +248,20 @@ async def oauth_metadata(request: Request) -> JSONResponse:
 
 async def oauth_protected_resource(request: Request) -> JSONResponse:
     """RFC 9728 OAuth protected-resource metadata. Claude/ChatGPT request this path
-    during discovery; it must be reachable without a bearer token (#20). With the MCP
-    endpoint served at "/" (#19), the protected resource is the base URL itself."""
+    during discovery; it must be reachable without a bearer token (#20).
+
+    The ``resource`` identifier must be the actual MCP endpoint URL (RFC 9728 / RFC
+    8707), i.e. the base URL plus VAULT_MCP_PATH. When the endpoint is at "/" (#19)
+    that collapses to the base URL; when mounted under a subpath (VAULT_MCP_PATH,
+    e.g. "/mcp" — added in #43) it must include that path. Strict clients such as
+    Home Assistant's MCP integration reject the metadata unless ``resource`` exactly
+    equals the endpoint they connected to; lenient clients (claude.ai) ignore the
+    mismatch, which is why the "/"-only assumption went unnoticed."""
     base_url = config.advertised_base_url(str(request.base_url))
+    path = config.VAULT_MCP_PATH
+    resource = base_url if path == "/" else f"{base_url}{path}"
     return JSONResponse({
-        "resource": base_url,
+        "resource": resource,
         "authorization_servers": [base_url],
         "bearer_methods_supported": ["header"],
     })

--- a/tests/test_oauth.py
+++ b/tests/test_oauth.py
@@ -274,6 +274,26 @@ def test_oauth_protected_resource_metadata(client):
     assert body["bearer_methods_supported"] == ["header"]
 
 
+def test_protected_resource_at_root_is_base_url(client, monkeypatch):
+    """With the endpoint at "/", resource == base URL (authorization server origin)."""
+    monkeypatch.setattr(config, "VAULT_MCP_PATH", "/")
+    monkeypatch.setattr(config, "VAULT_MCP_PUBLIC_URL", "https://obsidian.example.xyz")
+    body = client.get("/.well-known/oauth-protected-resource").json()
+    assert body["resource"] == "https://obsidian.example.xyz"
+    assert body["authorization_servers"] == ["https://obsidian.example.xyz"]
+
+
+def test_protected_resource_includes_subpath(client, monkeypatch):
+    """Under a VAULT_MCP_PATH subpath, resource must be the full endpoint URL so
+    strict RFC 9728 clients (e.g. Home Assistant) accept it — while the
+    authorization server stays the base origin."""
+    monkeypatch.setattr(config, "VAULT_MCP_PATH", "/mcp")
+    monkeypatch.setattr(config, "VAULT_MCP_PUBLIC_URL", "https://obsidian.example.xyz")
+    body = client.get("/.well-known/oauth-protected-resource").json()
+    assert body["resource"] == "https://obsidian.example.xyz/mcp"
+    assert body["authorization_servers"] == ["https://obsidian.example.xyz"]
+
+
 def test_protected_resource_path_is_auth_exempt():
     from obsidian_vault_mcp.auth import _AUTH_EXEMPT_PATHS
     assert "/.well-known/oauth-protected-resource" in _AUTH_EXEMPT_PATHS


### PR DESCRIPTION
## What it does

The RFC 9728 `resource` identifier is hardcoded to the base URL, which is only correct while the MCP endpoint is at `/`. Since `VAULT_MCP_PATH` landed (#43) an operator can mount it under a subpath, and the metadata then advertises a resource identifier that isn't the endpoint the client connected to.

Strict clients reject this. Home Assistant's MCP integration requires `resource` to exactly equal the connected endpoint; with `VAULT_MCP_PATH=/mcp` it fails with "OAuth resource metadata is invalid" and never starts the OAuth flow. claude.ai ignores the mismatch, which is why the `/`-only assumption went unnoticed.

`resource` becomes base URL + `VAULT_MCP_PATH`, collapsing to the base URL when the path is `/`. `authorization_servers` stays the base origin. With the default `VAULT_MCP_PATH="/"` the emitted document is byte-identical.

## Surface

- **No new surface:** no new route, `_AUTH_EXEMPT_PATHS` unchanged, and only one field's value changes in a document already served unauthenticated by design (#20).
- **No new input:** `VAULT_MCP_PATH` is already startup-validated by `_validate_mcp_path` — absolute, clean, no `..`, and rejected outright if it collides with an exempt route.
- **Host-spoofing protection intact:** `base_url` still comes from `advertised_base_url()`, so the `VAULT_MCP_PUBLIC_URL` pinning from #36 still applies; this only appends an already-validated path.
- **`auth.py` deliberately untouched:** its `resource_metadata` (#35) is the metadata *document* URL, which stays at the origin root wherever the endpoint mounts. Only the resource *identifier* is endpoint-specific.

## Tests

Two tests in `tests/test_oauth.py`, both through the test client rather than the helper: one pins the `/` default so an off-root change can't silently alter it, one asserts `VAULT_MCP_PATH=/mcp` yields `resource == "https://…/mcp"` while `authorization_servers` stays the origin. Full suite green on Linux: **374 passed, 1 skipped** (on mcp 1.29.1).

## PR checklist

- [x] One self-contained change, rebased on main (not stacked on another PR)
- [x] Full test suite passes locally (`pytest`)
- [x] New/abuse inputs covered by tests; the tool wiring is tested, not just helpers
- [x] Auth: any new route/mount validated against the exempt set; fails closed (n/a — no new route; exempt set unchanged)
- [x] Paths go through resolve_vault_path; resolved path re-validated (n/a — no filesystem path built)
- [x] No shell=True on request input; subprocess env scrubbed of secrets (n/a — no subprocess)
- [x] Outbound requests don't follow redirects to private ranges; response size capped (n/a — no outbound)
- [x] No secrets/tokens/capability URLs in logs
- [x] New config validated at startup, fails closed, off by default if risky (n/a — reuses `VAULT_MCP_PATH`)
- [x] Bridge/optional deps fail soft when absent; heavy deps are optional extras (n/a — no new deps)
- [x] Writes go through the atomic write path (n/a — read-only endpoint)
- [x] README updated for new env vars / tools / dependencies (n/a — none added)

Claude-assisted; human-reviewed.

